### PR TITLE
Adding new field to SDK constructor to accept env var

### DIFF
--- a/lib/v1/config.js
+++ b/lib/v1/config.js
@@ -1,7 +1,7 @@
 const KEYS_URL = 'https://keys.evervault.com';
 const METRICS_URL = ' https://metrics.evervault.com';
 
-module.exports = (teamId) => ({
+module.exports = (teamId, keysUrlOverride) => ({
   teamId,
   encryption: {
     cipherAlgorithm: 'aes-256-gcm',
@@ -14,7 +14,7 @@ module.exports = (teamId) => ({
     },
   },
   http: {
-    keysUrl: KEYS_URL,
+    keysUrl: keysUrlOverride || KEYS_URL,
     metricsUrl: METRICS_URL,
   }
 })

--- a/lib/v1/config.js
+++ b/lib/v1/config.js
@@ -1,11 +1,11 @@
 const KEYS_URL = 'https://keys.evervault.com';
 const METRICS_URL = 'https://metrics.evervault.com';
 
-module.exports = DEFAULT_CONFIG_URLS = {
+const DEFAULT_CONFIG_URLS = {
   keysUrl: KEYS_URL
 };
 
-module.exports = (teamId, urls = DEFAULT_CONFIG_URLS) => ({
+module.exports = (teamId, urlOverrides = DEFAULT_CONFIG_URLS) => ({
   teamId,
   encryption: {
     cipherAlgorithm: 'aes-256-gcm',
@@ -18,7 +18,7 @@ module.exports = (teamId, urls = DEFAULT_CONFIG_URLS) => ({
     },
   },
   http: {
-    keysUrl: urls.keysUrl || DEFAULT_CONFIG_URLS.keysUrl,
+    keysUrl: urlOverrides.keysUrl || DEFAULT_CONFIG_URLS.keysUrl,
     metricsUrl: METRICS_URL
   }
 })

--- a/lib/v1/config.js
+++ b/lib/v1/config.js
@@ -2,7 +2,7 @@ const KEYS_URL = 'https://keys.evervault.com';
 const METRICS_URL = 'https://metrics.evervault.com';
 
 const DEFAULT_CONFIG = {
-  urls = {
+  urls: {
     keysUrl: KEYS_URL
   }
 };

--- a/lib/v1/config.js
+++ b/lib/v1/config.js
@@ -21,6 +21,6 @@ module.exports = (teamId, config = DEFAULT_CONFIG) => ({
   },
   http: {
     keysUrl: config.urls.keysUrl,
-    metricsUrl = METRICS_URL
+    metricsUrl: METRICS_URL
   }
 })

--- a/lib/v1/config.js
+++ b/lib/v1/config.js
@@ -1,7 +1,12 @@
 const KEYS_URL = 'https://keys.evervault.com';
 const METRICS_URL = ' https://metrics.evervault.com';
 
-module.exports = (teamId, apiUrlOverride) => ({
+const DEFAULT_CONFIG_URLS = {
+	keysUrl: KEYS_URL,
+  metricsUrl: METRICS_URL
+};
+
+module.exports = (teamId, configUrls = DEFAULT_CONFIG_URLS) => ({
   teamId,
   encryption: {
     cipherAlgorithm: 'aes-256-gcm',
@@ -13,8 +18,5 @@ module.exports = (teamId, apiUrlOverride) => ({
       version: 1,
     },
   },
-  http: {
-    keysUrl: apiUrlOverride || KEYS_URL,
-    metricsUrl: METRICS_URL,
-  }
+  http: configUrls
 })

--- a/lib/v1/config.js
+++ b/lib/v1/config.js
@@ -1,7 +1,7 @@
 const KEYS_URL = 'https://keys.evervault.com';
 const METRICS_URL = ' https://metrics.evervault.com';
 
-module.exports = (teamId, keysUrlOverride) => ({
+module.exports = (teamId, apiUrlOverride) => ({
   teamId,
   encryption: {
     cipherAlgorithm: 'aes-256-gcm',
@@ -14,7 +14,7 @@ module.exports = (teamId, keysUrlOverride) => ({
     },
   },
   http: {
-    keysUrl: keysUrlOverride || KEYS_URL,
+    keysUrl: apiUrlOverride || KEYS_URL,
     metricsUrl: METRICS_URL,
   }
 })

--- a/lib/v1/config.js
+++ b/lib/v1/config.js
@@ -1,13 +1,11 @@
 const KEYS_URL = 'https://keys.evervault.com';
 const METRICS_URL = 'https://metrics.evervault.com';
 
-const DEFAULT_CONFIG = {
-  urls: {
-    keysUrl: KEYS_URL
-  }
+module.exports = DEFAULT_CONFIG_URLS = {
+  keysUrl: KEYS_URL
 };
 
-module.exports = (teamId, config = DEFAULT_CONFIG) => ({
+module.exports = (teamId, urls = DEFAULT_CONFIG_URLS) => ({
   teamId,
   encryption: {
     cipherAlgorithm: 'aes-256-gcm',
@@ -20,7 +18,7 @@ module.exports = (teamId, config = DEFAULT_CONFIG) => ({
     },
   },
   http: {
-    keysUrl: config.urls.keysUrl,
+    keysUrl: urls.keysUrl || DEFAULT_CONFIG_URLS.keysUrl,
     metricsUrl: METRICS_URL
   }
 })

--- a/lib/v1/config.js
+++ b/lib/v1/config.js
@@ -1,12 +1,13 @@
 const KEYS_URL = 'https://keys.evervault.com';
 const METRICS_URL = 'https://metrics.evervault.com';
 
-const DEFAULT_CONFIG_URLS = {
-	keysUrl: KEYS_URL,
-  metricsUrl: METRICS_URL
+const DEFAULT_CONFIG = {
+  urls = {
+    keysUrl: KEYS_URL
+  }
 };
 
-module.exports = (teamId, configUrls = DEFAULT_CONFIG_URLS) => ({
+module.exports = (teamId, config = DEFAULT_CONFIG) => ({
   teamId,
   encryption: {
     cipherAlgorithm: 'aes-256-gcm',
@@ -18,5 +19,8 @@ module.exports = (teamId, configUrls = DEFAULT_CONFIG_URLS) => ({
       version: 1,
     },
   },
-  http: configUrls
+  http: {
+    keysUrl: config.urls.keysUrl,
+    metricsUrl = METRICS_URL
+  }
 })

--- a/lib/v1/config.js
+++ b/lib/v1/config.js
@@ -5,7 +5,7 @@ const DEFAULT_CONFIG_URLS = {
   keysUrl: KEYS_URL
 };
 
-module.exports = (teamId, urlOverrides = DEFAULT_CONFIG_URLS) => ({
+module.exports = (teamId, customUrl = DEFAULT_CONFIG_URLS) => ({
   teamId,
   encryption: {
     cipherAlgorithm: 'aes-256-gcm',
@@ -18,7 +18,7 @@ module.exports = (teamId, urlOverrides = DEFAULT_CONFIG_URLS) => ({
     },
   },
   http: {
-    keysUrl: urlOverrides.keysUrl || DEFAULT_CONFIG_URLS.keysUrl,
+    keysUrl: customUrl.keysUrl || DEFAULT_CONFIG_URLS.keysUrl,
     metricsUrl: METRICS_URL
   }
 })

--- a/lib/v1/config.js
+++ b/lib/v1/config.js
@@ -1,5 +1,5 @@
 const KEYS_URL = 'https://keys.evervault.com';
-const METRICS_URL = ' https://metrics.evervault.com';
+const METRICS_URL = 'https://metrics.evervault.com';
 
 const DEFAULT_CONFIG_URLS = {
 	keysUrl: KEYS_URL,

--- a/lib/v1/config.js
+++ b/lib/v1/config.js
@@ -5,7 +5,7 @@ const DEFAULT_CONFIG_URLS = {
   keysUrl: KEYS_URL
 };
 
-module.exports = (teamId, customUrl = DEFAULT_CONFIG_URLS) => ({
+module.exports = (teamId, customUrls = DEFAULT_CONFIG_URLS) => ({
   teamId,
   encryption: {
     cipherAlgorithm: 'aes-256-gcm',
@@ -18,7 +18,7 @@ module.exports = (teamId, customUrl = DEFAULT_CONFIG_URLS) => ({
     },
   },
   http: {
-    keysUrl: customUrl.keysUrl || DEFAULT_CONFIG_URLS.keysUrl,
+    keysUrl: customUrls.keysUrl || DEFAULT_CONFIG_URLS.keysUrl,
     metricsUrl: METRICS_URL
   }
 })

--- a/lib/v1/index.js
+++ b/lib/v1/index.js
@@ -4,14 +4,14 @@ const { Crypto, Http, Forms } = require('./core');
 const extractDomainFromUrl = require('./utils/domain');
 
 class EvervaultClient {
-  constructor(teamId, keysUrlOverride) {
+  constructor(teamId, apiUrlOverride) {
     if (!Datatypes.isString(teamId)) {
       throw new errors.InitializationError('teamId must be a string');
     }
-    if (!Datatypes.isUndefined(keysUrlOverride) || !Datatypes.isString(keysUrlOverride)) {
+    if (!Datatypes.isUndefined(apiUrlOverride) || !Datatypes.isString(apiUrlOverride)) {
       throw new errors.InitializationError('appUrl must be a string');
     }
-    this.config = Config(teamId, keysUrlOverride);
+    this.config = Config(teamId, apiUrlOverride);
     this.crypto = Crypto(this.config.encryption);
     this.http = Http(this.config.http, this.config.teamId);
     this.forms = Forms(this);

--- a/lib/v1/index.js
+++ b/lib/v1/index.js
@@ -3,11 +3,16 @@ const Config = require('./config');
 const { Crypto, Http, Forms } = require('./core');
 
 class EvervaultClient {
-  constructor(teamId, configUrls) {
+  constructor(teamId, config) {
     if (!Datatypes.isString(teamId)) {
       throw new errors.InitializationError('teamId must be a string');
     }
-    this.config = Config(teamId, configUrls);
+    if(!config.urls.keysUrl) {
+      if (!Datatypes.isString(config.urls.keysUrl)) {
+        config = undefined;
+      }
+    }
+    this.config = Config(teamId, config.urls);
     this.crypto = Crypto(this.config.encryption);
     this.http = Http(this.config.http, this.config.teamId);
     this.forms = Forms(this);

--- a/lib/v1/index.js
+++ b/lib/v1/index.js
@@ -8,7 +8,7 @@ class EvervaultClient {
     if (!Datatypes.isString(teamId)) {
       throw new errors.InitializationError('teamId must be a string');
     }
-    if (!Datatypes.isUndefined(apiUrlOverride) || !Datatypes.isString(apiUrlOverride)) {
+    if (!Datatypes.isUndefined(apiUrlOverride) && !Datatypes.isString(apiUrlOverride)) {
       throw new errors.InitializationError('appUrl must be a string');
     }
     this.config = Config(teamId, apiUrlOverride);

--- a/lib/v1/index.js
+++ b/lib/v1/index.js
@@ -4,14 +4,11 @@ const { Crypto, Http, Forms } = require('./core');
 const extractDomainFromUrl = require('./utils/domain');
 
 class EvervaultClient {
-  constructor(teamId, apiUrlOverride) {
+  constructor(teamId, configUrls) {
     if (!Datatypes.isString(teamId)) {
       throw new errors.InitializationError('teamId must be a string');
     }
-    if (!Datatypes.isUndefined(apiUrlOverride) && !Datatypes.isString(apiUrlOverride)) {
-      throw new errors.InitializationError('appUrl must be a string');
-    }
-    this.config = Config(teamId, apiUrlOverride);
+    this.config = Config(teamId, configUrls);
     this.crypto = Crypto(this.config.encryption);
     this.http = Http(this.config.http, this.config.teamId);
     this.forms = Forms(this);

--- a/lib/v1/index.js
+++ b/lib/v1/index.js
@@ -7,11 +7,7 @@ class EvervaultClient {
     if (!Datatypes.isString(teamId)) {
       throw new errors.InitializationError('teamId must be a string');
     }
-    if(!config.urls.keysUrl) {
-      if (!Datatypes.isString(config.urls.keysUrl)) {
-        config = undefined;
-      }
-    }
+    this.validateConfig(config);
     this.config = Config(teamId, config.urls);
     this.crypto = Crypto(this.config.encryption);
     this.http = Http(this.config.http, this.config.teamId);
@@ -64,6 +60,17 @@ class EvervaultClient {
       writable: false,
       value,
     });
+  }
+
+  validateConfig(config) {
+    if(!config){
+      config = {urls: Config.DEFAULT_CONFIG_URLS};     
+    } else if (!config.urls) {
+      config.urls = Config.DEFAULT_CONFIG_URLS;
+    }
+    if (!config.urls.keysUrl && !Datatypes.isString(config.urls.keysUrl)) {
+      config.urls = Config.DEFAULT_CONFIG_URLS.keysUrl;
+    }
   }
 }
 

--- a/lib/v1/index.js
+++ b/lib/v1/index.js
@@ -4,11 +4,14 @@ const { Crypto, Http, Forms } = require('./core');
 const extractDomainFromUrl = require('./utils/domain');
 
 class EvervaultClient {
-  constructor(teamId) {
+  constructor(teamId, keysUrlOverride) {
     if (!Datatypes.isString(teamId)) {
       throw new errors.InitializationError('teamId must be a string');
     }
-    this.config = Config(teamId);
+    if (!Datatypes.isUndefined(keysUrlOverride) || !Datatypes.isString(keysUrlOverride)) {
+      throw new errors.InitializationError('appUrl must be a string');
+    }
+    this.config = Config(teamId, keysUrlOverride);
     this.crypto = Crypto(this.config.encryption);
     this.http = Http(this.config.http, this.config.teamId);
     this.forms = Forms(this);

--- a/lib/v1/index.js
+++ b/lib/v1/index.js
@@ -1,7 +1,6 @@
 const { Datatypes, errors, extractDomain } = require('./utils');
 const Config = require('./config');
 const { Crypto, Http, Forms } = require('./core');
-const extractDomainFromUrl = require('./utils/domain');
 
 class EvervaultClient {
   constructor(teamId, configUrls) {

--- a/lib/v1/index.js
+++ b/lib/v1/index.js
@@ -3,16 +3,14 @@ const Config = require('./config');
 const { Crypto, Http, Forms } = require('./core');
 
 class EvervaultClient {
-  constructor(teamId, configOverride) {
+  constructor(teamId, customConfig = {}) {
     if (!Datatypes.isString(teamId)) {
       throw new errors.InitializationError('teamId must be a string');
     }
-    if(!configOverride || !configOverride?.urls) {
-      configOverride = {
-        urls: undefined
-      }
+    if(!customConfig) {
+      customConfig = {};
     }
-    this.config = Config(teamId, configOverride.urls);
+    this.config = Config(teamId, customConfig.urls);
     this.crypto = Crypto(this.config.encryption);
     this.http = Http(this.config.http, this.config.teamId);
     this.forms = Forms(this);

--- a/lib/v1/index.js
+++ b/lib/v1/index.js
@@ -3,12 +3,16 @@ const Config = require('./config');
 const { Crypto, Http, Forms } = require('./core');
 
 class EvervaultClient {
-  constructor(teamId, config) {
+  constructor(teamId, configOverride) {
     if (!Datatypes.isString(teamId)) {
       throw new errors.InitializationError('teamId must be a string');
     }
-    this.validateConfig(config);
-    this.config = Config(teamId, config.urls);
+    if(!configOverride || !configOverride?.urls) {
+      configOverride = {
+        urls: undefined
+      }
+    }
+    this.config = Config(teamId, configOverride.urls);
     this.crypto = Crypto(this.config.encryption);
     this.http = Http(this.config.http, this.config.teamId);
     this.forms = Forms(this);
@@ -60,17 +64,6 @@ class EvervaultClient {
       writable: false,
       value,
     });
-  }
-
-  validateConfig(config) {
-    if(!config){
-      config = {urls: Config.DEFAULT_CONFIG_URLS};     
-    } else if (!config.urls) {
-      config.urls = Config.DEFAULT_CONFIG_URLS;
-    }
-    if (!config.urls.keysUrl && !Datatypes.isString(config.urls.keysUrl)) {
-      config.urls = Config.DEFAULT_CONFIG_URLS.keysUrl;
-    }
   }
 }
 


### PR DESCRIPTION
# Why
Cage playground in staging cannot use the React SDK because the production API URL is hard coded in the Javascript SDK config.

# How
Adding a path to the constructor to accept env var as the keys url path, and passing that through to the config.
