### PR TITLE
Eoin/etr 1628 integrate evervault js with hubspot form embedding

### DIFF
--- a/.changeset/mighty-dingos-whisper.md
+++ b/.changeset/mighty-dingos-whisper.md
@@ -1,0 +1,5 @@
+---
+"@evervault/browser": minor
+---
+
+feat: support thirdparty forms for evervault Form encryption

--- a/examples/forms/global.d.ts
+++ b/examples/forms/global.d.ts
@@ -1,0 +1,7 @@
+import type EvervaultClient from "@evervault/browser";
+
+declare global {
+  interface Window {
+    Evervault: typeof EvervaultClient;
+  }
+}

--- a/examples/forms/index.html
+++ b/examples/forms/index.html
@@ -14,8 +14,12 @@
       hbspt.forms.create({
         region: "eu1",
         portalId: "144130402",
-        formId: "7355e85d-cb55-4e32-a3a4-560da4c704fc"
+        formId: "7355e85d-cb55-4e32-a3a4-560da4c704fc",
+        onFormReady: function($form, e) {
+          window.evervault.enableFormEncryption($form)
+        },
       });
+
     </script>
   </body>
 </html>

--- a/examples/forms/index.html
+++ b/examples/forms/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- Load Evervault.js -->
+    <script src="%VITE_EVERVAULT_JS_URL%"></script>
+  </head>
+
+  <body>
+    <script type="module" src="./src/main.ts"></script>
+    <script charset="utf-8" type="text/javascript" src="//js-eu1.hsforms.net/forms/embed/v2.js"></script>
+    <script>
+      hbspt.forms.create({
+        region: "eu1",
+        portalId: "144130402",
+        formId: "7355e85d-cb55-4e32-a3a4-560da4c704fc"
+      });
+    </script>
+  </body>
+</html>

--- a/examples/forms/package.json
+++ b/examples/forms/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "example-forms",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "dev": "vite --port 4000"
+  },
+  "dependencies": {
+    "@evervault/browser": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.2",
+    "vite": "^4.5.2"
+  }
+}

--- a/examples/forms/src/main.ts
+++ b/examples/forms/src/main.ts
@@ -1,0 +1,5 @@
+const evervault = new window.Evervault(
+  import.meta.env.VITE_EV_TEAM_UUID,
+  import.meta.env.VITE_EV_APP_UUID,
+);
+

--- a/examples/forms/src/main.ts
+++ b/examples/forms/src/main.ts
@@ -1,4 +1,4 @@
-const evervault = new window.Evervault(
+window.evervault = new window.Evervault(
   import.meta.env.VITE_EV_TEAM_UUID,
   import.meta.env.VITE_EV_APP_UUID,
 );

--- a/examples/forms/src/vite-env.d.ts
+++ b/examples/forms/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/examples/forms/tsconfig.json
+++ b/examples/forms/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"$schema": "https://json.schemastore.org/tsconfig",
+	"extends": "tsconfig/browser.json",
+	"compilerOptions": {
+		"rootDir": "."
+	}
+}

--- a/examples/forms/vite-env.d.ts
+++ b/examples/forms/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/packages/browser/lib/main.ts
+++ b/packages/browser/lib/main.ts
@@ -309,7 +309,7 @@ export default class EvervaultClient {
     return this.http.decryptWithToken(token, data);
   }
 
