### PR TITLE
make errors serialize in safari

### DIFF
--- a/.changeset/eighty-jars-float.md
+++ b/.changeset/eighty-jars-float.md
@@ -1,0 +1,6 @@
+---
+"@evervault/browser": patch
+"@evervault/inputs": patch
+---
+
+fix error serialization in safari

--- a/packages/browser/lib/core/inputs.ts
+++ b/packages/browser/lib/core/inputs.ts
@@ -97,7 +97,22 @@ export default function Inputs(config: Config) {
             }
           }
           if (event.data?.type === "EV_REVEAL_ERROR_EVENT") {
-            reject(event.data?.error);
+            let errorStr = event.data?.error;
+            if (errorStr) {
+              try {
+                const error = JSON.parse(errorStr);
+                try {
+                  // @ts-ignore
+                  // Try and reconstruct the exact error type if available in this window context.
+                  // TS despises this but we catch and throw a generic error so its fine.
+                  reject(new window[error.type](error.message));
+                } catch (e) {
+                  reject(new Error(error.message));
+                }
+              } catch (e) {
+                reject(`Failed to parse Error: ${e}, Unparsed: ${errorStr}`);
+              }
+            }
           }
           if (
             event.data?.type === "EV_REVEAL_LOADED" ||

--- a/packages/inputs/src/app/index.ts
+++ b/packages/inputs/src/app/index.ts
@@ -388,7 +388,8 @@ const onLoad = function () {
       });
       parent.postMessage(
         {
-          type: "EV_REVEAL_ERROR_EVENT", error: serializedError
+          type: "EV_REVEAL_ERROR_EVENT",
+          error: serializedError,
         },
         "*"
       );

--- a/packages/inputs/src/app/index.ts
+++ b/packages/inputs/src/app/index.ts
@@ -381,8 +381,15 @@ const onLoad = function () {
       }
     })
     .catch((e) => {
-      const test = parent.postMessage(
-        { type: "EV_REVEAL_ERROR_EVENT", error: e },
+      const serializedError = JSON.stringify({
+        type: e.name,
+        message: e.message,
+        cause: e.cause,
+      });
+      parent.postMessage(
+        {
+          type: "EV_REVEAL_ERROR_EVENT", error: serializedError
+        },
         "*"
       );
     });


### PR DESCRIPTION
# Why
Safari doesn't support serializing errors (they are the one browser not to do this) which breaks our promise throwing.

# How
Serialize the error manually. Then we try and reconstruct in to the correct error type if its available in the current context