### PR TITLE
[ETR-851] Rename Config to Typescript

### DIFF
--- a/.changeset/seven-carpets-know.md
+++ b/.changeset/seven-carpets-know.md
@@ -1,0 +1,5 @@
+---
+"@evervault/browser": patch
+---
+
+rename config to typescript file

--- a/packages/browser/lib/config.ts
+++ b/packages/browser/lib/config.ts
@@ -2,6 +2,9 @@ const KEYS_URL = "https://keys.evervault.com";
 const INPUTS_ORIGIN = "https://inputs.evervault.com";
 const INPUTS_URL = `${INPUTS_ORIGIN}/v2/index.html`;
 
+
+type 
+
 const DEFAULT_CONFIG_URLS = {
   keysUrl: KEYS_URL,
   inputsUrl: INPUTS_URL,
@@ -11,10 +14,10 @@ const DEFAULT_CONFIG_URLS = {
 const MAX_FILE_SIZE_IN_MB = 25;
 
 export default function Config(
-  teamId,
-  appId,
+  teamId: string,
+  appId: string,
   customUrls = DEFAULT_CONFIG_URLS,
-  publicKey
+  publicKey: string
 ) {
   return {
     teamId,

--- a/packages/browser/lib/config.ts
+++ b/packages/browser/lib/config.ts
@@ -2,38 +2,78 @@ const KEYS_URL = "https://keys.evervault.com";
 const INPUTS_ORIGIN = "https://inputs.evervault.com";
 const INPUTS_URL = `${INPUTS_ORIGIN}/v2/index.html`;
 
+
+export type EncryptionSubConfig = typeof encryptionConstants & { publicKey?: string };
+
+export type HttpConfig = {
+  keysUrl: string;
+};
+
+export type InputConfig = {
+  inputsUrl: string;
+  inputsOrigin: string;
+};
+
+export type KeyConfig = {
+  ecdhP256KeyUncompressed: string;
+  ecdhP256Key: string;
+  isDebugMode: boolean;
+};
+
+export type Config = {
+  teamId: string;
+  appId: string;
+  encryption: EncryptionSubConfig;
+  http: HttpConfig;
+  input: InputConfig;
+  debugKey: typeof debugKey;
+};
+
 const DEFAULT_CONFIG_URLS = {
   keysUrl: KEYS_URL,
   inputsUrl: INPUTS_URL,
   inputsOrigin: INPUTS_ORIGIN,
 };
 
-const MAX_FILE_SIZE_IN_MB = 25;
+const MAX_FILE_SIZE_IN_MB = 25 as const;
+
+const encryptionConstants = {
+  cipherAlgorithm: "aes-256-gcm" as const,
+  keyLength: 32 as const, // bytes
+  ivLength: 12 as const, // bytes
+  authTagLength: 128 as const, // bits
+  publicHash: "sha256" as const,
+  evVersion: "NOC" as const, // (Tk9D) NIST-P256 KDF
+  header: {
+    iss: "evervault" as const,
+    version: 1 as const,
+  },
+  maxFileSizeInMB: MAX_FILE_SIZE_IN_MB,
+  maxFileSizeInBytes: MAX_FILE_SIZE_IN_MB * 1024 * 1024,
+};
+
+const createEncryptionConfig = (publicKey?: string) => ({
+  ...encryptionConstants,
+  publicKey,
+} satisfies EncryptionSubConfig);
+
+const debugKey = {
+  ecdhP256KeyUncompressed:
+    "BF1/Mo85D7t/XvC3I+YYpJvP+OsSyxIbSrhtDhg1SClQ2xdoyGpXYrplO/f8AZ+7cGkUnMF3tzSfLC5Io8BuNyw=" as const,
+  ecdhP256Key: "Al1/Mo85D7t/XvC3I+YYpJvP+OsSyxIbSrhtDhg1SClQ" as const,
+  isDebugMode: true,
+} as const satisfies KeyConfig;
 
 export default function Config(
   teamId: string,
   appId: string,
   customUrls = DEFAULT_CONFIG_URLS,
-  publicKey: string
-) {
+  publicKey?: string
+): Config {
   return {
     teamId,
     appId,
-    encryption: {
-      cipherAlgorithm: "aes-256-gcm",
-      keyLength: 32, // bytes
-      ivLength: 12, // bytes
-      authTagLength: 128, // bits
-      publicHash: "sha256",
-      evVersion: "NOC", // (Tk9D) NIST-P256 KDF
-      header: {
-        iss: "evervault",
-        version: 1,
-      },
-      publicKey, // optional: include the uncompressed public key to allow offline use of the SDK (no call to keys.evervault.com)
-      maxFileSizeInMB: MAX_FILE_SIZE_IN_MB,
-      maxFileSizeInBytes: MAX_FILE_SIZE_IN_MB * 1024 * 1024,
-    },
+    encryption: createEncryptionConfig(publicKey),
     http: {
       keysUrl: customUrls.keysUrl || DEFAULT_CONFIG_URLS.keysUrl,
     },
@@ -41,11 +81,6 @@ export default function Config(
       inputsUrl: customUrls.inputsUrl || DEFAULT_CONFIG_URLS.inputsUrl,
       inputsOrigin: customUrls.inputsOrigin || DEFAULT_CONFIG_URLS.inputsOrigin,
     },
-    debugKey: {
-      ecdhP256KeyUncompressed:
-        "BF1/Mo85D7t/XvC3I+YYpJvP+OsSyxIbSrhtDhg1SClQ2xdoyGpXYrplO/f8AZ+7cGkUnMF3tzSfLC5Io8BuNyw=",
-      ecdhP256Key: "Al1/Mo85D7t/XvC3I+YYpJvP+OsSyxIbSrhtDhg1SClQ",
-      isDebugMode: true,
-    },
+    debugKey,
   };
 }

--- a/packages/browser/lib/config.ts
+++ b/packages/browser/lib/config.ts
@@ -2,9 +2,6 @@ const KEYS_URL = "https://keys.evervault.com";
 const INPUTS_ORIGIN = "https://inputs.evervault.com";
 const INPUTS_URL = `${INPUTS_ORIGIN}/v2/index.html`;
 
-
-type 
-
 const DEFAULT_CONFIG_URLS = {
   keysUrl: KEYS_URL,
   inputsUrl: INPUTS_URL,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,7 +30,7 @@
     /* Modules */
     "module": "esnext",                                  /* Specify what module code is generated. */
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    "moduleResolution": "nodenext",                      /* Specify how TypeScript looks up a file from a given module specifier. */
+    "moduleResolution": "bundler",                      /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
@@ -47,7 +47,7 @@
     // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
 
     /* JavaScript Support */
-    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+    "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
     // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
     // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
 


### PR DESCRIPTION
# Why
Typing the config file seems like a good idea.

# How
Rename config.js to config.ts and give the functions type annotations. That's it.

