### PR TITLE
Sling: Update material-sling spacing for redesign

### DIFF
--- a/.changeset/twenty-meals-fail.md
+++ b/.changeset/twenty-meals-fail.md
@@ -1,0 +1,5 @@
+---
+"@evervault/inputs": patch
+---
+
+Sling: Update material-sling spacing for redesign

--- a/packages/inputs/src/app/styles.css
+++ b/packages/inputs/src/app/styles.css
@@ -339,11 +339,11 @@ textarea {
     background-color: var(--input-background);
     width: 100%;
     position: relative;
-    padding-inline: 1.5rem;
+    padding-inline: 1rem;
     padding-block: 1rem;
 
     &[data-element="cardnumber"] {
-      margin-bottom: 1rem;
+      margin-bottom: 0.5rem;
     }
   }
 
@@ -365,7 +365,7 @@ textarea {
     display: flex;
     font-size: 1rem;
     font-weight: 400;
-    left: 1.5rem;
+    left: 1rem;
     line-height: 1.2;
     margin: 0;
     pointer-events: none;


### PR DESCRIPTION
# Why
Hey team
We're reworking some designs at Sling and just need to slightly tweak the spacing of some inputs on `material-sling`

Won't merge until we deploy the new version on our end as well. 
 
