### PR TITLE
Prevent material theme from overriding .hide class

### DIFF
--- a/.changeset/smooth-kids-float.md
+++ b/.changeset/smooth-kids-float.md
@@ -1,0 +1,5 @@
+---
+"@evervault/inputs": patch
+---
+
+Prevent material theme from overriding disableCVV config

--- a/packages/inputs/src/app/styles.css
+++ b/packages/inputs/src/app/styles.css
@@ -262,7 +262,7 @@ textarea {
     padding: 0.5rem 0;
   }
 
-  & .input-group {
+  & .input-group:not(.hide) {
     display: flex;
     align-items: center;
     justify-content: flex-start;


### PR DESCRIPTION
# Why
The `material` theme was applying `display: flex` which was overriding the `.hide` class.

# How
Restrict the material theme CSS selector to  input groups that don't have the hide class.
