### PR TITLE
fix: Use v2 inputs

### DIFF
--- a/lib/utils/constructSource.js
+++ b/lib/utils/constructSource.js
@@ -9,7 +9,7 @@ module.exports = function (config, theme, styles) {
   const { inputsUrl } = config.input;
   const { teamId, appId } = config;
 
-  return `${inputsUrl}/?team=${teamId}&app=${appId}${
+  return `${inputsUrl}?team=${teamId}&app=${appId}${
     theme ? `&theme=${theme}` : ""
   }${stylesQuery}
   `;

--- a/lib/utils/constructSource.js
+++ b/lib/utils/constructSource.js
@@ -7,9 +7,9 @@ module.exports = function (config, theme, styles) {
   }
 
   const { inputsUrl } = config.input;
-  const { teamId } = config;
+  const { teamId, appId } = config;
 
-  return `${inputsUrl}/?team=${teamId}${
+  return `${inputsUrl}/?team=${teamId}&app=${appId}${
     theme ? `&theme=${theme}` : ""
   }${stylesQuery}
   `;

--- a/lib/v2/config.js
+++ b/lib/v2/config.js
@@ -1,6 +1,6 @@
 const KEYS_URL = "https://keys.evervault.com";
 const METRICS_URL = "https://metrics.evervault.com";
-const INPUTS_URL = "https://inputs.evervault.com/v2";
+const INPUTS_URL = "https://inputs.evervault.com/v2/index.html";
 
 const DEFAULT_CONFIG_URLS = {
   keysUrl: KEYS_URL,

--- a/lib/v2/config.js
+++ b/lib/v2/config.js
@@ -1,6 +1,6 @@
 const KEYS_URL = "https://keys.evervault.com";
 const METRICS_URL = "https://metrics.evervault.com";
-const INPUTS_URL = "https://inputs.evervault.com";
+const INPUTS_URL = "https://inputs.evervault.com/v2";
 
 const DEFAULT_CONFIG_URLS = {
   keysUrl: KEYS_URL,


### PR DESCRIPTION
# Why
Need to use the v2 endpoint for inputs to have them be app tenanted
