### PR TITLE
Fix change event handler when clearing inputs

### DIFF
--- a/.changeset/rude-candles-play.md
+++ b/.changeset/rude-candles-play.md
@@ -1,0 +1,5 @@
+---
+"@evervault/ui-components": patch
+---
+
+Fix bug that caused the onchange event to not be fired when inputs were being cleared.

--- a/e2e-tests/ui-components/tests/cardDetails.spec.js
+++ b/e2e-tests/ui-components/tests/cardDetails.spec.js
@@ -11,6 +11,7 @@ test.describe("card component", () => {
       let values = {};
 
       await page.exposeFunction("handleChange", (newValues) => {
+        console.log("change fired");
         values = newValues;
       });
 

--- a/e2e-tests/ui-components/tests/cardDetails.spec.js
+++ b/e2e-tests/ui-components/tests/cardDetails.spec.js
@@ -11,7 +11,6 @@ test.describe("card component", () => {
       let values = {};
 
       await page.exposeFunction("handleChange", (newValues) => {
-        console.log("change fired");
         values = newValues;
       });
 

--- a/examples/custom-theme/src/main.ts
+++ b/examples/custom-theme/src/main.ts
@@ -118,6 +118,10 @@ card.on("change", (values) => {
   }
 });
 
+card.on("complete", (values) => {
+  console.log("complete", values);
+});
+
 card.on("ready", () => {
   console.log("component is ready");
 });

--- a/packages/ui-components/src/Card/CardCVC.tsx
+++ b/packages/ui-components/src/Card/CardCVC.tsx
@@ -34,12 +34,7 @@ export const CardCVC = forwardRef<HTMLInputElement, CVCProps>(
       return "000";
     }, [cardNumber]);
 
-    const [unmasked, setValue] = useMask(innerRef, { mask });
-
-    useEffect(() => {
-      if (!unmasked) return;
-      onChange(unmasked);
-    }, [unmasked]);
+    const { setValue } = useMask(innerRef, onChange, { mask });
 
     useEffect(() => {
       setValue(value);

--- a/packages/ui-components/src/Card/CardExpiry.tsx
+++ b/packages/ui-components/src/Card/CardExpiry.tsx
@@ -38,15 +38,10 @@ export function CardExpiry({
   readOnly,
 }: CardExpiryProps) {
   const ref = useRef<HTMLInputElement>(null);
-  const [unmasked, setValue] = useMask(ref, {
+  const { setValue } = useMask(ref, onChange, {
     mask: "MM / YY",
     blocks: EXPIRY_BLOCKS,
   });
-
-  useEffect(() => {
-    if (!unmasked) return;
-    onChange(unmasked);
-  }, [unmasked]);
 
   useEffect(() => {
     setValue(value);

--- a/packages/ui-components/src/Card/CardNumber.tsx
+++ b/packages/ui-components/src/Card/CardNumber.tsx
@@ -21,14 +21,9 @@ export function CardNumber({
   readOnly,
 }: CardNumberProps) {
   const ref = useRef<HTMLInputElement>(null);
-  const [unmasked, setValue] = useMask(ref, {
+  const { setValue } = useMask(ref, onChange, {
     mask: "0000 0000 0000 0000 000",
   });
-
-  useEffect(() => {
-    if (!unmasked) return;
-    onChange(unmasked);
-  }, [unmasked]);
 
   useEffect(() => {
     setValue(value);

--- a/packages/ui-components/src/Pin/index.tsx
+++ b/packages/ui-components/src/Pin/index.tsx
@@ -142,16 +142,10 @@ function PinInput({
   type: "number" | "text" | "password";
 }) {
   const ref = useRef<HTMLInputElement>(null);
-  const [_, setValue] = useMask(
-    ref,
-    {
-      mask,
-      prepareChar: (c) => c.toUpperCase(),
-    },
-    (char) => {
-      onChange(char);
-    }
-  );
+  const { setValue } = useMask(ref, onChange, {
+    mask,
+    prepareChar: (c) => c.toUpperCase(),
+  });
 
   useEffect(() => {
     setValue(value);

--- a/packages/ui-components/src/utilities/useMask.ts
+++ b/packages/ui-components/src/utilities/useMask.ts
@@ -1,14 +1,15 @@
 import IMask, { FactoryOpts } from "imask";
-import { RefObject, useCallback, useEffect, useRef, useState } from "react";
+import { RefObject, useCallback, useEffect, useRef } from "react";
 
-type UseMaskReturn = [string, (value: string) => void];
+interface UseMaskReturn {
+  setValue: (newValue: string) => void;
+}
 
 export function useMask(
   ref: RefObject<HTMLInputElement>,
-  config: FactoryOpts,
-  onAccept?: (value: string) => void
+  onAccept: (value: string) => void,
+  config: FactoryOpts
 ): UseMaskReturn {
-  const [value, setValue] = useState("");
   const mask = useRef<ReturnType<typeof IMask>>();
 
   useEffect(() => {
@@ -17,8 +18,7 @@ export function useMask(
 
     const handleAccept = () => {
       if (!mask.current) return;
-      setValue(mask.current.unmaskedValue);
-      if (onAccept) onAccept(mask.current.unmaskedValue);
+      onAccept(mask.current.unmaskedValue);
     };
 
     mask.current.on("accept", handleAccept);
@@ -29,10 +29,10 @@ export function useMask(
     };
   }, [config]);
 
-  const updateValue = useCallback((newValue: string) => {
+  const setValue = useCallback((newValue: string) => {
     if (!mask.current) return;
     mask.current.value = newValue;
   }, []);
 
-  return [value, updateValue];
+  return { setValue };
 }


### PR DESCRIPTION
The onChange handler for inputs was being called in a usEffect call which checks if the value was truthy. This was preventing the handler being called when it was being cleared as the empty value would be falsey. This was to prevent useEffect firing the change handler multiple times.

Instead the handler is now passed directly through to the useMask hook rather than doing it inside of an effect.