### PR TITLE
Bundle dependency types with the react package

### DIFF
--- a/.changeset/weak-walls-provide.md
+++ b/.changeset/weak-walls-provide.md
@@ -1,0 +1,5 @@
+---
+"@evervault/react": patch
+---
+
+Improved type definitions

--- a/packages/react/vite.config.mts
+++ b/packages/react/vite.config.mts
@@ -29,13 +29,7 @@ export default defineConfig({
     react({ jsxRuntime: "classic" }),
     dts({
       rollupTypes: true,
-      bundledPackages: [
-        "types",
-        "themes",
-        "@evervault/browser",
-        "jss",
-        "csstype",
-      ],
+      bundledPackages: ["types", "themes", "@evervault/browser"],
     }),
   ],
 });

--- a/packages/react/vite.config.mts
+++ b/packages/react/vite.config.mts
@@ -29,6 +29,13 @@ export default defineConfig({
     react({ jsxRuntime: "classic" }),
     dts({
       rollupTypes: true,
+      bundledPackages: [
+        "types",
+        "themes",
+        "@evervault/browser",
+        "jss",
+        "csstype",
+      ],
     }),
   ],
 });


### PR DESCRIPTION
# Why
The Types from the internal types, themes, and browser packages were being stripped out.

# How
Update the dts config to bundle them.
