### PR TITLE
Move types and themes to devDependency for react

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -36,6 +36,7 @@
   "peerDependencies": {
     "react": ">=18.0.0"
   },
+	"bundledDependencies": ["types", "themes"],
   "devDependencies": {
     "types": "workspace:^",
     "themes": "workspace:^",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -33,14 +33,12 @@
     "preinstall": "npx only-allow pnpm",
     "typecheck": "tsc --noEmit"
   },
-  "dependencies": {
-    "types": "workspace:^",
-    "themes": "workspace:^"
-  },
   "peerDependencies": {
     "react": ">=18.0.0"
   },
   "devDependencies": {
+    "types": "workspace:^",
+    "themes": "workspace:^",
     "@evervault/browser": "workspace:^",
     "@types/react": "^18.2.8",
     "@types/react-dom": "^18.2.4",

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,5 +1,6 @@
 {
   "name": "themes",
+  "version": "0.0.0",
   "main": "index.ts",
   "types": "index.ts",
   "dependencies": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,5 +1,6 @@
 {
   "name": "types",
+  "version": "0.0.0",
   "main": "index.ts",
   "types": "index.ts",
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -310,13 +310,6 @@ importers:
         version: 3.6.3(@types/node@18.15.11)(typescript@5.3.3)(vite@4.5.1)
 
   packages/react:
-    dependencies:
-      themes:
-        specifier: workspace:^
-        version: link:../themes
-      types:
-        specifier: workspace:^
-        version: link:../types
     devDependencies:
       '@evervault/browser':
         specifier: workspace:^
@@ -336,9 +329,15 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
+      themes:
+        specifier: workspace:^
+        version: link:../themes
       tsconfig:
         specifier: workspace:^
         version: link:../tsconfig
+      types:
+        specifier: workspace:^
+        version: link:../types
       vite:
         specifier: ^4.5.1
         version: 4.5.1(@types/node@18.15.11)


### PR DESCRIPTION
# Why
Publish step failed because themes and types are internal packages and they were listed as dependencies.