### PR TITLE
Fix an invalid cast in the decrypt function

### DIFF
--- a/.changeset/odd-fireants-behave.md
+++ b/.changeset/odd-fireants-behave.md
@@ -1,0 +1,5 @@
+---
+"@evervault/browser": patch
+---
+
+Fix casting issue in the response of the `decrypt()` function

--- a/e2e-apps/browser/src/scaffold-test-single.js
+++ b/e2e-apps/browser/src/scaffold-test-single.js
@@ -16,9 +16,7 @@ encryptForm.addEventListener("submit", async (e) => {
   const value = formData.get("ev-encrypt-input");
   const encryptedValue = await ev.encrypt(value);
 
-  const tokenPayload = {
-    data: encryptedValue,
-  };
+  const tokenPayload = encryptedValue;
 
   const fnPlayload = {
     encrypted: encryptedValue,

--- a/packages/browser/lib/core/http.ts
+++ b/packages/browser/lib/core/http.ts
@@ -77,9 +77,8 @@ export default function Http(
         throw new Error(`HTTP error! status: ${response.status}`);
       }
 
-      const body = (await response.json()) as { data: { value: T } };
-
-      return body.data;
+      const body = (await response.json()) as { value: T };
+      return body;
     } catch (err) {
       throw new errors.DecryptError(
         "An error occurred while decrypting the data",

--- a/packages/browser/test/basic.test.ts
+++ b/packages/browser/test/basic.test.ts
@@ -54,7 +54,7 @@ describe("Resolving SDK Context", () => {
 
 const execToken = "abcdefg";
 const decrypted = {
-  value: "Big Secret"
+  value: "Big Secret",
 };
 
 export const restHandlers = [

--- a/packages/browser/test/basic.test.ts
+++ b/packages/browser/test/basic.test.ts
@@ -54,9 +54,7 @@ describe("Resolving SDK Context", () => {
 
 const execToken = "abcdefg";
 const decrypted = {
-  data: {
-    value: "Big Secret",
-  },
+  value: "Big Secret"
 };
 
 export const restHandlers = [
@@ -88,7 +86,7 @@ describe("decrypt", () => {
     it("decrypts correctly", async () => {
       const ev = new EvervaultClient("abcdefg", "uppa");
       const result = await ev.decrypt(execToken, "encryptedString");
-      assert(result.value === decrypted.data.value);
+      assert(result.value === decrypted.value);
     });
   });
 


### PR DESCRIPTION
# Why
`Decrypt` was returning the `data` attribute of the decrypt response when `data` didn't exist. Unit tests made this behaviour pass tests.

# How
Remove casting to `{ data: ... }`
