### PR TITLE
[ETR-883] Deprecate Forms module

### DIFF
--- a/.changeset/famous-pumpkins-applaud.md
+++ b/.changeset/famous-pumpkins-applaud.md
@@ -1,0 +1,5 @@
+---
+"@evervault/browser": patch
+---
+
+deprecate forms module

--- a/packages/browser/lib/core/forms.js
+++ b/packages/browser/lib/core/forms.js
@@ -1,5 +1,9 @@
 import { EventEmitter } from "events";
 
+/** 
+ * @deprecated Forms is no longer a supported Evervault product and this feature will be removed in a future version 
+ * @param {Evervault} evervault
+ * */
 function Forms(evervault) {
   const formEmitter = new EventEmitter();
   return {
@@ -49,6 +53,14 @@ function Forms(evervault) {
       const forms = document.querySelectorAll("[data-evervault-form]");
 
       let form = undefined;
+
+      if(forms.length != 0) {
+        // Dear lord, there actually using forms
+        // This should not fire at all, but if it does, Customers should be advised to uses Inputs, Relay or the SDK encrypt function
+        // This notice is put in by Ciaran.
+        console.error("Evervault Forms is no longer a supported Evervault product. This feature is not to beused in production code and will be removed in a future version. Please contact Evervault support if you see this message.");
+      };
+
       for (let i = 0; i < forms.length; i++) {
         form = forms[i];
         let prevOnSubmit = form.onsubmit;


### PR DESCRIPTION
# Why
Nobody should be using Forms now
Nobody.

But someone might be using it anyway, I don't know.

# How
- Add the `@deperecatated` tag to the module
- JSDoc typings: gave up and used any
- Added a console.error call if the register function actually finds a form element that it hooks into it. If a customer is using forms, we wanna know.

Actually deleting this function will require a v3.