### PR TITLE
Remove TESTS_API_KEY from workflows

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,8 +14,6 @@ on:
         required: true
       TESTS_DECRYPT_FN_KEY:
         required: true
-      TESTS_API_KEY:
-        required: true
       TURBO_TOKEN:
         required: true
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -15,5 +15,4 @@ jobs:
       TESTS_TEAM_UUID: ${{ secrets.TESTS_TEAM_UUID }}
       TESTS_APP_UUID: ${{ secrets.TESTS_APP_UUID }}
       TESTS_DECRYPT_FN_KEY: ${{ secrets.TESTS_DECRYPT_FN_KEY }}
-      TESTS_API_KEY: ${{ secrets.TESTS_API_KEY }}
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}


### PR DESCRIPTION
The Github Action build and test workflow was requiring TESTS_API_KEY, however, it didn't actually use it.
