### PR TITLE
Fix: Correct check for inputs context in browser SDK

### DIFF
--- a/.changeset/cyan-goats-battle.md
+++ b/.changeset/cyan-goats-battle.md
@@ -1,0 +1,5 @@
+---
+"@evervault/browser": patch
+---
+
+Update context resolution for browser SDK - compare window origin against inputs url.

--- a/packages/browser/lib/config.ts
+++ b/packages/browser/lib/config.ts
@@ -39,6 +39,8 @@ export type Config = {
   debugKey: typeof debugKey;
 };
 
+export type SdkContext = "inputs" | "default";
+
 const DEFAULT_CONFIG_URLS = {
   keysUrl: KEYS_URL,
   inputsUrl: INPUTS_URL,

--- a/packages/browser/lib/core/http.ts
+++ b/packages/browser/lib/core/http.ts
@@ -1,4 +1,4 @@
-import type { HttpConfig } from "../config";
+import type { HttpConfig, SdkContext } from "../config";
 
 import { errors } from "../utils";
 
@@ -6,7 +6,7 @@ export default function Http(
   config: HttpConfig,
   teamId: string,
   appId: string,
-  context: string
+  context: SdkContext
 ) {
   if (window == null) {
     throw new errors.InitializationError(
@@ -52,8 +52,6 @@ export default function Http(
 
   const decryptWithToken = async (token: string, data: any) => {
     try {
-      const decryptEndpoint = new URL(`${config.apiUrl}/decrypt`);
-
       const response = await fetch(`${config.apiUrl}/decrypt`, {
         method: "POST",
         headers: {

--- a/packages/browser/lib/main.ts
+++ b/packages/browser/lib/main.ts
@@ -51,7 +51,10 @@ export default class EvervaultClient {
       customConfig?.publicKey
     );
 
-    const context = this.getContext(window?.location?.origin ?? "", this.config.input.inputsUrl);
+    const context = this.getContext(
+      window?.location?.origin ?? "",
+      this.config.input.inputsUrl
+    );
 
     this.http = Http(
       this.config.http,

--- a/packages/browser/lib/main.ts
+++ b/packages/browser/lib/main.ts
@@ -5,7 +5,7 @@ import {
   buildCageKeyFromSuppliedPublicKey,
   deriveSharedSecret,
 } from "./utils";
-import Config, { ConfigUrls } from "./config";
+import Config, { ConfigUrls, SdkContext } from "./config";
 import { CoreCrypto, Http, Forms, Input } from "./core";
 import { base64StringToUint8Array } from "./encoding";
 
@@ -51,11 +51,13 @@ export default class EvervaultClient {
       customConfig?.publicKey
     );
 
+    const context = this.getContext(this.config.input.inputsUrl);
+
     this.http = Http(
       this.config.http,
       this.config.teamId,
       this.config.appId,
-      this.config.input.inputsUrl ? "inputs" : "default"
+      context
     );
 
     this.forms = Forms(this);
@@ -102,6 +104,14 @@ export default class EvervaultClient {
       this.config.encryption,
       this.isInDebugMode()
     );
+  }
+
+  getContext(inputsUrl: string): SdkContext {
+    if(window?.location?.origin === inputsUrl) {
+      return "inputs";
+    } else {
+      return "default";
+    }
   }
 
   /**

--- a/packages/browser/lib/main.ts
+++ b/packages/browser/lib/main.ts
@@ -51,7 +51,7 @@ export default class EvervaultClient {
       customConfig?.publicKey
     );
 
-    const context = this.getContext(this.config.input.inputsUrl);
+    const context = this.getContext(window?.location?.origin ?? "", this.config.input.inputsUrl);
 
     this.http = Http(
       this.config.http,
@@ -106,8 +106,8 @@ export default class EvervaultClient {
     );
   }
 
-  getContext(inputsUrl: string): SdkContext {
-    if(window?.location?.origin === inputsUrl) {
+  getContext(origin: string, inputsUrl: string): SdkContext {
+    if (origin === inputsUrl) {
       return "inputs";
     } else {
       return "default";

--- a/packages/browser/test/basic.test.ts
+++ b/packages/browser/test/basic.test.ts
@@ -30,6 +30,34 @@ describe("customConfig", () => {
   });
 });
 
+describe("Resolving SDK Context", () => {
+  it("Is able to correctly resolve the SDK context", () => {
+    const ev = new EvervaultClient(
+      import.meta.env.VITE_EV_TEAM_UUID,
+      import.meta.env.VITE_EV_APP_UUID,
+      {
+        publicKey:
+          "BDeIKmwjqB35+tnMzQFEvXIvM2kyK6DX75NBEhSZxCR5CQZYnh1fwWsXMEqqKihmEGfMX0+EDHtmZNP/TK7mqMc=",
+      }
+    );
+    assert(ev.getContext("https://inputs.evervault.com") === "inputs");
+    assert(
+      ev.getContext("https://inputs.evervault.com/v2/index.html") === "inputs"
+    );
+    assert(
+      ev.getContext(
+        "https://inputs.evervault.com/v2/index.html?query=string"
+      ) === "inputs"
+    );
+    assert(ev.getContext("https://app.acme.com") === "default");
+    assert(ev.getContext("https://app.acme.com/v2/index.html") === "default");
+    assert(
+      ev.getContext("https://app.acme.com/v2/index.html?query=string") ===
+        "default"
+    );
+  });
+});
+
 const execToken = "abcdefg";
 const decrypted = {
   data: {

--- a/packages/browser/test/basic.test.ts
+++ b/packages/browser/test/basic.test.ts
@@ -40,19 +40,16 @@ describe("Resolving SDK Context", () => {
           "BDeIKmwjqB35+tnMzQFEvXIvM2kyK6DX75NBEhSZxCR5CQZYnh1fwWsXMEqqKihmEGfMX0+EDHtmZNP/TK7mqMc=",
       }
     );
-    assert(ev.getContext("https://inputs.evervault.com") === "inputs");
-    assert(
-      ev.getContext("https://inputs.evervault.com/v2/index.html") === "inputs"
-    );
+    // SDK in an inputs iFrame should always resolve `inputs` context
     assert(
       ev.getContext(
-        "https://inputs.evervault.com/v2/index.html?query=string"
+        "https://inputs.evervault.com",
+        "https://inputs.evervault.com"
       ) === "inputs"
     );
-    assert(ev.getContext("https://app.acme.com") === "default");
-    assert(ev.getContext("https://app.acme.com/v2/index.html") === "default");
+    // SDK on a non-inputs iFrame should always resolve `default` context
     assert(
-      ev.getContext("https://app.acme.com/v2/index.html?query=string") ===
+      ev.getContext("https://app.acme.com", "https://inputs.evervault.com") ===
         "default"
     );
   });


### PR DESCRIPTION
# Why
The browser SDK was incorrectly resolving its context, defaulting to inputs in every case.

# How
Add function to check context against the current window 
