### PR TITLE
Allow for longer card numbers

### DIFF
--- a/packages/inputs/src/app/InputElementsManager.ts
+++ b/packages/inputs/src/app/InputElementsManager.ts
@@ -56,7 +56,7 @@ export class InputElementsManager {
 
     this.masks = {
       cardNumber: IMask(this.elements.cardNumber, {
-        mask: "0000 0000 0000 0000",
+        mask: "0000 0000 0000 0000 000",
       }),
       expirationDate: IMask(this.elements.expirationDate, {
         mask: "MM / YY",


### PR DESCRIPTION
# Why
Need to support up to 19 digit pans

# How
Allow the mask to grow up to 19 digits