### PR TITLE
[ETR-882] Convert Inputs Module to Typescript

### DIFF
--- a/.changeset/wet-items-occur.md
+++ b/.changeset/wet-items-occur.md
@@ -1,0 +1,5 @@
+---
+"@evervault/browser": patch
+---
+
+change inputs module to typescript

--- a/packages/browser/lib/core/inputs.ts
+++ b/packages/browser/lib/core/inputs.ts
@@ -1,10 +1,16 @@
+import type { Config } from "../config";
+
 import { constructSource, calculateHeight } from "../utils";
 
-export default function Inputs(config) {
+export default function Inputs(config: Config) {
   return {
-    generate: function (id, settings) {
-      document.getElementById(id).innerHTML = `<iframe src="${constructSource(
+    generate: function (id: string, settings: Record<string, any>) {
+      // TODO: add error check in a seperate pr (small behavour change)
+      (
+        document.getElementById(id) as HTMLIFrameElement
+      ).innerHTML = `<iframe src="${constructSource(
         config,
+        // TODO: better typings for this (will affect user facing typings)
         settings
       )}" id="ev-iframe" title="Payment details" frameborder="0" scrolling="0" height=${calculateHeight(
         settings
@@ -16,18 +22,18 @@ export default function Inputs(config) {
           settings?.height === "auto" &&
           event.data?.type === "EV_FRAME_HEIGHT"
         ) {
-          document.getElementById("ev-iframe").height = event.data.height;
+          (document.getElementById(id) as HTMLIFrameElement).height =
+            event.data.height;
         }
       });
 
-      /**
-       * @type {Promise<boolean>}
-       */
-      const isInputsLoaded = new Promise((resolve) => {
+      const isInputsLoaded = new Promise<boolean>((resolve) => {
         const elem = document.getElementById("ev-iframe");
 
         if (elem instanceof HTMLIFrameElement) {
-          const doc = elem.contentDocument ?? elem.contentWindow.document;
+          // TODO: needs another error check
+          const doc = (elem.contentDocument ??
+            elem.contentWindow?.document) as Document;
 
           if (doc.readyState === "complete") {
             resolve(true);
@@ -53,11 +59,11 @@ export default function Inputs(config) {
               return res(data);
             };
 
-            document
-              .getElementById("ev-iframe")
-              .contentWindow.postMessage("message", "*", [channel.port2]);
+            (
+              document.getElementById("ev-iframe") as HTMLIFrameElement
+            ).contentWindow?.postMessage("message", "*", [channel.port2]);
           }),
-        on: (event, fn) => {
+        on: (event: "change" | unknown, fn: (data: any) => void) => {
           if (event === "change") {
             window.addEventListener(
               "message",
@@ -71,11 +77,11 @@ export default function Inputs(config) {
             );
           }
         },
-        setLabels: (labels) => {
+        setLabels: (labels: Record<string, any>) => {
           const channel = new MessageChannel();
-          document
-            .getElementById("ev-iframe")
-            .contentWindow.postMessage(labels, "*", [channel.port2]);
+          (
+            document.getElementById("ev-iframe") as HTMLIFrameElement
+          ).contentWindow?.postMessage(labels, "*", [channel.port2]);
         },
       };
     },


### PR DESCRIPTION
# Why
types

# How
Rename inputs from `.js` to `.ts`. Note that the file still requires stricter null checking for more graceful errors, but that is a bit of a behavior change for a minor version.