### PR TITLE
Eoin/etr 1668 third party form will need to pass in the form UUID

### DIFF
--- a/.changeset/funny-queens-join.md
+++ b/.changeset/funny-queens-join.md
@@ -1,0 +1,5 @@
+---
+"@evervault/browser": patch
+---
+
+fix: specify form uuid for thirdparties

--- a/.env.example
+++ b/.env.example
@@ -4,11 +4,12 @@ EV_APP_UUID=
 VITE_EV_TEAM_UUID=$EV_TEAM_UUID
 VITE_EV_APP_UUID=$EV_APP_UUID
 
-# URLs for 
+# URLs for
 VITE_KEYS_URL=https://keys.evervault.com
 VITE_API_URL=https://api.evervault.com
 VITE_UI_COMPONENTS_URL=http://localhost:4001
 VITE_EVERVAULT_JS_URL=http://localhost:4002/evervault-browser.main.umd.cjs
+VITE_FORM_UUID=form_
 
 # API key is useed in some e2e tests
 EV_API_KEY=

--- a/examples/forms/index.html
+++ b/examples/forms/index.html
@@ -16,7 +16,7 @@
         portalId: "144130402",
         formId: "7355e85d-cb55-4e32-a3a4-560da4c704fc",
         onFormReady: function($form, e) {
-          window.evervault.enableFormEncryption($form)
+          window.evervault.enableFormEncryption($form, 'form_a0388079aee2')
         },
       });
 

--- a/examples/forms/index.html
+++ b/examples/forms/index.html
@@ -16,7 +16,7 @@
         portalId: "144130402",
         formId: "7355e85d-cb55-4e32-a3a4-560da4c704fc",
         onFormReady: function($form, e) {
-          window.evervault.enableFormEncryption($form, 'form_a0388079aee2')
+          window.evervault.enableFormEncryption($form, "%VITE_FORM_UUID%")
         },
       });
 

--- a/packages/browser/lib/main.ts
+++ b/packages/browser/lib/main.ts
@@ -323,7 +323,10 @@ export default class EvervaultClient {
           event.preventDefault();
           if (forms.length > 0) {
             const form = forms.find((f) => f.uuid === formUuid);
-            if (!form) return;
+            if (!form) {
+              thirdPartyForm.submit();
+              return;
+            }
             const { targetElements } = form;
             for (let x = 0; x < targetElements.length; x++) {
               const childToEncrypt = findChildOfForm(

--- a/packages/browser/lib/main.ts
+++ b/packages/browser/lib/main.ts
@@ -324,6 +324,7 @@ export default class EvervaultClient {
           if (forms.length > 0) {
             const form = forms.find((f) => f.uuid === formUuid);
             if (!form) {
+              console.error(`Unable to find form ${formUuid}`);
               thirdPartyForm.submit();
               return;
             }

--- a/packages/browser/lib/main.ts
+++ b/packages/browser/lib/main.ts
@@ -309,9 +309,12 @@ export default class EvervaultClient {
     return this.http.decryptWithToken(token, data);
   }
 
-  async enableFormEncryption(thirdPartyForm: HTMLFormElement | undefined) {
+  async enableFormEncryption(
+    thirdPartyForm: HTMLFormElement | undefined,
+    formUuid: string | undefined
+  ) {
     const forms: Form[] = await this.http.getAppForms();
-    if (thirdPartyForm) {
+    if (thirdPartyForm && formUuid) {
       const findSubmitButton = thirdPartyForm.querySelector("[type='submit']");
       findSubmitButton?.addEventListener(
         "click",
@@ -319,29 +322,29 @@ export default class EvervaultClient {
           const mutations = [];
           event.preventDefault();
           if (forms.length > 0) {
-            for (const form of forms) {
-              const { targetElements } = form;
-              for (let x = 0; x < targetElements.length; x++) {
-                const childToEncrypt = findChildOfForm(
-                  thirdPartyForm,
-                  form.targetElements[x].elementType,
-                  form.targetElements[x].elementName
+            const form = forms.find((f) => f.uuid === formUuid);
+            if (!form) return;
+            const { targetElements } = form;
+            for (let x = 0; x < targetElements.length; x++) {
+              const childToEncrypt = findChildOfForm(
+                thirdPartyForm,
+                form.targetElements[x].elementType,
+                form.targetElements[x].elementName
+              );
+              if (childToEncrypt !== undefined) {
+                mutations.push(
+                  new Promise((resolve, reject) => {
+                    // @ts-expect-error explict cast is needed for more then a textarea
+                    this.encrypt(childToEncrypt.value)
+                      .then((encValue) => {
+                        // @ts-expect-error explict cast is needed for more then a textarea
+                        resolve((childToEncrypt.value = encValue));
+                      })
+                      .catch((err) => {
+                        reject(err);
+                      });
+                  })
                 );
-                if (childToEncrypt !== undefined) {
-                  mutations.push(
-                    new Promise((resolve, reject) => {
-                      // @ts-expect-error explict cast is needed for more then a textarea
-                      this.encrypt(childToEncrypt.value)
-                        .then((encValue) => {
-                          // @ts-expect-error explict cast is needed for more then a textarea
-                          resolve((childToEncrypt.value = encValue));
-                        })
-                        .catch((err) => {
-                          reject(err);
-                        });
-                    })
-                  );
-                }
               }
             }
           }


### PR DESCRIPTION
# Why
The formUuid will need to passed in for a third party form so the JS knows in the response from the API to target this form.

# How
- Pass formUuid as a form parameter
- Find the formUuid in the response from the API
