### PR TITLE
fix: fix onload event in firefox

### DIFF
--- a/.changeset/olive-foxes-tickle.md
+++ b/.changeset/olive-foxes-tickle.md
@@ -1,0 +1,5 @@
+---
+"@evervault/inputs": patch
+---
+
+fixed onload behaviour in firefox

--- a/packages/inputs/src/index.js
+++ b/packages/inputs/src/index.js
@@ -233,7 +233,7 @@ function setFrameHeight() {
   parent.postMessage({ type: "EV_FRAME_HEIGHT", height: scrollHeight }, "*");
 }
 
-window.onload = function () {
+const onLoad = function () {
   watchSDKStatus();
   inputElementsManager = new InputElementsManager(postToParent, formOverrides);
   const magStripe = new MagStripe(inputElementsManager);
@@ -255,3 +255,5 @@ window.onload = function () {
 
   document.addEventListener("keypress", magStripe.swipeCapture, true);
 };
+
+window.addEventListener('load', onLoad);


### PR DESCRIPTION
# Why
Firefox does not support `window.onload`

# How
Using window.addEventListener instead