### PR TITLE
Support displaying card holder name field via fields argument

### DIFF
--- a/.changeset/chilly-bees-lick.md
+++ b/.changeset/chilly-bees-lick.md
@@ -1,0 +1,7 @@
+---
+"@evervault/ui-components": minor
+"@evervault/browser": minor
+"@evervault/react": minor
+---
+
+Adds a new 'fields' option for Card components that can be used to configure which fields should be shown inside of the component. By default the number, expiry and cvc fields will be shown. The available options for fields are 'name', 'number', 'expiry' and 'cvc'

--- a/packages/browser/lib/ui/card.ts
+++ b/packages/browser/lib/ui/card.ts
@@ -14,6 +14,7 @@ interface CardEvents {
   ready: () => void;
   error: () => void;
   change: (payload: CardPayload) => void;
+  complete: (payload: CardPayload) => void;
   swipe: (payload: SwipedCard) => void;
 }
 
@@ -35,6 +36,10 @@ export default class Card {
       this.#events.dispatch("change", payload);
     });
 
+    this.#frame.on("EV_COMPLETE", (payload) => {
+      this.#events.dispatch("complete", payload);
+    });
+
     this.#frame.on("EV_SWIPE", (payload) => {
       this.#events.dispatch("swipe", payload);
     });
@@ -50,7 +55,8 @@ export default class Card {
       config: {
         autoFocus: this.#options.autoFocus,
         translations: this.#options.translations,
-        hiddenFields: (this.#options.hiddenFields ?? [])?.join(","),
+        hiddenFields: this.#options.hiddenFields,
+        fields: this.#options.fields,
       },
     };
   }

