### PR TITLE
Invalidate assets in cloudfront when a new 

### DIFF
--- a/.github/workflows/aws-generic-deploy-inputs.yml
+++ b/.github/workflows/aws-generic-deploy-inputs.yml
@@ -55,4 +55,4 @@ jobs:
 
       - name: Cloudfront Cache Invalidation
         run: |
-          aws cloudfront create-invalidation --distribution-id ${{ secrets.aws-cloudfront-distribution-id }} --paths "/index.html" "/bundle.js" "/v2/index.html"
+          aws cloudfront create-invalidation --distribution-id ${{ secrets.aws-cloudfront-distribution-id }} --paths "/index.html" "/bundle.js" "/v2/*"


### PR DESCRIPTION
# Why
Inputs assets are not properly invalidated with CloudFront when a new version of inputs is deployed.

# How
Invalidate the entirety of /v2
