### PR TITLE
Use primary-color instead of label color when focused for material theme

### DIFF
--- a/.changeset/stupid-insects-occur.md
+++ b/.changeset/stupid-insects-occur.md
@@ -1,0 +1,5 @@
+---
+"@evervault/inputs": minor
+---
+
+Use primary color for focused input labels in material theme

--- a/packages/inputs/src/styles.css
+++ b/packages/inputs/src/styles.css
@@ -223,7 +223,7 @@ textarea {
 
   & .input-group:focus-within .absoluteLabel {
     transform: translateY(-100%) scale(0.8);
-    color: var(--label-color);
+    color: var(--color-primary);
   }
 
   & .input-group input:not(:placeholder-shown) + label {


### PR DESCRIPTION
# Why

Requested by Stitch.

[Slack thread](https://evervault.slack.com/archives/C04BTBHRYCV/p1685443320523839)

# How
Use primary color for label when the input is focused.
