### PR TITLE
Create new browser minor version

### DIFF
--- a/.changeset/spotty-impalas-enjoy.md
+++ b/.changeset/spotty-impalas-enjoy.md
@@ -1,0 +1,7 @@
+---
+"@evervault/browser": minor
+---
+
+Adds UI Components
+
+You can read more about UI Components, and how to upgrade from Inputs here: https://docs.evervault.com/primitives/ui-components


### PR DESCRIPTION
# Why
Our browser versions are out of sync due to a deployment last month. Currently 2.15.1 is also tagged and released as 2.16.

# How
Force a new minor version.