### PR TITLE
Prevent XSS in inputs reveal

### DIFF
--- a/.changeset/polite-moles-jog.md
+++ b/.changeset/polite-moles-jog.md
@@ -1,0 +1,5 @@
+---
+"@evervault/inputs": patch
+---
+
+Fix XSS vulnerability for Inputs Reveal

--- a/packages/inputs/src/app/RevealManager.ts
+++ b/packages/inputs/src/app/RevealManager.ts
@@ -46,19 +46,19 @@ function makeRequest(request: Request): Promise<Response> {
 function setRevealContent(cardData: CardData) {
   const cardNumberElement = document.getElementById("cardnumber");
   if (cardNumberElement) {
-    cardNumberElement.innerHTML = formatAnyLengthCardNumber(
+    cardNumberElement.textContent = formatAnyLengthCardNumber(
       cardData.cardNumber
     );
   }
 
   const expiryElement = document.getElementById("expirationdate");
   if (expiryElement) {
-    expiryElement.innerHTML = formatExpiryDate(cardData.expiry.toString());
+    expiryElement.textContent = formatExpiryDate(cardData.expiry.toString());
   }
 
   const cvvElement = document.getElementById("securitycode");
   if (cvvElement) {
-    cvvElement.innerHTML = cardData.cvv.toString();
+    cvvElement.textContent = cardData.cvv.toString();
   }
 }
 


### PR DESCRIPTION
# Why
Inputs Reveal uses `innerHTML` to set the response values which is vulnerable to XSS.

# How
Use `textContent` instead.
