### PR TITLE
add normal to the inputs color scheme

### DIFF
--- a/.changeset/shy-taxis-allow.md
+++ b/.changeset/shy-taxis-allow.md
@@ -1,0 +1,5 @@
+---
+"@evervault/inputs": patch
+---
+
+add normal to color scheme to fix transparency

--- a/packages/inputs/index.html
+++ b/packages/inputs/index.html
@@ -7,7 +7,7 @@
       content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0"
     />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
-    <meta name="color-scheme" content="light dark" />
+    <meta name="color-scheme" content="light dark normal" />
     <title>Evervault</title>
     <script type="module" src="/src/index.ts"></script>
   </head>


### PR DESCRIPTION
# Why
to be compatible with webpages rendered with the `normal` color scheme

# How
add normal to the meta tag