### PR TITLE
feat: add crc32 checksum to file encryption

### DIFF
--- a/lib/utils/crc32.js
+++ b/lib/utils/crc32.js
@@ -1,0 +1,29 @@
+const crcTable = new Uint32Array(256);
+for (let i = 0; i < 256; i++) {
+  let c = i;
+  for (let j = 0; j < 8; j++) {
+    if (c & 1) {
+      c = 0xedb88320 ^ (c >>> 1);
+    } else {
+      c = c >>> 1;
+    }
+  }
+  crcTable[i] = c;
+}
+
+// calculate a crc32 given an array buffer
+//
+// @param {ArrayBuffer} buffer
+// @return {Number}
+function crc32(buffer) {
+  let crc = 0xffffffff;
+  const len = buffer.byteLength;
+
+  for (let i = 0; i < len; i++) {
+    crc = crcTable[(crc ^ buffer[i]) & 0xff] ^ (crc >>> 8);
+  }
+
+  return crc ^ 0xffffffff;
+}
+
+module.exports = crc32;

--- a/lib/v2/core/crypto.js
+++ b/lib/v2/core/crypto.js
@@ -2,6 +2,7 @@
 
 const { Datatypes, errors, cryptoUtils } = require("../../utils");
 const { arrayBufferToBase64 } = require("../../utils/datatypes");
+const crc32 = require("../../utils/crc32");
 
 const generateBytes = (byteLength) => {
   return new Promise((resolve, reject) => {
@@ -201,7 +202,7 @@ module.exports = (config, isDebug) => {
     const evEncryptedFileIdentifier = Buffer.from([
       0x25, 0x45, 0x56, 0x45, 0x4e, 0x43,
     ]);
-    const versionNumber = Buffer.from([0x01]);
+    const versionNumber = Buffer.from([0x03]);
     const offsetToData = Buffer.from([0x37, 0x00]);
     const flags = isDebug ? Buffer.from([0x01]) : Buffer.from([0x00]);
 
@@ -215,12 +216,19 @@ module.exports = (config, isDebug) => {
       Buffer.from(encryptedData),
     ]);
 
+    const crc32Hash = crc32(data);
+
+    const crc32HashBytes = Buffer.alloc(4);
+    crc32HashBytes.writeInt32LE(crc32Hash);
+
+    const checkedData = Buffer.concat([data, crc32HashBytes]);
+
     if (fileName) {
-      return new File([data], fileName, {
+      return new File([checkedData], fileName, {
         type: "application/octet-stream",
       });
     } else {
-      return new Blob([data], {
+      return new Blob([checkedData], {
         type: "application/octet-stream",
       });
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "evervault-browser-sdk",
       "version": "1.0.0",
       "license": "ISC",
+      "dependencies": {
+        "crc-32": "^1.2.2"
+      },
       "devDependencies": {
         "dotenv": "^16.0.3",
         "jsdom": "^20.0.3",
@@ -1147,6 +1150,17 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/create-ecdh": {
       "version": "4.0.4",

--- a/package.json
+++ b/package.json
@@ -18,10 +18,11 @@
     "dotenv": "^16.0.3",
     "jsdom": "^20.0.3",
     "mocha": "^10.2.0",
+    "nock": "^13.3.0",
     "prettier": "^2.0.5",
     "web-file-polyfill": "^1.0.4",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.12",
-    "nock": "^13.3.0"
+    "crc-32": "^1.2.2"
   }
 }


### PR DESCRIPTION
# Why
File encryption format now includes a crc32 checksum.

# How
Added the checksum to the end of encrypted files.
Added a crc32 library as a dev dependency to ensure that we are crc32'ing files correctly in our tests.