### PR TITLE
fix: backport race condition fix to v1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-node@v1
         with:
-          node-version: '14.x'
+          node-version: '18.x'
       - run: npm ci
       - run: npx semantic-release
         env:

--- a/lib/v1/index.js
+++ b/lib/v1/index.js
@@ -63,9 +63,10 @@ class EvervaultClient {
       return data;
     }
     this.http.reportMetric();
-    if (!Datatypes.isDefined(this._ecdhTeamKey)) {
-      await this.loadKeys();
+    if (!this.keysLoadingPromise) {
+      this.keysLoadingPromise = this.loadKeys();
     }
+    await this.keysLoadingPromise;
     try {
       return await this.crypto.encrypt(
         this._ecdhTeamKey,


### PR DESCRIPTION
# Why
When testing file encryption a race condition came up where two objects are encrypted in quick succession.
This was fixed in the v2 sdk but not backported to the v1 sdk.

# How
Backported the fix to the v1 sdk

Also had to bump the version of node in the workflow because the semantic release bot was refusing to run with node < 18