### PR TITLE
[hotfix] Prevent short lag where users were seeing the uncustomised form

### DIFF
--- a/.changeset/slow-eggs-fly.md
+++ b/.changeset/slow-eggs-fly.md
@@ -1,0 +1,5 @@
+---
+"@evervault/inputs": patch
+---
+
+The form was rendered before customisations were applied to it. This caused a short lag where users were seeing the uncustomised form on some browsers.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The build artifacts will be under `dist` in each package.
 
 ## Testing
 
-`pnpm test` will run all unite tests in the repo.
+`pnpm test` will run all unit tests in the repo.
 
 `pnpm e2e:test` will run all Playwright e2e tests in the repo.
 

--- a/packages/inputs/index.html
+++ b/packages/inputs/index.html
@@ -11,7 +11,7 @@
     <script type="module" src="/src/index.ts"></script>
   </head>
   <body>
-    <form class="form" id="form">
+    <form class="form hide" id="form">
       <input type="hidden" id="trackdata" />
       <input type="hidden" id="trackone" />
       <input type="hidden" id="tracktwo" />

--- a/packages/inputs/src/index.ts
+++ b/packages/inputs/src/index.ts
@@ -125,6 +125,9 @@ if (formOverrides.disableCVV) {
   evCard = new EvervaultCard(DEFAULT_CARD_CONFIG);
 }
 
+// Unhide form when all customisations are applied to avoid lag
+document.getElementById("form")?.classList.remove("hide");
+
 const postToParent = async () => {
   window.parent.postMessage(await getData(), "*");
 };

--- a/packages/inputs/src/index.ts
+++ b/packages/inputs/src/index.ts
@@ -125,7 +125,7 @@ if (formOverrides.disableCVV) {
   evCard = new EvervaultCard(DEFAULT_CARD_CONFIG);
 }
 
-// Unhide form when all customisations are applied to avoid lag
+// Unhide form when all customisations are applied in order to avoid a flash of unstyled content
 document.getElementById("form")?.classList.remove("hide");
 
 const postToParent = async () => {


### PR DESCRIPTION
# Why
On some browsers, users are seeing the uncustomised form for a short moment before customisations are applied to it.

# How
This PR introduces a change where the card form is hidden by default, then unhidden once all customisations have been applied to it.
