### PR TITLE
Add missing React props for UI component options

### DIFF
--- a/.changeset/mighty-waves-hope.md
+++ b/.changeset/mighty-waves-hope.md
@@ -1,0 +1,9 @@
+---
+"@evervault/react": patch
+---
+
+Some UI component options weren't available as React props.
+
+- Adds autoFocus prop for Card and Pin Component.
+- Adds mode prop for Pin component.
+- Adds inputType prop for Pin component.

--- a/packages/react/lib/ui/Card.tsx
+++ b/packages/react/lib/ui/Card.tsx
@@ -11,6 +11,7 @@ import type {
 } from "types";
 
 export interface CardProps {
+  autoFocus?: boolean;
   theme?: ThemeDefinition;
   translations?: CardTranslations;
   fields?: CardField[];
@@ -26,12 +27,13 @@ type CardClass = ReturnType<Evervault["ui"]["card"]>;
 export function Card({
   theme,
   fields,
+  autoFocus,
+  translations,
   onSwipe,
   onReady,
   onError,
   onChange,
   onComplete,
-  translations,
 }: CardProps) {
   const ev = useEvervault();
   const initialized = useRef(false);
@@ -72,9 +74,10 @@ export function Card({
     () => ({
       theme,
       fields,
+      autoFocus,
       translations,
     }),
-    [theme, translations, fields]
+    [theme, translations, fields, autoFocus]
   );
 
   useLayoutEffect(() => {

--- a/packages/react/lib/ui/Pin.tsx
+++ b/packages/react/lib/ui/Pin.tsx
@@ -12,7 +12,16 @@ export type PinProps = PinOptions & {
 
 type PinClass = ReturnType<Evervault["ui"]["pin"]>;
 
-export function Pin({ theme, onReady, onChange, onError, length }: PinProps) {
+export function Pin({
+  theme,
+  autoFocus,
+  mode,
+  inputType,
+  length,
+  onReady,
+  onChange,
+  onError,
+}: PinProps) {
   const ev = useEvervault();
   const initialized = useRef(false);
   const [instance, setInstance] = React.useState<PinClass | null>(null);
@@ -40,8 +49,11 @@ export function Pin({ theme, onReady, onChange, onError, length }: PinProps) {
     () => ({
       theme,
       length,
+      autoFocus,
+      mode,
+      inputType,
     }),
-    [theme, length]
+    [theme, length, autoFocus, mode, inputType]
   );
 
   useLayoutEffect(() => {


### PR DESCRIPTION
Some UI component options weren't available as React props.

- Adds autoFocus prop for Card and Pin Component.
- Adds mode prop for Pin component.
- Adds inputType prop for Pin component.