### PR TITLE
Correct parsing of config overrides from search params

### DIFF
--- a/e2e-tests/inputs/tests/default.spec.js
+++ b/e2e-tests/inputs/tests/default.spec.js
@@ -182,4 +182,59 @@ test.describe("evervault inputs", () => {
       await expect(page.getByText("Your card number is invalid")).toBeVisible();
     });
   });
+
+  test.describe("v2 render with expiry and CVV defaults explicitly set", () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto(
+        "http://localhost:4173/v2/?team=59a96deeef03&app=app_869a0605f7c3&disableExpiry=false&disableCVV=false"
+      );
+    });
+
+    test("renders inputs with expiry", async ({ page }) => {
+      await expect(page.getByLabel("Card number")).toBeVisible();
+      await expect(page.getByLabel("Security code")).toBeVisible();
+      await expect(page.getByLabel("Expiration date")).toBeVisible();
+    });
+
+    test("does not show errors for correct fields", async ({ page }) => {
+      await page.getByLabel("Card number").fill(CardLib.validCardNumber);
+      await page.getByLabel("Card number").press("Enter");
+
+      await expect(
+        page.getByText("Your card number is invalid")
+      ).not.toBeVisible();
+    });
+
+    test("does show errors for incorrect card number", async ({ page }) => {
+      await page.getByLabel("Card number").fill(CardLib.invalidCardNumber);
+      await page.getByLabel("Card number").press("Enter");
+
+      await expect(page.getByText("Your card number is invalid")).toBeVisible();
+    });
+
+    test("does show errors for incorrect exiry date", async ({ page }) => {
+      await page
+        .getByLabel("Expiration date")
+        .fill(CardLib.invalidExpirationData);
+      await page.getByLabel("Expiration date").press("Enter");
+
+      await expect(
+        page.getByText("Your expiration date is invalid")
+      ).toBeVisible();
+    });
+
+    test("does show errors for incorrect cvv", async ({ page }) => {
+      await page.getByLabel("Card number").fill(CardLib.validCardNumber);
+      await page.getByLabel("Card number").press("Enter");
+      await page
+        .getByLabel("Expiration date")
+        .fill(CardLib.validExpirationData);
+      await page.getByLabel("Expiration date").press("Enter");
+      // AMEX code is invalid for non-AMEX cards
+      await page.getByLabel("Security code").fill(CardLib.validAmexCVV);
+      await page.getByLabel("Security code").press("Enter");
+
+      await expect(page.getByText("Your CVC is invalid")).toBeVisible();
+    });
+  });
 });

--- a/packages/inputs/src/customLabelsHandler.ts
+++ b/packages/inputs/src/customLabelsHandler.ts
@@ -86,18 +86,35 @@ export function updateErrorLabels(
   };
 }
 
-const defaultFormOverrides = {
+type FormOverrides = {
+  disableCVV: boolean;
+  disableExpiry: boolean;
+};
+
+const defaultFormOverrides: FormOverrides = {
   disableCVV: false,
   disableExpiry: false,
 };
 
+function evaluateSearchParam(
+  label: keyof FormOverrides,
+  urlParams: URLSearchParams,
+  defaults: FormOverrides
+): boolean {
+  return urlParams.get(label) == "true" ?? defaults[label];
+}
+
 export function setFormOverrides(urlParams: URLSearchParams) {
   return {
-    disableCVV: Boolean(
-      urlParams.get("disableCVV") ?? defaultFormOverrides.disableCVV
+    disableCVV: evaluateSearchParam(
+      "disableCVV",
+      urlParams,
+      defaultFormOverrides
     ),
-    disableExpiry: Boolean(
-      urlParams.get("disableExpiry") ?? defaultFormOverrides.disableExpiry
+    disableExpiry: evaluateSearchParam(
+      "disableExpiry",
+      urlParams,
+      defaultFormOverrides
     ),
   };
 }


### PR DESCRIPTION
# Why
Inputs form overrides were always treated as true regardless of the value. This was due to an incorrect `truthy` check on the values.

# How
Update form override parsing — compare the value against a stringified boolean to correctly account for `true` and `false` in search params