--- a/packages/browser/lib/ui/card.ts
+++ b/packages/browser/lib/ui/card.ts
@@ -55,7 +55,7 @@ export default class Card {
       config: {
         autoFocus: this.#options.autoFocus,
         translations: this.#options.translations,
-        hiddenFields: this.#options.hiddenFields,
+        hiddenFields: (this.#options.hiddenFields ?? [])?.join(","),
         fields: this.#options.fields,
       },
     };

--- a/packages/react/lib/ui/Card.tsx
+++ b/packages/react/lib/ui/Card.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import { useEffect, useLayoutEffect, useMemo, useRef } from "react";
 import { useEvervault } from "../useEvervault";
 import type {
+  CardField,
   CardPayload,
   CardTranslations,
   SwipedCard,
@@ -12,20 +13,24 @@ import type {
 export interface CardProps {
   theme?: ThemeDefinition;
   translations?: CardTranslations;
+  fields?: CardField[];
   onReady?: () => void;
   onError?: () => void;
   onSwipe?: (data: SwipedCard) => void;
   onChange?: (data: CardPayload) => void;
+  onComplete?: (data: CardPayload) => void;
 }
 
 type CardClass = ReturnType<Evervault["ui"]["card"]>;
 
 export function Card({
   theme,
+  fields,
   onSwipe,
   onReady,
   onError,
   onChange,
+  onComplete,
   translations,
 }: CardProps) {
   const ev = useEvervault();
@@ -57,12 +62,19 @@ export function Card({
     return instance?.on("change", onChange);
   }, [instance, onChange]);
 
+  // setup complete event listener
+  useEffect(() => {
+    if (!instance || !onComplete) return undefined;
+    return instance?.on("complete", onComplete);
+  }, [instance, onComplete]);
+
   const config = useMemo(
     () => ({
       theme,
+      fields,
       translations,
     }),
-    [theme, translations]
+    [theme, translations, fields]
   );
 
   useLayoutEffect(() => {

--- a/packages/themes/minimal.ts
+++ b/packages/themes/minimal.ts
@@ -83,25 +83,43 @@ export function minimal(extended?: ThemeDefinition): ThemeDefinition {
             display: "block",
           },
 
-        "& [ev-name=number]": {
-          marginBottom: "-1px",
+        "& [ev-valid=true]:nth-child(1) + [ev-valid=true]:nth-child(2) + [ev-valid=true]:nth-child(3) + [ev-valid=false] .error":
+          {
+            display: "block",
+          },
 
+        "& .field:not(:last-child)": {
+          marginBottom: "-1px",
+        },
+
+        "& .field:first-child": {
           "& input": {
             borderTopLeftRadius: 6,
             borderTopRightRadius: 6,
           },
         },
 
-        "& .field:nth-child(2) input": {
-          borderBottomLeftRadius: 6,
+        "& .field:last-child": {
+          "& input": {
+            borderBottomRightRadius: 6,
+            borderBottomLeftRadius: 6,
+          },
+        },
+      },
+
+      "[ev-component=card][ev-fields*=cvc][ev-fields*=expiry]": {
+        "& .field[ev-name=expiry]": {
+          "& input": {
+            borderBottomLeftRadius: 6,
+          },
         },
 
-        "& .field:nth-child(3)": {
+        "& .field[ev-name=cvc]": {
           marginLeft: "-1px",
-        },
 
-        "& .field:last-child input": {
-          borderBottomRightRadius: 6,
+          "& input": {
+            borderBottomLeftRadius: 0,
+          },
         },
       },
 

--- a/packages/types/uiComponents.ts
+++ b/packages/types/uiComponents.ts
@@ -33,8 +33,8 @@ interface CardExpiry {
 }
 
 export interface CardPayload {
-  isValid: boolean;
   card: {
+    name: string | null;
     brand: string | undefined;
     number: string | null;
     lastFour: string | null;
@@ -42,6 +42,8 @@ export interface CardPayload {
     expiry: CardExpiry;
     cvc: string | null;
   };
+  isValid: boolean;
+  isComplete: boolean;
   errors: null | Partial<{
     number?: string;
     cvc?: string;
@@ -49,7 +51,7 @@ export interface CardPayload {
   }>;
 }
 
-export type CardField = "number" | "expiry" | "cvc";
+export type CardField = "name" | "number" | "expiry" | "cvc";
 
 interface CardFieldTranslations<E extends TranslationsObject>
   extends TranslationsObject {
@@ -67,7 +69,8 @@ export interface CardTranslations extends TranslationsObject {
 export interface CardOptions {
   theme?: ThemeDefinition;
   autoFocus?: boolean;
-  hiddenFields?: CardField[];
+  hiddenFields?: ("number" | "expiry" | "cvc")[]; // deprecated
+  fields?: CardField[];
   translations?: Partial<CardTranslations>;
 }
 
@@ -98,14 +101,13 @@ export interface EvervaultFrameHostMessages {
   };
 }
 
-export interface CardFrameClientMessages
-  extends EvervaultFrameClientMessages {
+export interface CardFrameClientMessages extends EvervaultFrameClientMessages {
   EV_SWIPE: SwipedCard;
   EV_CHANGE: CardPayload;
+  EV_COMPLETE: CardPayload;
 }
 
-export interface CardFrameHostMessages
-  extends EvervaultFrameHostMessages {
+export interface CardFrameHostMessages extends EvervaultFrameHostMessages {
   EV_VALIDATE: undefined;
 }
 

--- a/packages/ui-components/src/Card/CardHolder.tsx
+++ b/packages/ui-components/src/Card/CardHolder.tsx
@@ -1,5 +1,4 @@
-import { FocusEvent, useEffect, useRef } from "react";
-import { useMask } from "../utilities/useMask";
+import { FocusEvent } from "react";
 
 interface CardHolderProps {
   disabled?: boolean;

--- a/packages/ui-components/src/Card/CardHolder.tsx
+++ b/packages/ui-components/src/Card/CardHolder.tsx
@@ -1,0 +1,40 @@
+import { FocusEvent, useEffect, useRef } from "react";
+import { useMask } from "../utilities/useMask";
+
+interface CardHolderProps {
+  disabled?: boolean;
+  autoFocus?: boolean;
+  onChange: (v: string) => void;
+  onBlur?: (e: FocusEvent<HTMLInputElement>) => void;
+  placeholder: string;
+  value: string;
+  readOnly?: boolean;
+}
+
+export function CardHolder({
+  autoFocus,
+  disabled,
+  onChange,
+  onBlur,
+  placeholder,
+  value,
+  readOnly,
+}: CardHolderProps) {
+  return (
+    <input
+      type="text"
+      id="number"
+      name="number"
+      value={value}
+      readOnly={readOnly}
+      inputMode="numeric"
+      onBlur={onBlur}
+      autoFocus={autoFocus}
+      disabled={disabled}
+      placeholder={placeholder}
+      pattern="[0-9]*"
+      autoComplete="billing cc-name"
+      onChange={(e) => onChange(e.target.value)}
+    />
+  );
+}

--- a/packages/ui-components/src/Card/index.tsx
+++ b/packages/ui-components/src/Card/index.tsx
@@ -28,11 +28,10 @@ export function Card({ config }: { config: CardConfig }) {
 
   const fields = useMemo(() => {
     let result = config.fields ?? ["number", "expiry", "cvc"];
+    const hidden = String(config?.hiddenFields ?? "").split(",");
 
-    if (config.hiddenFields) {
-      result = (result as typeof config.hiddenFields).filter(
-        (field) => !config.hiddenFields?.includes(field)
-      );
+    if (hidden.length > 0) {
+      result = result.filter((field) => !hidden?.includes(field));
     }
 
     return result;

--- a/packages/ui-components/src/Card/translations.ts
+++ b/packages/ui-components/src/Card/translations.ts
@@ -1,8 +1,15 @@
 import { CardTranslations } from "types";
 
 export const DEFAULT_TRANSLATIONS: CardTranslations = {
+  name: {
+    label: "Card Holder",
+    placeholder: "Name",
+    errors: {
+      invalid: "Please enter your full name",
+    },
+  },
   number: {
-    label: "Card number",
+    label: "Card Number",
     placeholder: "0000 0000 0000 0000",
     errors: {
       invalid: "Your card number is invalid",

--- a/packages/ui-components/src/Card/types.ts
+++ b/packages/ui-components/src/Card/types.ts
@@ -3,11 +3,13 @@ import type { ThemeObject, CardField, CardTranslations } from "types";
 export interface CardConfig {
   theme?: ThemeObject;
   autoFocus?: boolean;
-  hiddenFields?: CardField[];
+  hiddenFields?: ("number" | "expiry" | "cvc")[];
+  fields?: CardField[];
   translations?: Partial<CardTranslations>;
 }
 
 export interface CardForm {
+  name: string;
   number: string;
   cvc: string;
   expiry: string;

--- a/packages/ui-components/src/index.css
+++ b/packages/ui-components/src/index.css
@@ -45,9 +45,11 @@ input {
   }
 }
 
-[ev-component="card"]:not([ev-hidden-fields]) .field:nth-child(2),
-[ev-component="card"]:not([ev-hidden-fields]) .field:nth-child(3) {
-  grid-column: auto;
+[ev-component="card"][ev-fields*="cvc"][ev-fields*="expiry"] {
+  & .field[ev-name="expiry"],
+  & .field[ev-name="cvc"] {
+    grid-column: auto;
+  }
 }
 
 [ev-component="pin"] {

--- a/packages/ui-components/src/utilities/useForm.ts
+++ b/packages/ui-components/src/utilities/useForm.ts
@@ -132,10 +132,8 @@ export function useForm<T extends object>({
 
   const register = useCallback(
     <K extends keyof T>(name: K) => {
-      const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
-        if (e.target.value) {
-          validateField(name);
-        }
+      const handleBlur = () => {
+        validateField(name);
       };
 
       const handleChange = (value: T[K]) => {


### PR DESCRIPTION
# Why

Browsers do not allow input auto completes to pass from the parent frame down into the child iframe. This meant that when prompted on a 'name' field in the parent document, the auto complete would not fill out the card number, expiry or cvc.

# How

The only way to fix this at the moment is to provide functionality for users to render a 'name' field inside of the component iFrame. This PR adds a `fields` option to the Card component which allows users to define which fields they want to display and supports a 'name' field.

```js
const card = evervault.ui.card({
  fields: ['name', 'number', 'expiry', 'cvc'],
})
```

This PR also includes a new `isComplete` field on the card payload which indicates if the card has been correctly filled out. As well as a new `complete` event which will fire once the complete is filled out successfully.