### PR TITLE
[ETR-650] Replace Buffer Polyfill

### DIFF
--- a/lib/core/crypto.js
+++ b/lib/core/crypto.js
@@ -1,6 +1,9 @@
 import { Datatypes, errors, cryptoUtils } from "../utils";
 import concatUint8Arrays from "../utils/concatUint8Arrays";
-import { uint8ArrayToBase64String, utf8StringToUint8Array } from "../utils/encoding";
+import {
+  uint8ArrayToBase64String,
+  utf8StringToUint8Array,
+} from "../utils/encoding";
 
 const generateBytes = async (byteLength) => {
   let randomBytes = new Uint8Array(byteLength);
@@ -67,7 +70,7 @@ export default function Crypto(config, isDebug) {
     }
   };
 
-  const _encryptFile = async (
+  const q = async (
     ecdhTeamKey,
     ecdhPublicKey,
     derivedSecret,
@@ -165,9 +168,7 @@ export default function Crypto(config, isDebug) {
   };
 
   const _evVersionPrefix = base64RemovePadding(
-    uint8ArrayToBase64String(
-      utf8StringToUint8Array(config.evVersion)
-    ),
+    uint8ArrayToBase64String(utf8StringToUint8Array(config.evVersion))
   );
 
   const _format = async (
@@ -181,10 +182,11 @@ export default function Crypto(config, isDebug) {
       ecdhPublicKey
     );
     const compressedKey = cryptoUtils.ecPointCompress(exportableEcdhPublicKey);
-    return `ev:${isDebug ? "debug:" : ""}${_evVersionPrefix}${datatype !== "string" ? ":" + datatype : ""
-      }:${base64RemovePadding(keyIv)}:${base64RemovePadding(
-        uint8ArrayToBase64String(compressedKey)
-      )}:${base64RemovePadding(encryptedData)}:$`;
+    return `ev:${isDebug ? "debug:" : ""}${_evVersionPrefix}${
+      datatype !== "string" ? ":" + datatype : ""
+    }:${base64RemovePadding(keyIv)}:${base64RemovePadding(
+      uint8ArrayToBase64String(compressedKey)
+    )}:${base64RemovePadding(encryptedData)}:$`;
   };
 
   const _formatFile = async (keyIv, ecdhPublicKey, encryptedData, fileName) => {
@@ -208,7 +210,7 @@ export default function Crypto(config, isDebug) {
       compressedKey,
       keyIv,
       flags,
-      utf8StringToUint8Array(encryptedData)
+      utf8StringToUint8Array(encryptedData),
     ]);
 
     if (fileName) {

--- a/lib/core/crypto.js
+++ b/lib/core/crypto.js
@@ -1,21 +1,17 @@
-import { Buffer } from "buffer/index";
+import { toString, fromString, concat } from "uint8arrays";
 
 import { Datatypes, errors, cryptoUtils } from "../utils";
 
-const generateBytes = (byteLength) => {
-  return new Promise((resolve, reject) => {
-    const randomBytes = new Uint8Array(byteLength);
-    if (window.crypto) {
-      window.crypto.getRandomValues(randomBytes);
-      resolve(randomBytes);
-    } else {
-      reject(
-        new errors.CryptoError(
-          "Your browser is outdated and does not support the Web Crypto API. Please upgrade it."
-        )
-      );
-    }
-  });
+const generateBytes = async (byteLength) => {
+  let randomBytes = new Uint8Array(byteLength);
+  if (window.crypto) {
+    window.crypto.getRandomValues(randomBytes);
+    return randomBytes;
+  } else {
+    throw new errors.CryptoError(
+      "Your browser is outdated and does not support the Web Crypto API. Please upgrade it."
+    );
+  }
 };
 
 export default function Crypto(config, isDebug) {
@@ -97,7 +93,7 @@ export default function Crypto(config, isDebug) {
     return new Promise((resolve, reject) => {
       const reader = new window.FileReader();
 
-      reader.onloadend = (event) => {
+      reader.onloadend = (_event) => {
         if (!reader.result) {
           reject({
             error: "Failed to read file to be encrypted",
@@ -110,7 +106,7 @@ export default function Crypto(config, isDebug) {
               name: "AES-GCM",
               iv: keyIv,
               tagLength: config.authTagLength,
-              additionalData: Buffer.from(ecdhTeamKey, "base64"),
+              additionalData: ecdhTeamKey,
             },
             derivedSecretImported,
             reader.result
@@ -150,17 +146,17 @@ export default function Crypto(config, isDebug) {
         name: "AES-GCM",
         iv: keyIv,
         tagLength: config.authTagLength,
-        additionalData: Buffer.from(ecdhTeamKey, "base64"),
+        additionalData: ecdhTeamKey,
       },
       derivedSecretImported,
-      Buffer.from(str)
+      fromString(str, 'utf-8')
     );
 
     return await _format(
       datatype,
-      Datatypes.arrayBufferToBase64(keyIv),
+      toString(keyIv, "base64"),
       ecdhPublicKey,
-      Datatypes.arrayBufferToBase64(Buffer.from(encryptedBuffer))
+      toString(new Uint8Array(encryptedBuffer), "base64")
     );
   };
 
@@ -169,7 +165,7 @@ export default function Crypto(config, isDebug) {
   };
 
   const _evVersionPrefix = base64RemovePadding(
-    Buffer.from(config.evVersion).toString("base64")
+    toString(fromString(config.evVersion, "utf-8"), "base64")
   );
 
   const _format = async (
@@ -186,7 +182,7 @@ export default function Crypto(config, isDebug) {
     return `ev:${isDebug ? "debug:" : ""}${_evVersionPrefix}${
       datatype !== "string" ? ":" + datatype : ""
     }:${base64RemovePadding(keyIv)}:${base64RemovePadding(
-      Datatypes.arrayBufferToBase64(compressedKey)
+      toString(compressedKey, "base64")
     )}:${base64RemovePadding(encryptedData)}:$`;
   };
 
@@ -197,21 +193,21 @@ export default function Crypto(config, isDebug) {
     );
 
     const compressedKey = cryptoUtils.ecPointCompress(exportableEcdhPublicKey);
-    const evEncryptedFileIdentifier = Buffer.from([
+    const evEncryptedFileIdentifier = new Uint8Array([
       0x25, 0x45, 0x56, 0x45, 0x4e, 0x43,
     ]);
-    const versionNumber = Buffer.from([0x01]);
-    const offsetToData = Buffer.from([0x37, 0x00]);
-    const flags = isDebug ? Buffer.from([0x01]) : Buffer.from([0x00]);
+    const versionNumber = new Uint8Array([0x01]);
+    const offsetToData = new Uint8Array([0x37, 0x00]);
+    const flags = isDebug ? new Uint8Array([0x01]) : new Uint8Array([0x00]);
 
-    const data = Buffer.concat([
+    const data = concat([
       evEncryptedFileIdentifier,
       versionNumber,
       offsetToData,
-      Buffer.from(compressedKey),
-      Buffer.from(keyIv),
+      compressedKey,
+      keyIv,
       flags,
-      Buffer.from(encryptedData),
+      fromString(encryptedData, 'utf-8'),
     ]);
 
     if (fileName) {

--- a/lib/core/crypto.js
+++ b/lib/core/crypto.js
@@ -1,6 +1,6 @@
-import { toString, fromString, concat } from "uint8arrays";
-
 import { Datatypes, errors, cryptoUtils } from "../utils";
+import concatUint8Arrays from "../utils/concatUint8Arrays";
+import { uint8ArrayToBase64String, utf8StringToUint8Array } from "../utils/encoding";
 
 const generateBytes = async (byteLength) => {
   let randomBytes = new Uint8Array(byteLength);
@@ -149,14 +149,14 @@ export default function Crypto(config, isDebug) {
         additionalData: ecdhTeamKey,
       },
       derivedSecretImported,
-      fromString(str, "utf-8")
+      utf8StringToUint8Array(str)
     );
 
     return await _format(
       datatype,
-      toString(keyIv, "base64"),
+      uint8ArrayToBase64String(keyIv),
       ecdhPublicKey,
-      toString(new Uint8Array(encryptedBuffer), "base64")
+      uint8ArrayToBase64String(new Uint8Array(encryptedBuffer))
     );
   };
 
@@ -165,7 +165,9 @@ export default function Crypto(config, isDebug) {
   };
 
   const _evVersionPrefix = base64RemovePadding(
-    toString(fromString(config.evVersion, "utf-8"), "base64")
+    uint8ArrayToBase64String(
+      utf8StringToUint8Array(config.evVersion)
+    ),
   );
 
   const _format = async (
@@ -179,11 +181,10 @@ export default function Crypto(config, isDebug) {
       ecdhPublicKey
     );
     const compressedKey = cryptoUtils.ecPointCompress(exportableEcdhPublicKey);
-    return `ev:${isDebug ? "debug:" : ""}${_evVersionPrefix}${
-      datatype !== "string" ? ":" + datatype : ""
-    }:${base64RemovePadding(keyIv)}:${base64RemovePadding(
-      toString(compressedKey, "base64")
-    )}:${base64RemovePadding(encryptedData)}:$`;
+    return `ev:${isDebug ? "debug:" : ""}${_evVersionPrefix}${datatype !== "string" ? ":" + datatype : ""
+      }:${base64RemovePadding(keyIv)}:${base64RemovePadding(
+        uint8ArrayToBase64String(compressedKey)
+      )}:${base64RemovePadding(encryptedData)}:$`;
   };
 
   const _formatFile = async (keyIv, ecdhPublicKey, encryptedData, fileName) => {
@@ -200,14 +201,14 @@ export default function Crypto(config, isDebug) {
     const offsetToData = new Uint8Array([0x37, 0x00]);
     const flags = isDebug ? new Uint8Array([0x01]) : new Uint8Array([0x00]);
 
-    const data = concat([
+    const data = concatUint8Arrays([
       evEncryptedFileIdentifier,
       versionNumber,
       offsetToData,
       compressedKey,
       keyIv,
       flags,
-      fromString(encryptedData, "utf-8"),
+      utf8StringToUint8Array(encryptedData)
     ]);
 
     if (fileName) {

--- a/lib/core/crypto.js
+++ b/lib/core/crypto.js
@@ -70,7 +70,7 @@ export default function Crypto(config, isDebug) {
     }
   };
 
-  const q = async (
+  const _encryptFile = async (
     ecdhTeamKey,
     ecdhPublicKey,
     derivedSecret,

--- a/lib/core/crypto.js
+++ b/lib/core/crypto.js
@@ -149,7 +149,7 @@ export default function Crypto(config, isDebug) {
         additionalData: ecdhTeamKey,
       },
       derivedSecretImported,
-      fromString(str, 'utf-8')
+      fromString(str, "utf-8")
     );
 
     return await _format(
@@ -207,7 +207,7 @@ export default function Crypto(config, isDebug) {
       compressedKey,
       keyIv,
       flags,
-      fromString(encryptedData, 'utf-8'),
+      fromString(encryptedData, "utf-8"),
     ]);
 
     if (fileName) {

--- a/lib/curves/base.js
+++ b/lib/curves/base.js
@@ -1,4 +1,4 @@
-import { Buffer } from "buffer/index";
+import { fromString, toString } from "uint8arrays";
 
 import ASN1 from "./asn1";
 
@@ -12,7 +12,7 @@ export function createCurve(curveValues) {
   const asn1Encoder = buildEncoder(curveValues);
   return (decompressedPublicKey) => {
     return asn1Encoder(
-      Buffer.from(decompressedPublicKey, "base64").toString("hex")
+      toString(fromString(decompressedPublicKey, "base64"), "hex")
     );
   };
 }
@@ -58,6 +58,6 @@ function buildEncoder({ p, a, b, seed, generator, n, h }) {
       ASN1.BitStr(decompressedKey)
     );
 
-    return Buffer.from(hexEncodedKey, "hex");
+    return fromString(hexEncodedKey, "hex");
   };
 }

--- a/lib/curves/base.js
+++ b/lib/curves/base.js
@@ -1,4 +1,8 @@
-import { base64StringToUint8Array, hexStringToUint8Array, uint8ArrayToHexString } from "../utils/encoding";
+import {
+  base64StringToUint8Array,
+  hexStringToUint8Array,
+  uint8ArrayToHexString,
+} from "../utils/encoding";
 import ASN1 from "./asn1";
 
 /**
@@ -11,9 +15,7 @@ export function createCurve(curveValues) {
   const asn1Encoder = buildEncoder(curveValues);
   return (decompressedPublicKey) => {
     return asn1Encoder(
-      uint8ArrayToHexString(
-        base64StringToUint8Array(decompressedPublicKey)
-      )
+      uint8ArrayToHexString(base64StringToUint8Array(decompressedPublicKey))
     );
   };
 }

--- a/lib/curves/base.js
+++ b/lib/curves/base.js
@@ -1,5 +1,4 @@
-import { fromString, toString } from "uint8arrays";
-
+import { base64StringToUint8Array, hexStringToUint8Array, uint8ArrayToHexString } from "../utils/encoding";
 import ASN1 from "./asn1";
 
 /**
@@ -12,7 +11,9 @@ export function createCurve(curveValues) {
   const asn1Encoder = buildEncoder(curveValues);
   return (decompressedPublicKey) => {
     return asn1Encoder(
-      toString(fromString(decompressedPublicKey, "base64"), "hex")
+      uint8ArrayToHexString(
+        base64StringToUint8Array(decompressedPublicKey)
+      )
     );
   };
 }
@@ -58,6 +59,6 @@ function buildEncoder({ p, a, b, seed, generator, n, h }) {
       ASN1.BitStr(decompressedKey)
     );
 
-    return fromString(hexEncodedKey, "hex");
+    return hexStringToUint8Array(hexEncodedKey);
   };
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,4 +1,4 @@
-import { fromString } from 'uint8arrays';
+import { fromString } from "uint8arrays";
 
 import { Datatypes, errors, extractDomain } from "./utils";
 import Config from "./config";

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,5 +1,3 @@
-import { fromString } from "uint8arrays";
-
 import { Datatypes, errors, extractDomain } from "./utils";
 import Config from "./config";
 import { Crypto, Http, Forms, Input } from "./core";
@@ -7,6 +5,7 @@ import {
   deriveSharedSecret,
   buildCageKeyFromSuppliedPublicKey,
 } from "./utils/crypto";
+import { base64StringToUint8Array } from "./utils/encoding";
 
 export default class EvervaultClient {
   #debugMode;
@@ -69,7 +68,7 @@ export default class EvervaultClient {
       ? this.config.debugKey
       : await this.http.getCageKey();
 
-    this.#ecdhTeamKey = fromString(cageKey.ecdhP256Key, "base64");
+    this.#ecdhTeamKey = base64StringToUint8Array(cageKey.ecdhP256Key);
 
     const keyPair = await window.crypto.subtle.generateKey(
       {

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,4 +1,4 @@
-import { Buffer } from "buffer/index";
+import { fromString } from 'uint8arrays';
 
 import { Datatypes, errors, extractDomain } from "./utils";
 import Config from "./config";
@@ -69,7 +69,7 @@ export default class EvervaultClient {
       ? this.config.debugKey
       : await this.http.getCageKey();
 
-    this.#ecdhTeamKey = Buffer.from(cageKey.ecdhP256Key, "base64");
+    this.#ecdhTeamKey = fromString(cageKey.ecdhP256Key, "base64");
 
     const keyPair = await window.crypto.subtle.generateKey(
       {

--- a/lib/utils/concatUint8Arrays.js
+++ b/lib/utils/concatUint8Arrays.js
@@ -1,4 +1,9 @@
-function concatUint8Arrays(...arrays) {
+/**
+ * 
+ * @param {Uint8Array[]} arrays 
+ * @returns {Uint8Array}
+ */
+function concatUint8Arrays(arrays) {
   const totalLength = arrays.reduce((acc, array) => acc + array.length, 0);
   const result = new Uint8Array(totalLength);
   let offset = 0;

--- a/lib/utils/concatUint8Arrays.js
+++ b/lib/utils/concatUint8Arrays.js
@@ -1,6 +1,6 @@
 /**
- * 
- * @param {Uint8Array[]} arrays 
+ *
+ * @param {Uint8Array[]} arrays
  * @returns {Uint8Array}
  */
 function concatUint8Arrays(arrays) {

--- a/lib/utils/concatUint8Arrays.js
+++ b/lib/utils/concatUint8Arrays.js
@@ -1,0 +1,14 @@
+function concatUint8Arrays(...arrays) {
+  const totalLength = arrays.reduce((acc, array) => acc + array.length, 0);
+  const result = new Uint8Array(totalLength);
+  let offset = 0;
+
+  for (const array of arrays) {
+    result.set(array, offset);
+    offset += array.length;
+  }
+
+  return result;
+}
+
+export default concatUint8Arrays;

--- a/lib/utils/crypto.js
+++ b/lib/utils/crypto.js
@@ -1,7 +1,6 @@
-import { Buffer } from "buffer/index";
+import { fromString, toString, concat } from "uint8arrays";
 
 import { P256 } from "../curves";
-import { arrayBufferToBase64 } from "./datatypes";
 
 // To compress - record the sign of the `y` point
 // then remove the `y` point and encode the recorded
@@ -18,7 +17,7 @@ export async function deriveSharedSecret(ecdh, publicKey, ephemeralPublicKey) {
   // Convert to a P256 `CryptoKey` object
   const importedPublicKey = await window.crypto.subtle.importKey(
     "raw",
-    Buffer.from(publicKey, "base64"),
+    fromString(publicKey, "base64"),
     {
       name: "ECDH",
       namedCurve: "P-256",
@@ -56,10 +55,12 @@ export async function deriveSharedSecret(ecdh, publicKey, ephemeralPublicKey) {
   // the ephemeral public key is used to make
   // the scheme CCA2
   // https://www.tic.itefi.csic.es/CIBERDINE/Documetos/Cryptologia%20-%20Security%20and%20practical%20considerations%20when%20implementing%20ECIES%20-%20v1.0.pdf
-  const concatSecret = Buffer.concat([
-    Buffer.from(exportableSecret),
-    Buffer.from([0x00, 0x00, 0x00, 0x01]),
-    P256.encodePublicKey(arrayBufferToBase64(exportableEphemeralPublicKey)),
+  const concatSecret = concat([
+    new Uint8Array(exportableSecret),
+    new Uint8Array([0x00, 0x00, 0x00, 0x01]),
+    P256.encodePublicKey(
+      toString(new Uint8Array(exportableEphemeralPublicKey), "base64")
+    ),
   ]);
 
   const hashDigest = await window.crypto.subtle.digest("SHA-256", concatSecret);
@@ -67,8 +68,8 @@ export async function deriveSharedSecret(ecdh, publicKey, ephemeralPublicKey) {
 }
 
 export async function buildCageKeyFromSuppliedPublicKey(publicKey) {
-  const compressedKey = ecPointCompress(Buffer.from(publicKey, "base64"));
-  const compressedKeyString = arrayBufferToBase64(compressedKey);
+  const compressedKey = ecPointCompress(fromString(publicKey, "base64"));
+  const compressedKeyString = toString(new Uint8Array(compressedKey), "base64")
   return {
     ecdhP256KeyUncompressed: publicKey,
     ecdhP256Key: compressedKeyString,

--- a/lib/utils/crypto.js
+++ b/lib/utils/crypto.js
@@ -69,7 +69,7 @@ export async function deriveSharedSecret(ecdh, publicKey, ephemeralPublicKey) {
 
 export async function buildCageKeyFromSuppliedPublicKey(publicKey) {
   const compressedKey = ecPointCompress(fromString(publicKey, "base64"));
-  const compressedKeyString = toString(new Uint8Array(compressedKey), "base64")
+  const compressedKeyString = toString(new Uint8Array(compressedKey), "base64");
   return {
     ecdhP256KeyUncompressed: publicKey,
     ecdhP256Key: compressedKeyString,

--- a/lib/utils/crypto.js
+++ b/lib/utils/crypto.js
@@ -1,6 +1,6 @@
-import { fromString, toString, concat } from "uint8arrays";
-
 import { P256 } from "../curves";
+import concatUint8Arrays from "./concatUint8Arrays";
+import { base64StringToUint8Array, uint8ArrayToBase64String } from "./encoding";
 
 // To compress - record the sign of the `y` point
 // then remove the `y` point and encode the recorded
@@ -17,7 +17,7 @@ export async function deriveSharedSecret(ecdh, publicKey, ephemeralPublicKey) {
   // Convert to a P256 `CryptoKey` object
   const importedPublicKey = await window.crypto.subtle.importKey(
     "raw",
-    fromString(publicKey, "base64"),
+    base64StringToUint8Array(publicKey),
     {
       name: "ECDH",
       namedCurve: "P-256",
@@ -55,11 +55,11 @@ export async function deriveSharedSecret(ecdh, publicKey, ephemeralPublicKey) {
   // the ephemeral public key is used to make
   // the scheme CCA2
   // https://www.tic.itefi.csic.es/CIBERDINE/Documetos/Cryptologia%20-%20Security%20and%20practical%20considerations%20when%20implementing%20ECIES%20-%20v1.0.pdf
-  const concatSecret = concat([
+  const concatSecret = concatUint8Arrays([
     new Uint8Array(exportableSecret),
     new Uint8Array([0x00, 0x00, 0x00, 0x01]),
     P256.encodePublicKey(
-      toString(new Uint8Array(exportableEphemeralPublicKey), "base64")
+      uint8ArrayToBase64String(new Uint8Array(exportableEphemeralPublicKey))
     ),
   ]);
 
@@ -68,8 +68,10 @@ export async function deriveSharedSecret(ecdh, publicKey, ephemeralPublicKey) {
 }
 
 export async function buildCageKeyFromSuppliedPublicKey(publicKey) {
-  const compressedKey = ecPointCompress(fromString(publicKey, "base64"));
-  const compressedKeyString = toString(new Uint8Array(compressedKey), "base64");
+  const compressedKey = ecPointCompress(base64StringToUint8Array(publicKey));
+  const compressedKeyString = uint8ArrayToBase64String(
+    new Uint8Array(compressedKey)
+  );
   return {
     ecdhP256KeyUncompressed: publicKey,
     ecdhP256Key: compressedKeyString,

--- a/lib/utils/datatypes.js
+++ b/lib/utils/datatypes.js
@@ -45,23 +45,3 @@ export const utf8ToBase64URL = (str) => {
     .replace(/\//g, "_")
     .replace(/=/g, "");
 };
-
-export const arrayBufferToBase64 = (buffer) => {
-  var binary = "";
-  var bytes = new Uint8Array(buffer);
-  var len = bytes.byteLength;
-  for (var i = 0; i < len; i++) {
-    binary += String.fromCharCode(bytes[i]);
-  }
-  return window.btoa(binary);
-};
-
-export const base64ToArrayBuffer = (base64) => {
-  var binary_string = window.atob(base64);
-  var len = binary_string.length;
-  var bytes = new Uint8Array(len);
-  for (var i = 0; i < len; i++) {
-    bytes[i] = binary_string.charCodeAt(i);
-  }
-  return bytes.buffer;
-};

--- a/lib/utils/encoding.js
+++ b/lib/utils/encoding.js
@@ -1,7 +1,6 @@
-
 /**
- * 
- * @param {string} str 
+ *
+ * @param {string} str
  * @returns {Uint8Array}
  */
 export function utf8StringToUint8Array(str) {
@@ -9,10 +8,9 @@ export function utf8StringToUint8Array(str) {
   return utf8Encoder.encode(str);
 }
 
-
 /**
- * 
- * @param {Uint8Array} arr 
+ *
+ * @param {Uint8Array} arr
  * @returns {string}
  */
 export function uint8ArrayToUtf8String(arr) {
@@ -21,7 +19,7 @@ export function uint8ArrayToUtf8String(arr) {
 }
 
 /**
- * 
+ *
  * @param {string} hex
  * @returns {Uint8Array}
  */
@@ -38,7 +36,7 @@ export function hexStringToUint8Array(hex) {
 }
 
 /**
- * 
+ *
  * @param {Uint8Array} arr
  * @returns {string}
  */
@@ -49,7 +47,7 @@ export function uint8ArrayToHexString(arr) {
 }
 
 /**
- * 
+ *
  * @param {string} base64
  * @returns {Uint8Array}
  */
@@ -66,8 +64,8 @@ export function base64StringToUint8Array(base64) {
 }
 
 /**
- * 
- * @param {Uint8Array} arr 
+ *
+ * @param {Uint8Array} arr
  * @returns {string}
  */
 export function uint8ArrayToBase64String(arr) {

--- a/lib/utils/encoding.js
+++ b/lib/utils/encoding.js
@@ -1,0 +1,79 @@
+
+/**
+ * 
+ * @param {string} str 
+ * @returns {Uint8Array}
+ */
+export function utf8StringToUint8Array(str) {
+  const utf8Encoder = new TextEncoder();
+  return utf8Encoder.encode(str);
+}
+
+
+/**
+ * 
+ * @param {Uint8Array} arr 
+ * @returns {string}
+ */
+export function uint8ArrayToUtf8String(arr) {
+  const utf8Decoder = new TextDecoder();
+  return utf8Decoder.decode(arr);
+}
+
+/**
+ * 
+ * @param {string} hex
+ * @returns {Uint8Array}
+ */
+export function hexStringToUint8Array(hex) {
+  const length = hex.length / 2;
+  const result = new Uint8Array(length);
+
+  for (let i = 0; i < length; i++) {
+    const byte = parseInt(hex.substr(i * 2, 2), 16);
+    result[i] = byte;
+  }
+
+  return result;
+}
+
+/**
+ * 
+ * @param {Uint8Array} arr
+ * @returns {string}
+ */
+export function uint8ArrayToHexString(arr) {
+  return Array.from(arr)
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/**
+ * 
+ * @param {string} base64
+ * @returns {Uint8Array}
+ */
+export function base64StringToUint8Array(base64) {
+  const binaryStr = window.atob(base64);
+  const length = binaryStr.length;
+  const result = new Uint8Array(length);
+
+  for (let i = 0; i < length; i++) {
+    result[i] = binaryStr.charCodeAt(i);
+  }
+
+  return result;
+}
+
+/**
+ * 
+ * @param {Uint8Array} arr 
+ * @returns {string}
+ */
+export function uint8ArrayToBase64String(arr) {
+  const binaryStr = Array.from(arr)
+    .map((byte) => String.fromCharCode(byte))
+    .join("");
+
+  return window.btoa(binaryStr);
+}

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "web-file-polyfill": "^1.0.4"
   },
   "dependencies": {
-    "buffer": "^6.0.3",
+    "uint8arrays": "^4.0.3",
     "events": "^3.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "web-file-polyfill": "^1.0.4"
   },
   "dependencies": {
-    "uint8arrays": "^4.0.3",
     "events": "^3.3.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,14 +11,12 @@ specifiers:
   nock: ^13.3.0
   prettier: ^2.8.7
   serve-handler: ^6.1.5
-  uint8arrays: ^4.0.3
   vite: ^4.2.1
   vitest: ^0.29.7
   web-file-polyfill: ^1.0.4
 
 dependencies:
   events: 3.3.0
-  uint8arrays: 4.0.3
 
 devDependencies:
   '@evervault/sdk': 3.10.1
@@ -1270,11 +1268,6 @@ packages:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
     dev: true
 
-  /multiformats/11.0.2:
-    resolution: {integrity: sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
-    dev: false
-
   /nanoid/3.3.4:
     resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -1638,13 +1631,6 @@ packages:
   /ufo/1.1.1:
     resolution: {integrity: sha512-MvlCc4GHrmZdAllBc0iUDowff36Q9Ndw/UzqmEKyrfSzokTd9ZCy1i+IIk5hrYKkjoYVQyNbrw7/F8XJ2rEwTg==}
     dev: true
-
-  /uint8arrays/4.0.3:
-    resolution: {integrity: sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==}
-    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
-    dependencies:
-      multiformats: 11.0.2
-    dev: false
 
   /universalify/0.2.0:
     resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,20 +5,20 @@ specifiers:
   '@peculiar/webcrypto': ^1.4.3
   '@playwright/test': ^1.32.1
   '@trust/webcrypto': ^0.9.2
-  buffer: ^6.0.3
   dotenv: ^16.0.3
   events: ^3.3.0
   jsdom: ^21.1.1
   nock: ^13.3.0
   prettier: ^2.8.7
   serve-handler: ^6.1.5
+  uint8arrays: ^4.0.3
   vite: ^4.2.1
   vitest: ^0.29.7
   web-file-polyfill: ^1.0.4
 
 dependencies:
-  buffer: 6.0.3
   events: 3.3.0
+  uint8arrays: 4.0.3
 
 devDependencies:
   '@evervault/sdk': 3.10.1
@@ -597,10 +597,6 @@ packages:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
     dev: true
 
-  /base64-js/1.5.1:
-    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
-    dev: false
-
   /base64url/3.0.1:
     resolution: {integrity: sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==}
     engines: {node: '>=6.0.0'}
@@ -620,13 +616,6 @@ packages:
   /brorand/1.1.0:
     resolution: {integrity: sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==}
     dev: true
-
-  /buffer/6.0.3:
-    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
-    dev: false
 
   /bytes/3.0.0:
     resolution: {integrity: sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==}
@@ -1116,10 +1105,6 @@ packages:
       safer-buffer: 2.1.2
     dev: true
 
-  /ieee754/1.2.1:
-    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
-    dev: false
-
   /inherits/2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
     dev: true
@@ -1284,6 +1269,11 @@ packages:
   /ms/2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
     dev: true
+
+  /multiformats/11.0.2:
+    resolution: {integrity: sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg==}
+    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+    dev: false
 
   /nanoid/3.3.4:
     resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
@@ -1648,6 +1638,13 @@ packages:
   /ufo/1.1.1:
     resolution: {integrity: sha512-MvlCc4GHrmZdAllBc0iUDowff36Q9Ndw/UzqmEKyrfSzokTd9ZCy1i+IIk5hrYKkjoYVQyNbrw7/F8XJ2rEwTg==}
     dev: true
+
+  /uint8arrays/4.0.3:
+    resolution: {integrity: sha512-b+aKlI2oTnxnfeSQWV1sMacqSNxqhtXySaH6bflvONGxF8V/fT3ZlYH7z2qgGfydsvpVo4JUgM/Ylyfl2YouCg==}
+    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+    dependencies:
+      multiformats: 11.0.2
+    dev: false
 
   /universalify/0.2.0:
     resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}

--- a/test/encryption.test.js
+++ b/test/encryption.test.js
@@ -1,3 +1,5 @@
+import { Buffer } from "node:buffer";
+
 import { describe, assert, it, beforeEach, expect } from "vitest";
 
 import Evervault from "../lib/main";


### PR DESCRIPTION
# Why

Should not be relying on the node js polyfill for Buffer

# How
Replaced with the `uint8arrays` helper library as Buffer is a superclass of that anyway. The npm package `uint8arrays` is better maintained and browser compatible.