### PR TITLE
Use callback to set form values

### DIFF
--- a/.changeset/rotten-forks-trade.md
+++ b/.changeset/rotten-forks-trade.md
@@ -1,0 +1,5 @@
+---
+"@evervault/ui-components": patch
+---
+
+Prevent race condition when setting form values

--- a/packages/ui-components/src/utilities/useForm.ts
+++ b/packages/ui-components/src/utilities/useForm.ts
@@ -69,19 +69,18 @@ export function useForm<T extends object>({
 
   const setValue = useCallback(
     <K extends keyof T>(field: K, value: T[K]) => {
-      const newValues = {
-        ...values,
-        [field]: value,
-      };
-
       if (errors?.[field]) {
         setError(field, undefined);
       }
 
-      setValues(newValues);
+      setValues((previous) => ({
+        ...previous,
+        [field]: value,
+      }));
+
       triggerChange.current = true;
     },
-    [values, errors, setError]
+    [errors, setError]
   );
 
   const isValid = useMemo(


### PR DESCRIPTION
# Why
 
We were setting form values by passing the updated form state to the `setValues` function call provided by React `useState`. This was causing a race condition for some browsers when using auto complete functionality for card data.

# How
Use a callback instead to ensure when the values are updated to avoid race conditions.

