### PR TITLE
Array elements are now encrypted rather than entire arrays

### DIFF
--- a/lib/v1/utils/datatypes.js
+++ b/lib/v1/utils/datatypes.js
@@ -14,8 +14,7 @@ const isNumber = (data) => typeof data === "number";
 const isBoolean = (data) => typeof data === "boolean";
 
 const isEncryptable = (data) =>
-  isDefined(data) &&
-  (isArray(data) || isString(data) || isNumber(data) || isBoolean(data));
+  isDefined(data) && (isString(data) || isNumber(data) || isBoolean(data));
 
 const getHeaderType = (data) => {
   if (!isDefined(data)) return;


### PR DESCRIPTION
# Why
Arrays are not supposed to be stringified and then encrypted. They should still be arrays, but every element should be encrypted.

# How
Changed `isEncryptable` to match the NodeJS SDK.
