### PR TITLE
Support auto setting height of inputs frame

### DIFF
--- a/lib/core/inputs.js
+++ b/lib/core/inputs.js
@@ -10,12 +10,15 @@ export default function Inputs(config) {
         settings
       )}></iframe>`;
 
-      window.addEventListener("message", event => {
+      window.addEventListener("message", (event) => {
         if (event.origin !== config.input.inputsOrigin) return;
-        if (settings?.height === "auto" && event.data?.type === "EV_FRAME_HEIGHT") {
+        if (
+          settings?.height === "auto" &&
+          event.data?.type === "EV_FRAME_HEIGHT"
+        ) {
           document.getElementById("ev-iframe").height = event.data.height;
         }
-      })
+      });
 
       return {
         getData: () =>

--- a/lib/core/inputs.js
+++ b/lib/core/inputs.js
@@ -10,6 +10,13 @@ export default function Inputs(config) {
         settings
       )}></iframe>`;
 
+      window.addEventListener("message", event => {
+        if (event.origin !== config.input.inputsOrigin) return;
+        if (settings?.height === "auto" && event.data?.type === "EV_FRAME_HEIGHT") {
+          document.getElementById("ev-iframe").height = event.data.height;
+        }
+      })
+
       return {
         getData: () =>
           new Promise((res, rej) => {
@@ -30,6 +37,7 @@ export default function Inputs(config) {
               "message",
               (event) => {
                 if (event.origin !== config.input.inputsOrigin) return;
+                if (event.data?.type === "EV_FRAME_HEIGHT") return;
                 fn(event.data);
               },
               false


### PR DESCRIPTION
# Why

We have had a few customers recently contact us with problems around setting the iframe height. Because iframes are their own document, they unfortunately don't have a native "height: auto" property that allows it to behave as if it's part of the document it's embedded in.

We now support various styling features that alter the height of the iframe as well as conditionally showing the error message. Requiring customers to set a specific height in px to cater for this is not ideal.

# How

Support automatically handling calculation of the iframe height by listening for a message from the Inputs iframe that fires when ever there are DOM changes. See https://github.com/evervault/evervault-inputs/pull/56.

```
evervault.inputs("ev-inputs", {
    height: "auto",
});
```

https://user-images.githubusercontent.com/1512593/229089677-13eb56b4-9107-4d4e-8172-a527d4595ffd.mp4