### PR TITLE
Fix npm publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -40,7 +40,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Publish to npm
-        run: pnpm --filter ${{ inputs.package }} publish --access public
+        run: pnpm --filter ${{ inputs.package }} publish --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
     with:
       package: "@evervault/browser"
     secrets:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      NPM_TOKEN: ${{ secrets.BROWSER_SDK_NPM_TOKEN }}
 
   publish-react:
     if: contains(github.event.release.tag_name, '@evervault/react')


### PR DESCRIPTION
# Why
NPM publish workflow uses pnpm's git checks, which assert that the branch must be `master|main`. We publish using tags, which is causing pnpm to block the release.

# How
Disable checks on git branch
