### PR TITLE
[ETR-889] Sanitize Font URL

### DIFF
--- a/.changeset/silly-hairs-smile.md
+++ b/.changeset/silly-hairs-smile.md
@@ -1,0 +1,5 @@
+---
+"@evervault/inputs": minor
+---
+
+sanitize fontUrl

--- a/packages/inputs/src/index.js
+++ b/packages/inputs/src/index.js
@@ -1,6 +1,5 @@
 import customStylesHandler from "./customStylesHandler";
 import "./styles.css";
-import { swipeCapture } from "./MagStripe";
 import {
   setInputLabels,
   updateInputLabels,
@@ -43,6 +42,40 @@ function insertLinkTag(id, rel, href, options = {}) {
 }
 
 if (fontUrl) {
+  try {
+    const parsedFontUrl = new URL(fontUrl);
+
+    // Only allow fonts from fonts.googleapis.com
+    if (parsedFontUrl.hostname !== "fonts.googleapis.com") {
+      console.log(
+        "Invalid fontUrl. Please use a fontUrl from fonts.googleapis.com"
+      );
+    } else {
+      // Avoid CSRF or Clickjacking attacks by reconstructing the URL
+      const reconstructedGoogleFontUrl = new URL(parsedFontUrl.pathname, "https://fonts.googleapis.com");
+      reconstructedGoogleFontUrl.params = parsedFontUrl.params;
+      
+      insertLinkTag(
+        "font-preconnect",
+        "preconnect",
+        "https://fonts.googleapis.com"
+      );
+
+      insertLinkTag(
+        "font-preconnect-cors",
+        "preconnect",
+        "https://fonts.gstatic.com",
+        { crossOrigin: "" }
+      );
+
+      insertLinkTag("font-url", "stylesheet", reconstructedGoogleFontUrl.toString(), {
+        type: "text/css",
+        media: "all",
+      });
+    }
+  } catch(e) {
+  }
+}
   insertLinkTag(
     "font-preconnect",
     "preconnect",

--- a/packages/inputs/src/index.js
+++ b/packages/inputs/src/index.js
@@ -47,14 +47,12 @@ if (fontUrl) {
 
     // Only allow fonts from fonts.googleapis.com
     if (parsedFontUrl.hostname !== "fonts.googleapis.com") {
-      console.log(
-        "Invalid fontUrl. Please use a fontUrl from fonts.googleapis.com"
-      );
+      throw new Error("Invalid fontUrl. Please use a fontUrl from fonts.googleapis.com")
     } else {
       // Avoid CSRF or Clickjacking attacks by reconstructing the URL
       const reconstructedGoogleFontUrl = new URL(parsedFontUrl.pathname, "https://fonts.googleapis.com");
       reconstructedGoogleFontUrl.params = parsedFontUrl.params;
-      
+
       insertLinkTag(
         "font-preconnect",
         "preconnect",
@@ -74,6 +72,8 @@ if (fontUrl) {
       });
     }
   } catch(e) {
+    console.error(e);
+    console.error("The above error means that your custom font's have not been set.")
   }
 }
   insertLinkTag(

--- a/packages/inputs/src/index.js
+++ b/packages/inputs/src/index.js
@@ -76,24 +76,6 @@ if (fontUrl) {
     console.error("The above error means that your custom font's have not been set.")
   }
 }
-  insertLinkTag(
-    "font-preconnect",
-    "preconnect",
-    "https://fonts.googleapis.com"
-  );
-
-  insertLinkTag(
-    "font-preconnect-cors",
-    "preconnect",
-    "https://fonts.gstatic.com",
-    { crossOrigin: "" }
-  );
-
-  insertLinkTag("font-url", "stylesheet", fontUrl, {
-    type: "text/css",
-    media: "all",
-  });
-}
 
 // Custom Styles
 customStylesHandler(urlParams);


### PR DESCRIPTION
# Why
CodeQL is informing us of a potential CSRF/Redirect vulnerability via the `fontUrl` property. 


# How
Sanitize and reconstruct the `fontURL` so it can only point to Google Fonts, and log an error if the `fontUrl` is not a valid Google Fonts endpoint. This is close to a breaking change, but we have only ever promised that Google Font's will work with our custom fonts feature. Failure will simply mean that the font url is not inserted.

