### PR TITLE
Reenable CI for Inputs

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -28,17 +28,17 @@ jobs:
       aws-secret-access-key: ${{ secrets.PUBLIC_REPO_AWS_SECRET_ACCESS_KEY_STAGING }}
       aws-s3-bucket: ${{ secrets.BROWSER_SDK_S3_BUCKET }}
       aws-cloudfront-distribution-id: ${{ secrets.BROWSER_SDK_CLOUDFRONT_DISTRIBUTION_ID }}
-  # deploy-inputs:
-  #     needs: build
-  #     uses: ./.github/workflows/aws-generic-deploy-inputs.yml
-  #     with:
-  #       environment: "staging"
-  #       name: "Deploy to Staging"
-  #     secrets:
-  #       aws-access-key-id: ${{ secrets.PUBLIC_REPO_AWS_ACCESS_KEY_ID_STAGING }}
-  #       aws-secret-access-key: ${{ secrets.PUBLIC_REPO_AWS_SECRET_ACCESS_KEY_STAGING }}
-  #       aws-s3-bucket: ${{ secrets.INPUTS_S3_BUCKET }}
-  #       aws-cloudfront-distribution-id: ${{ secrets.INPUTS_CLOUDFRONT_DISTRIBUTION_ID }}
+  deploy-inputs:
+      needs: build
+      uses: ./.github/workflows/aws-generic-deploy-inputs.yml
+      with:
+        environment: "staging"
+        name: "Deploy to Staging"
+      secrets:
+        aws-access-key-id: ${{ secrets.PUBLIC_REPO_AWS_ACCESS_KEY_ID_STAGING }}
+        aws-secret-access-key: ${{ secrets.PUBLIC_REPO_AWS_SECRET_ACCESS_KEY_STAGING }}
+        aws-s3-bucket: ${{ secrets.INPUTS_S3_BUCKET }}
+        aws-cloudfront-distribution-id: ${{ secrets.INPUTS_CLOUDFRONT_DISTRIBUTION_ID }}
   
   release:
     name: Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,16 +27,16 @@ jobs:
       aws-secret-access-key: ${{ secrets.PUBLIC_REPO_AWS_SECRET_ACCESS_KEY }}
       aws-s3-bucket: ${{ secrets.BROWSER_SDK_S3_BUCKET }}
       aws-cloudfront-distribution-id: ${{ secrets.BROWSER_SDK_CLOUDFRONT_DISTRIBUTION_ID }}
-  # deploy-inputs:
-  #   if: contains( github.event.release.tag_name, 'inputs')
-  #   needs: build
-  #   uses: ./.github/workflows/aws-generic-deploy-inputs.yml
-  #   with:
-  #     environment: "production"
-  #     name: "Deploy to Production"
-  #   secrets:
-  #     aws-access-key-id: ${{ secrets.PUBLIC_REPO_AWS_ACCESS_KEY_ID }}
-  #     aws-secret-access-key: ${{ secrets.PUBLIC_REPO_AWS_SECRET_ACCESS_KEY }}
-  #     aws-s3-bucket: ${{ secrets.INPUTS_S3_BUCKET }}
-  #     aws-cloudfront-distribution-id: ${{ secrets.INPUTS_CLOUDFRONT_DISTRIBUTION_ID }}
+  deploy-inputs:
+    if: contains( github.event.release.tag_name, 'inputs')
+    needs: build
+    uses: ./.github/workflows/aws-generic-deploy-inputs.yml
+    with:
+      environment: "production"
+      name: "Deploy to Production"
+    secrets:
+      aws-access-key-id: ${{ secrets.PUBLIC_REPO_AWS_ACCESS_KEY_ID }}
+      aws-secret-access-key: ${{ secrets.PUBLIC_REPO_AWS_SECRET_ACCESS_KEY }}
+      aws-s3-bucket: ${{ secrets.INPUTS_S3_BUCKET }}
+      aws-cloudfront-distribution-id: ${{ secrets.INPUTS_CLOUDFRONT_DISTRIBUTION_ID }}
     


### PR DESCRIPTION
# Why
Disabled the deployment CI for the inputs package until https://github.com/evervault/evervault-inputs is archived

# How
Reenable the deployment steps for CI once the old repo is archived.