-  async enableFormEncryption(thirdPartyForm: Element | undefined) {
+  async enableFormEncryption(thirdPartyForm: HTMLFormElement | undefined) {
     const forms: Form[] = await this.http.getAppForms();
     if (thirdPartyForm) {
       const findSubmitButton = thirdPartyForm.querySelector("[type='submit']")

--- a/packages/browser/lib/main.ts
+++ b/packages/browser/lib/main.ts
@@ -313,22 +313,26 @@ export default class EvervaultClient {
     const forms: Form[] = await this.http.getAppForms();
     if (thirdPartyForm) {
       const findSubmitButton = thirdPartyForm.querySelector("[type='submit']")
-      findSubmitButton?.addEventListener("click", (event) => {
+      findSubmitButton?.addEventListener("click", async (event) => {
         event.preventDefault();
-        forms.forEach((form: Form) => {
-          form.targetElements.forEach((field, idx) => {
-            const childToEncrypt = findChildOfForm(
-              thirdPartyForm,
-              field.elementType,
-              field.elementName
-            );
-            this.encrypt(childToEncrypt.value).then((v) => {
-              childToEncrypt.value = v;
-            });
-          });
-        }, false);
+        if (forms.length > 0) {
+          for (let i = 0; i < forms.length; i++) {
+            const targetElements = forms[i].targetElements
+            for (let x = 0; x < targetElements.length; x++) {
+              const childToEncrypt = findChildOfForm(
+                thirdPartyForm,
+                forms[i].targetElements[x].elementType,
+                forms[i].targetElements[x].elementName
+              );
+              if (childToEncrypt != undefined) {
+                const encValue = await this.encrypt(childToEncrypt.value);
+                childToEncrypt.value = encValue;
+              }
+            }
+          }
+        }
         thirdPartyForm.submit();
-      });
+      }, false);
     } else {
       forms.forEach((form: Form) => {
         const hiddenInput = findFormByHiddenField(form.uuid);

--- a/packages/browser/lib/main.ts
+++ b/packages/browser/lib/main.ts
@@ -315,22 +315,25 @@ export default class EvervaultClient {
       const findSubmitButton = thirdPartyForm.querySelector("[type='submit']");
       findSubmitButton?.addEventListener(
         "click",
-        async (event) => {
+        (event) => {
           event.preventDefault();
           if (forms.length > 0) {
-            for (let i = 0; i < forms.length; i++) {
-              const targetElements = forms[i].targetElements;
+            for (const form of forms) {
+              const { targetElements } = form
               for (let x = 0; x < targetElements.length; x++) {
                 const childToEncrypt = findChildOfForm(
                   thirdPartyForm,
-                  forms[i].targetElements[x].elementType,
-                  forms[i].targetElements[x].elementName
+                  form.targetElements[x].elementType,
+                  form.targetElements[x].elementName
                 );
-                if (childToEncrypt != undefined) {
+                if (childToEncrypt !== undefined) {
                   // @ts-expect-error explict cast is needed for more then a textarea
-                  const encValue = await this.encrypt(childToEncrypt.value);
-                  // @ts-expect-error explict cast is needed for more then a textarea
-                  childToEncrypt.value = encValue;
+                  this.encrypt(childToEncrypt.value).then((encValue) => {
+                    // @ts-expect-error explict cast is needed for more then a textarea
+                    childToEncrypt.value = encValue
+                  }).catch((_) => {
+                    console.error("Error encrypting form value");
+                  });
                 }
               }
             }

--- a/packages/browser/lib/main.ts
+++ b/packages/browser/lib/main.ts
@@ -312,27 +312,33 @@ export default class EvervaultClient {
   async enableFormEncryption(thirdPartyForm: HTMLFormElement | undefined) {
     const forms: Form[] = await this.http.getAppForms();
     if (thirdPartyForm) {
-      const findSubmitButton = thirdPartyForm.querySelector("[type='submit']")
-      findSubmitButton?.addEventListener("click", async (event) => {
-        event.preventDefault();
-        if (forms.length > 0) {
-          for (let i = 0; i < forms.length; i++) {
-            const targetElements = forms[i].targetElements
-            for (let x = 0; x < targetElements.length; x++) {
-              const childToEncrypt = findChildOfForm(
-                thirdPartyForm,
-                forms[i].targetElements[x].elementType,
-                forms[i].targetElements[x].elementName
-              );
-              if (childToEncrypt != undefined) {
-                const encValue = await this.encrypt(childToEncrypt.value);
-                childToEncrypt.value = encValue;
+      const findSubmitButton = thirdPartyForm.querySelector("[type='submit']");
+      findSubmitButton?.addEventListener(
+        "click",
+        async (event) => {
+          event.preventDefault();
+          if (forms.length > 0) {
+            for (let i = 0; i < forms.length; i++) {
+              const targetElements = forms[i].targetElements;
+              for (let x = 0; x < targetElements.length; x++) {
+                const childToEncrypt = findChildOfForm(
+                  thirdPartyForm,
+                  forms[i].targetElements[x].elementType,
+                  forms[i].targetElements[x].elementName
+                );
+                if (childToEncrypt != undefined) {
+                  // @ts-expect-error explict cast is needed for more then a textarea
+                  const encValue = await this.encrypt(childToEncrypt.value);
+                  // @ts-expect-error explict cast is needed for more then a textarea
+                  childToEncrypt.value = encValue;
+                }
               }
             }
           }
-        }
-        thirdPartyForm.submit();
-      }, false);
+          thirdPartyForm.submit();
+        },
+        false
+      );
     } else {
       forms.forEach((form: Form) => {
         const hiddenInput = findFormByHiddenField(form.uuid);

--- a/packages/browser/lib/utils/htmlUtils.ts
+++ b/packages/browser/lib/utils/htmlUtils.ts
@@ -21,21 +21,17 @@ function findFormByHiddenField(uuid: string): Element | null {
 }
 
 function findChildOfForm(
-  form: HTMLFormElement | Element,
+  form: Element,
   elementType: string,
   elementName: string
-): HTMLInputElement | HTMLTextAreaElement {
+): Element {
   const field = form.querySelector(`${elementType}[name="${elementName}"]`);
-
   if (field === null) {
-    throw new Error(`Could not find field with type ${elementType} and name ${elementName}`);
+    throw new Error(
+      `Could not find field with type ${elementType} and name ${elementName}`
+    );
   }
-
-  if (field instanceof HTMLInputElement || field instanceof HTMLTextAreaElement) {
-    return field;
-  } else {
-    throw new Error(`Element found is not an input or textarea element.`);
-  }
+  return field;
 }
 
 export { findParentOfInput, findFormByHiddenField, findChildOfForm };

--- a/packages/browser/lib/utils/htmlUtils.ts
+++ b/packages/browser/lib/utils/htmlUtils.ts
@@ -21,17 +21,21 @@ function findFormByHiddenField(uuid: string): Element | null {
 }
 
 function findChildOfForm(
-  form: Element,
+  form: HTMLFormElement | Element,
   elementType: string,
   elementName: string
-): Element {
+): HTMLInputElement | HTMLTextAreaElement {
   const field = form.querySelector(`${elementType}[name="${elementName}"]`);
+
   if (field === null) {
-    throw new Error(
-      `Could not find field with type ${elementType} and name ${elementName}`
-    );
+    throw new Error(`Could not find field with type ${elementType} and name ${elementName}`);
   }
-  return field;
+
+  if (field instanceof HTMLInputElement || field instanceof HTMLTextAreaElement) {
+    return field;
+  } else {
+    throw new Error(`Element found is not an input or textarea element.`);
+  }
 }
 
 export { findParentOfInput, findFormByHiddenField, findChildOfForm };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 overrides:
   yaml@>=2.0.0-5 <2.2.2: '>=2.2.2'
 
@@ -151,6 +147,19 @@ importers:
         version: 4.5.2(@types/node@18.15.11)
 
   examples/custom-theme:
+    dependencies:
+      '@evervault/browser':
+        specifier: workspace:*
+        version: link:../../packages/browser
+    devDependencies:
+      typescript:
+        specifier: ^5.0.2
+        version: 5.3.3
+      vite:
+        specifier: ^4.5.2
+        version: 4.5.2(@types/node@18.15.11)
+
+  examples/forms:
     dependencies:
       '@evervault/browser':
         specifier: workspace:*
@@ -365,7 +374,7 @@ importers:
         version: link:../types
       typescript:
         specifier: latest
-        version: 5.3.2
+        version: 5.3.3
 
   packages/tsconfig: {}
 
@@ -376,7 +385,7 @@ importers:
         version: 10.10.0
       typescript:
         specifier: latest
-        version: 5.3.2
+        version: 5.3.3
 
   packages/ui-components:
     dependencies:
@@ -8411,12 +8420,12 @@ packages:
     resolution: {integrity: sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==}
     engines: {node: '>=14.17'}
     hasBin: true
+    dev: true
 
   /typescript@5.3.3:
     resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
     engines: {node: '>=14.17'}
     hasBin: true
-    dev: true
 
   /typescript@5.4.2:
     resolution: {integrity: sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==}
@@ -9056,3 +9065,7 @@ packages:
     optionalDependencies:
       commander: 9.5.0
     dev: true
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false


### PR DESCRIPTION
# Why
Adding support for a form embedded on a third party site.

# How
If a form element is passed in the and event listener is attached to the submit button which stop the submit until the field is encrypted and then resubmits the form.

- Allow a HTML Form DOM node to be passed into the `enableFormEncryption` function.
- Add an example application with a Hubspot embedded form
