### PR TITLE
Release YML fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,9 @@ jobs:
   release:
     needs: build
     name: Release
-    uses: softprops/action-gh-release@v1
-    with:
-      generate_release_notes: true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: softprops/action-gh-release@v0.1.15
+        with:
+          generate_release_notes: true
     


### PR DESCRIPTION
# Why
Release workflow has incorrect syntax

# How
Put the `action-gh-release` action in a job step rather then a job, so it knows it's an action and not a reusable workflow (Thanks, Github!)

