### PR TITLE
fix header serialization and dark mode

### DIFF
--- a/.changeset/young-pets-sit.md
+++ b/.changeset/young-pets-sit.md
@@ -1,0 +1,6 @@
+---
+"@evervault/browser": patch
+"@evervault/inputs": patch
+---
+
+fix: fix header serialization

--- a/packages/browser/lib/core/inputs.ts
+++ b/packages/browser/lib/core/inputs.ts
@@ -63,7 +63,9 @@ export default function Inputs(config: Config) {
               };
 
               if (request.headers instanceof Headers) {
-                requestSerializable.headers = Object.fromEntries(request.headers.entries());
+                requestSerializable.headers = Object.fromEntries(
+                  request.headers.entries()
+                );
               } else if (request.headers instanceof Object) {
                 requestSerializable.headers = request.headers;
               }

--- a/packages/browser/lib/core/inputs.ts
+++ b/packages/browser/lib/core/inputs.ts
@@ -48,22 +48,27 @@ export default function Inputs(config: Config) {
               if (!request) {
                 throw new Error("Request is required for Evervault Reveal");
               }
-              const requestStr = JSON.stringify(request, [
-                "bodyUsed",
-                "cache",
-                "credentials",
-                "destination",
-                "headers",
-                "integrity",
-                "isHistoryNavigation",
-                "keepalive",
-                "method",
-                "mode",
-                "redirect",
-                "referrer",
-                "referrerPolicy",
-                "url",
-              ]);
+
+              let requestSerializable: EvervaultRequestProps = {
+                cache: request.cache,
+                credentials: request.credentials,
+                destination: request.destination,
+                integrity: request.integrity,
+                keepalive: request.keepalive,
+                method: request.method,
+                mode: request.mode,
+                referrer: request.referrer,
+                referrerPolicy: request.referrerPolicy,
+                url: request.url,
+              };
+
+              if (request.headers instanceof Headers) {
+                requestSerializable.headers = Object.fromEntries(request.headers.entries());
+              } else if (request.headers instanceof Object) {
+                requestSerializable.headers = request.headers;
+              }
+
+              const requestStr = JSON.stringify(requestSerializable);
 
               const channel = new MessageChannel();
               (

--- a/packages/browser/lib/main.ts
+++ b/packages/browser/lib/main.ts
@@ -19,9 +19,11 @@ export interface EvervaultRequestProps {
   cache?: RequestCache;
   credentials?: RequestCredentials;
   destination?: RequestDestination;
-  headers?: Headers;
+  headers?: {
+    [key: string]: string;
+  };
   integrity?: string;
-  keepalive?: string;
+  keepalive?: boolean;
   method?: string;
   mode?: RequestMode;
   referrer?: string;

--- a/packages/inputs/src/app/RevealManager.ts
+++ b/packages/inputs/src/app/RevealManager.ts
@@ -19,7 +19,7 @@ async function makeRequest(requestJson: string): Promise<CardData> {
   const request = new Request(requestData.url, {
     ...requestData,
   });
-  let req = await fetch(request.url);
+  let req = await fetch(request);
   let response = await req.json();
 
   if (!response.cardNumber) {

--- a/packages/inputs/src/index.html
+++ b/packages/inputs/src/index.html
@@ -7,7 +7,7 @@
       content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0"
     />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
-    <meta name="color-scheme" content="light dark normal" />
+    <meta name="color-scheme" content="light dark only" />
     <title>Evervault</title>
     <script type="module" src="./app/index.ts" mode="inputs"></script>
   </head>

--- a/packages/inputs/src/reveal.html
+++ b/packages/inputs/src/reveal.html
@@ -7,7 +7,7 @@
       content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0"
     />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
-    <meta name="color-scheme" content="light dark normal" />
+    <meta name="color-scheme" content="light dark only" />
     <title>Evervault Reveal</title>
     <script type="module" src="./app/index.ts" mode="reveal"></script>
   </head>


### PR DESCRIPTION
# Why
need to be able to serialize headers for requests
fixes a bug where reveal displayed weirdly on darkmode

# How
turn headers in to a normal object if they're a `Headers`
change meta theme