### PR TITLE
Rework Build Order

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
 
+      - name: Build
+        run: pnpm build
+
       - name: Unit test
         run: pnpm test
 
@@ -58,9 +61,6 @@ jobs:
 
       - name: Typescript check
         run: pnpm run typecheck
-
-      - name: Build
-        run: pnpm build
 
       - name: E2E test
         run: pnpm run e2e:test


### PR DESCRIPTION
# Why
Build and test workflow doens't always work since build happens after tests and format checks

# How
Move build up the order after install, before test, format and typecheck

