### PR TITLE
Update lockfile when versioning

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -65,5 +65,7 @@ jobs:
 
       - name: Create Release Pull Request
         uses: changesets/action@v1
+        with:
+          version: pnpm version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -66,6 +66,6 @@ jobs:
       - name: Create Release Pull Request
         uses: changesets/action@v1
         with:
-          version: pnpm version
+          version: pnpm run version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "typecheck": "turbo run typecheck",
     "e2e:test": "dotenv -- turbo run e2e:test",
     "e2e:test:browser": "dotenv -- turbo run e2e:test --filter=browser",
-    "ci:prune:browser": "turbo prune --scope=\"browser\" --docker"
+    "ci:prune:browser": "turbo prune --scope=\"browser\" --docker",
+    "version": "changeset version && pnpm install"
   },
   "devDependencies": {
     "@changesets/cli": "^2.26.1",


### PR DESCRIPTION
# Why
Version action is not updating `pnpm-lock`

# How
Make a custom version script to run `pnpm install` alongside the version command.