### PR TITLE
fix: bytes are not a string

### DIFF
--- a/lib/core/crypto.js
+++ b/lib/core/crypto.js
@@ -210,7 +210,7 @@ export default function Crypto(config, isDebug) {
       compressedKey,
       keyIv,
       flags,
-      utf8StringToUint8Array(encryptedData),
+      new Uint8Array(encryptedData),
     ]);
 
     if (fileName) {


### PR DESCRIPTION
# Why
Bytes from encrypted files are not a string

# How
Treat them as bytes