### PR TITLE
Use the correct names for secrets in Github Actions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -37,8 +37,8 @@ jobs:
       secrets:
         aws-access-key-id: ${{ secrets.PUBLIC_REPO_AWS_ACCESS_KEY_ID_STAGING }}
         aws-secret-access-key: ${{ secrets.PUBLIC_REPO_AWS_SECRET_ACCESS_KEY_STAGING }}
-        aws-s3-bucket: ${{ secrets.INPUTS_SDK_S3_BUCKET }}
-        aws-cloudfront-distribution-id: ${{ secrets.INPUTS_SDK_CLOUDFRONT_DISTRIBUTION_ID }}
+        aws-s3-bucket: ${{ secrets.INPUTS_S3_BUCKET }}
+        aws-cloudfront-distribution-id: ${{ secrets.INPUTS_CLOUDFRONT_DISTRIBUTION_ID }}
   
   release:
     name: Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,6 @@ jobs:
     secrets:
       aws-access-key-id: ${{ secrets.PUBLIC_REPO_AWS_ACCESS_KEY_ID }}
       aws-secret-access-key: ${{ secrets.PUBLIC_REPO_AWS_SECRET_ACCESS_KEY }}
-      aws-s3-bucket: ${{ secrets.INPUTS_SDK_S3_BUCKET }}
-      aws-cloudfront-distribution-id: ${{ secrets.INPUTS_SDK_CLOUDFRONT_DISTRIBUTION_ID }}
+      aws-s3-bucket: ${{ secrets.INPUTS_S3_BUCKET }}
+      aws-cloudfront-distribution-id: ${{ secrets.INPUTS_CLOUDFRONT_DISTRIBUTION_ID }}
     


### PR DESCRIPTION
# Why
Inputs not working because the workflows use the wrong names for some secrets

# How
Use the correct names
