### PR TITLE
Fix incorrect attributes for card holder input

### DIFF
--- a/packages/ui-components/src/Card/CardHolder.tsx
+++ b/packages/ui-components/src/Card/CardHolder.tsx
@@ -22,16 +22,14 @@ export function CardHolder({
   return (
     <input
       type="text"
-      id="number"
-      name="number"
+      id="name"
+      name="name"
       value={value}
       readOnly={readOnly}
-      inputMode="numeric"
       onBlur={onBlur}
       autoFocus={autoFocus}
       disabled={disabled}
       placeholder={placeholder}
-      pattern="[0-9]*"
       autoComplete="billing cc-name"
       onChange={(e) => onChange(e.target.value)}
     />


### PR DESCRIPTION
# Why

The card holder input had incorrect fields that were copied over from the card number.

# How

Remove the card number related attributes and change name and id attributes to `name`