### PR TITLE
BIN number should be 8 if not amex

### DIFF
--- a/.changeset/angry-toys-listen.md
+++ b/.changeset/angry-toys-listen.md
@@ -1,0 +1,5 @@
+---
+"@evervault/inputs": minor
+---
+
+Card number BIN will now return 8 characters instead of 6 for any card that is not AMEX

--- a/.changeset/angry-toys-listen.md
+++ b/.changeset/angry-toys-listen.md
@@ -2,4 +2,4 @@
 "@evervault/inputs": minor
 ---
 
-Card number BIN will now return 8 characters instead of 6 for any card that is not AMEX
+Bugfix: Card number BIN will now return 8 characters instead of 6 for any card that is not AMEX

--- a/e2e-tests/inputs/tests/events.spec.js
+++ b/e2e-tests/inputs/tests/events.spec.js
@@ -40,6 +40,7 @@ test.describe("evervault inputs", () => {
       expect(data.encryptedCard.lastFour).toMatch(
         CardLib.validCardNumber.slice(-4)
       );
+      expect(data.encryptedCard.bin).toMatch(CardLib.validAmexCard.slice(0, 8));
       expect(data.encryptedCard.expMonth).toMatch(
         CardLib.validExpirationData.split("/")[0]
       );
@@ -80,6 +81,7 @@ test.describe("evervault inputs", () => {
       expect(data.encryptedCard.lastFour).toMatch(
         CardLib.validAmexCard.slice(-4)
       );
+      expect(data.encryptedCard.bin).toMatch(CardLib.validAmexCard.slice(0, 6));
       expect(data.encryptedCard.expMonth).toMatch(
         CardLib.validExpirationData.split("/")[0]
       );

--- a/e2e-tests/inputs/tests/events.spec.js
+++ b/e2e-tests/inputs/tests/events.spec.js
@@ -40,7 +40,7 @@ test.describe("evervault inputs", () => {
       expect(data.encryptedCard.lastFour).toMatch(
         CardLib.validCardNumber.slice(-4)
       );
-      expect(data.encryptedCard.bin).toMatch(CardLib.validAmexCard.slice(0, 8));
+      expect(data.encryptedCard.bin).toMatch(CardLib.validCardNumber.slice(0, 8));
       expect(data.encryptedCard.expMonth).toMatch(
         CardLib.validExpirationData.split("/")[0]
       );

--- a/packages/inputs/src/index.ts
+++ b/packages/inputs/src/index.ts
@@ -194,14 +194,13 @@ const getData = async () => {
   };
 
   const isEmpty = cardIsEmpty(card);
-
   const encryptedCard = {
     ...(await encryptSensitiveCardDetails(card)),
     lastFour: evCard.cardNumberVerification.isValid
       ? cardNumberValue.substr(cardNumberValue.length - 4)
       : "",
     bin: evCard.cardNumberVerification.isValid
-      ? binNumber(cardNumberValue, evCard.cardNumberVerification.card.type)
+      ? binNumber(cardNumberValue, evCard.cardNumberVerification?.card?.type)
       : "",
   };
 
@@ -217,12 +216,15 @@ const getData = async () => {
 };
 
 // Formatting of BIN taken from https://www.pcisecuritystandards.org/faq/articles/Frequently_Asked_Question/What-are-acceptable-formats-for-truncation-of-primary-account-numbers/
-function binNumber(cardNumber: string, cardType: string) {
-  if (cardType === "amex") {
-    return cardNumber.substring(0, 6);
-  } else {
-    return cardNumber.substring(0, 8);
+function binNumber(cardNumber: string, cardType: string | undefined) {
+  if (cardType) {
+    if (cardType === "amex") {
+      return cardNumber.substring(0, 6);
+    } else {
+      return cardNumber.substring(0, 8);
+    }
   }
+  return "";
 }
 
 async function encryptSensitiveCardDetails(card: {

--- a/packages/inputs/src/index.ts
+++ b/packages/inputs/src/index.ts
@@ -201,7 +201,7 @@ const getData = async () => {
       ? cardNumberValue.substr(cardNumberValue.length - 4)
       : "",
     bin: evCard.cardNumberVerification.isValid
-      ? cardNumberValue.substr(0, 6)
+      ? binNumber(cardNumberValue, evCard.cardNumberVerification.card.type)
       : "",
   };
 
@@ -215,6 +215,15 @@ const getData = async () => {
     error,
   };
 };
+
+// Formatting of BIN taken from https://www.pcisecuritystandards.org/faq/articles/Frequently_Asked_Question/What-are-acceptable-formats-for-truncation-of-primary-account-numbers/
+function binNumber(cardNumber: string, cardType: string) {
+  if (cardType === "amex") {
+    return cardNumber.substring(0, 6);
+  } else {
+    return cardNumber.substring(0, 8);
+  }
+}
 
 async function encryptSensitiveCardDetails(card: {
   number: string;


### PR DESCRIPTION
# Why
8 number BIN's are allowed by all card providers expect Amex

# How
- Update BIN extractor to use 8 number BIN if not Amex
