### PR TITLE
Readd datatype isDefined check

### DIFF
--- a/lib/v1/index.js
+++ b/lib/v1/index.js
@@ -63,7 +63,7 @@ class EvervaultClient {
       return data;
     }
     this.http.reportMetric();
-    if (!this.keysLoadingPromise) {
+    if (!this.keysLoadingPromise && !Datatypes.isDefined(this._ecdhTeamKey)) {
       this.keysLoadingPromise = this.loadKeys();
     }
     await this.keysLoadingPromise;


### PR DESCRIPTION
# Why
Backporting fix was not compatible with v1 inputs due to its raw use of `evervault.loadKeys()`

# How
Re-added the datatype isDefined check to encrypt in the v1 sdk