### PR TITLE
Automate Deployments and releases

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -64,8 +64,14 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Create Release Pull Request
+        id: changesets
         uses: changesets/action@v1
         with:
           version: pnpm run version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create Tags
+        if: steps.changesets.outputs.hasChangesets == 'false'
+        run: |
+          npx changeset tag && git push origin --tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,9 @@
 
 name: Main Release Workflow
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - "@evervault/*"
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -18,7 +19,7 @@ jobs:
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   deploy-js:
-    if: contains( github.event.release.tag_name, 'browser')
+    if: contains( github.ref, 'refs/tags/@evervault/browser')
     needs: build
     uses: ./.github/workflows/aws-generic-deploy-browser.yml
     with:
@@ -31,7 +32,7 @@ jobs:
       aws-s3-bucket: ${{ secrets.BROWSER_SDK_S3_BUCKET }}
       aws-cloudfront-distribution-id: ${{ secrets.BROWSER_SDK_CLOUDFRONT_DISTRIBUTION_ID }}
   deploy-inputs:
-    if: contains( github.event.release.tag_name, 'inputs')
+    if: contains( github.ref, 'refs/tags/@evervault/inputs')
     needs: build
     uses: ./.github/workflows/aws-generic-deploy-inputs.yml
     with:
@@ -43,4 +44,8 @@ jobs:
       aws-secret-access-key: ${{ secrets.PUBLIC_REPO_AWS_SECRET_ACCESS_KEY }}
       aws-s3-bucket: ${{ secrets.INPUTS_S3_BUCKET }}
       aws-cloudfront-distribution-id: ${{ secrets.INPUTS_CLOUDFRONT_DISTRIBUTION_ID }}
+  release:
+    needs: build
+    name: Release
+    uses: softprops/action-gh-release@v1
     

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,4 +48,6 @@ jobs:
     needs: build
     name: Release
     uses: softprops/action-gh-release@v1
+    with:
+      generate_release_notes: true
     

--- a/README.md
+++ b/README.md
@@ -93,15 +93,7 @@ We use [changsets](https://github.com/changesets/changesets) to version manage t
 
 When creating a pr that needs to be rolled into a version release, do `npx changeset`, select the level of the version bump required and describe the changes for the change logs. DO NOT select `major` for releasing breaking changes without team approval.
 
-To release:
-- Merge the version PR that the changeset bot created to bump the version numbers.
-- On local machine, `git checkout master`
-- `git pull`
-- `npx changeset tag`, which will create git tags for each package and version needed
-- Push the tag to base the release on to needed with `git push origin <TAG_NAME>`
-- Create a GitHub release with either the UI or the local CLI: `gh release create`
-
-The production deployment action will deploy code to the production environment on release publish.
+To release, merge the version PR that the changeset bot created to bump the version numbers. This will bump the versions of the packages, deploy them to AWS and/or publish to NPM, and create a new release on GitHub.
 
 ## Environments
 


### PR DESCRIPTION
# Why
Production releases are currently a somewhat manual process, requiring multiple commands per release per package(!). It's been reasonably well documented in the readme, but I'm now confident enough that we can automate it reasonably efficiently.

# How
- GH releases now created alongside deployments/publishing
- Workflow is triggered when tags created by changeset are created
- Pull request merges of new version create and push changeset tags

This should all mean that merging the "Version packages" PR created by `changesets/action` is all that's needed to release to production.