### PR TITLE
Remove bundledDependencies from react package.json

### DIFF
--- a/.changeset/two-zoos-reflect.md
+++ b/.changeset/two-zoos-reflect.md
@@ -1,0 +1,5 @@
+---
+"@evervault/react": patch
+---
+
+Remove bundledDependencies from package.json

--- a/packages/eslint-config-custom/index.js
+++ b/packages/eslint-config-custom/index.js
@@ -40,7 +40,7 @@ module.exports = {
       { ts: "never", js: "never", mjs: "never", jsx: "never", tsx: "never" },
     ],
     "import/no-extraneous-dependencies": [
-      "error",
+      "warn",
       {
         devDependencies: [
           "**/postcss.config.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -36,7 +36,6 @@
   "peerDependencies": {
     "react": ">=18.0.0"
   },
-	"bundledDependencies": ["types", "themes"],
   "devDependencies": {
     "types": "workspace:^",
     "themes": "workspace:^",


### PR DESCRIPTION
# Why
Yarn does not support package.json `bundledDependencies`.

# How
We had added `bundledDependencies` in the first place because eslint was erroring on themes and types being devDependencies instead of dependencies. This won't work though as neither of these are published packages and instead are bundled by the SDK. So we have changed the eslint error to a warning.