### PR TITLE
fix: removing call to metrics

### DIFF
--- a/lib/v1/config.js
+++ b/lib/v1/config.js
@@ -1,5 +1,4 @@
 const KEYS_URL = "https://keys.evervault.com";
-const METRICS_URL = "https://metrics.evervault.com";
 const INPUTS_URL = "https://inputs.evervault.com";
 
 const DEFAULT_CONFIG_URLS = {
@@ -23,7 +22,6 @@ module.exports = (teamId, customUrls = DEFAULT_CONFIG_URLS) => ({
   },
   http: {
     keysUrl: customUrls.keysUrl || DEFAULT_CONFIG_URLS.keysUrl,
-    metricsUrl: METRICS_URL,
   },
   input: {
     inputsUrl: customUrls.inputsUrl || DEFAULT_CONFIG_URLS.inputsUrl,

--- a/lib/v1/core/http.js
+++ b/lib/v1/core/http.js
@@ -51,14 +51,5 @@ module.exports = (config, teamId, context) => {
     }
   };
 
-  const reportMetric = () => {
-    try {
-      post(config.metricsUrl, "", {
-        teamUuid: teamId,
-        event: "Data Encrypted",
-      });
-    } catch (err) {}
-  };
-
-  return { getCageKey, reportMetric };
+  return { getCageKey };
 };

--- a/lib/v1/index.js
+++ b/lib/v1/index.js
@@ -62,7 +62,6 @@ class EvervaultClient {
     if (Datatypes.isEmptyString(data)) {
       return data;
     }
-    this.http.reportMetric();
     if (!this.keysLoadingPromise && !Datatypes.isDefined(this._ecdhTeamKey)) {
       this.keysLoadingPromise = this.loadKeys();
     }

--- a/lib/v2/config.js
+++ b/lib/v2/config.js
@@ -1,5 +1,4 @@
 const KEYS_URL = "https://keys.evervault.com";
-const METRICS_URL = "https://metrics.evervault.com";
 const INPUTS_ORIGIN = "https://inputs.evervault.com";
 const INPUTS_URL = `${INPUTS_ORIGIN}/v2/index.html`;
 

--- a/lib/v2/config.js
+++ b/lib/v2/config.js
@@ -25,7 +25,6 @@ module.exports = (teamId, appId, customUrls = DEFAULT_CONFIG_URLS) => ({
   },
   http: {
     keysUrl: customUrls.keysUrl || DEFAULT_CONFIG_URLS.keysUrl,
-    metricsUrl: METRICS_URL,
   },
   input: {
     inputsUrl: customUrls.inputsUrl || DEFAULT_CONFIG_URLS.inputsUrl,

--- a/lib/v2/core/http.js
+++ b/lib/v2/core/http.js
@@ -51,15 +51,5 @@ module.exports = (config, teamId, appId, context) => {
     }
   };
 
-  const reportMetric = () => {
-    try {
-      post(config.metricsUrl, "", {
-        teamUuid: teamId,
-        appUuid: appId,
-        event: "Data Encrypted",
-      });
-    } catch (err) {}
-  };
-
-  return { getCageKey, reportMetric };
+  return { getCageKey };
 };

--- a/lib/v2/index.js
+++ b/lib/v2/index.js
@@ -85,7 +85,6 @@ class EvervaultClient {
     if (Datatypes.isEmptyString(data)) {
       return data;
     }
-    this.http.reportMetric();
     if (!this.keysLoadingPromise) {
       this.keysLoadingPromise = this.loadKeys();
     }


### PR DESCRIPTION
# Why
We no longer want to report metrics back to Evervault in this way

# How
Removed calls to metrics
