### PR TITLE
fix: inputs upload

### DIFF
--- a/.github/workflows/aws-generic-deploy-inputs.yml
+++ b/.github/workflows/aws-generic-deploy-inputs.yml
@@ -4,29 +4,29 @@ on:
   workflow_call:
     inputs:
       environment:
-        description: 'Environment to deploy to'
+        description: "Environment to deploy to"
         required: true
         type: string
       name:
-        description: 'Name of the job'
+        description: "Name of the job"
         required: true
         type: string
       version:
-        description: 'Version path to deploy inputs to'
+        description: "Version path to deploy inputs to"
         required: true
         type: string
     secrets:
       aws-access-key-id:
-        description: 'AWS Access Key ID'
+        description: "AWS Access Key ID"
         required: true
       aws-secret-access-key:
-        description: 'AWS Secret Access Key'
+        description: "AWS Secret Access Key"
         required: true
       aws-s3-bucket:
-        description: 'AWS S3 Bucket'
+        description: "AWS S3 Bucket"
         required: true
       aws-cloudfront-distribution-id:
-        description: 'AWS Cloudfront Distribution ID'
+        description: "AWS Cloudfront Distribution ID"
         required: true
 
 jobs:
@@ -41,7 +41,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.aws-access-key-id }}
           aws-secret-access-key: ${{ secrets.aws-secret-access-key }}
-          aws-region: 'us-east-1'
+          aws-region: "us-east-1"
 
       - name: Download Build Artifacts
         uses: actions/download-artifact@v3
@@ -51,8 +51,7 @@ jobs:
 
       - name: S3 Deploy
         run: |
-          aws s3 rm s3://${{ secrets.aws-s3-bucket }}/${{ inputs.version }}/assets --recursive |
-          aws s3 cp ./dist s3://${{ secrets.aws-s3-bucket }}/${{ inputs.version }}/ --recursive
+          aws s3 rm s3://${{ secrets.aws-s3-bucket }}/${{ inputs.version }}/assets --recursive && aws s3 cp ./dist s3://${{ secrets.aws-s3-bucket }}/${{ inputs.version }}/ --recursive
 
       - name: Cloudfront Cache Invalidation
         run: |


### PR DESCRIPTION
# Why
Inputs deploy command was wierd

# How
Replace pipe operator with `&&`