### PR TITLE
Change PostCSS config from .mts to .js

### DIFF
--- a/.changeset/rotten-badgers-reply.md
+++ b/.changeset/rotten-badgers-reply.md
@@ -1,0 +1,5 @@
+---
+"@evervault/inputs": patch
+---
+
+Use .js extension for PostCSS config

--- a/packages/inputs/.prettierignore
+++ b/packages/inputs/.prettierignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/packages/inputs/postcss.config.js
+++ b/packages/inputs/postcss.config.js
@@ -1,5 +1,4 @@
-import type { Config } from "postcss-load-config";
-import postcssPresetEnv from "postcss-preset-env";
+const postcssPresetEnv = require("postcss-preset-env");
 
 const config = {
   plugins: [
@@ -9,6 +8,6 @@ const config = {
       features: { "nesting-rules": true },
     }),
   ],
-} satisfies Config;
+};
 
-export default config;
+module.exports = config;


### PR DESCRIPTION
# Why
PostCSS wasn't detecting the `postcss.config.mts` file. I'm not sure if it supports `mts` extension.

# How
Change it to a `.js` file.

This also includes a `.prettierignore` file for inputs to ignore formatting/checking formatting for compiled files in the `dist` dir.
