### PR TITLE
update with payload

### DIFF
--- a/examples/forms/index.html
+++ b/examples/forms/index.html
@@ -1,25 +1,24 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <!-- Load Evervault.js -->
-    <script src="%VITE_EVERVAULT_JS_URL%"></script>
-  </head>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <!-- Load Evervault.js -->
+  <script src="%VITE_EVERVAULT_JS_URL%"></script>
+</head>
 
-  <body>
-    <script type="module" src="./src/main.ts"></script>
-    <script charset="utf-8" type="text/javascript" src="//js-eu1.hsforms.net/forms/embed/v2.js"></script>
-    <script>
-      hbspt.forms.create({
-        region: "eu1",
-        portalId: "144130402",
-        formId: "7355e85d-cb55-4e32-a3a4-560da4c704fc",
-        onFormReady: function($form, e) {
-          window.evervault.enableFormEncryption($form, "%VITE_FORM_UUID%")
-        },
-      });
-
-    </script>
-  </body>
+<body>
+<script type="module" src="./src/main.ts"></script>
+<script charset="utf-8" type="text/javascript" src="//js-eu1.hsforms.net/forms/embed/v2.js"></script>
+<script>
+  hbspt.forms.create({
+    region: "eu1",
+    portalId: "144130402",
+    formId: "7355e85d-cb55-4e32-a3a4-560da4c704fc",
+    onFormReady: function($form, e) {
+      window.evervault.enableFormEncryption($form, "%VITE_FORM_UUID%")
+    },
+  });
+</script>
+</body>
 </html>

--- a/packages/browser/lib/utils/htmlUtils.ts
+++ b/packages/browser/lib/utils/htmlUtils.ts
@@ -1,22 +1,28 @@
-function findParentOfInput(input: Element): Element {
+function findParentOfInput(input: Element): HTMLFormElement | null {
   const parent = input.parentElement;
 
   if (parent === null || parent === undefined) {
-    return input;
+    return null;
   }
 
   if (parent.tagName === "FORM") {
-    return parent;
+    return parent as HTMLFormElement;
   }
 
   return findParentOfInput(parent);
 }
 
-function findFormByHiddenField(uuid: string): Element | null {
-  const hiddenFieldSelector = `ev_${uuid}`;
-  const hiddenInput = document.querySelector(
-    `input[name="${hiddenFieldSelector}"]`
-  );
+function findFormByHiddenField(
+  uuid: string,
+): Element | null {
+  const hiddenFieldSelectors = [`ev_${uuid}`, uuid];
+  let hiddenInput = null;
+  hiddenFieldSelectors.forEach((selector) => {
+    const field = document.querySelector(`input[name="${selector}"]`);
+    if (field !== null) {
+      hiddenInput = field;
+    }
+  });
   return hiddenInput;
 }
 


### PR DESCRIPTION
# Why
The current implementation breaks form validation for HTML fields that have a required attribute. This is because the js creates shadow copies of the DOM elements and submits them with encrypted values instead of the real ones, causing a validation error on the empty original elements.

# How
- Attach an event handler to the detected form and remove its action attribute, this stops the iframe submit the form. Then cache the action value and attach an `onClick` handler to the form. When the submit button is clicked halt the event, encrypted the required field values, reset the form action and submit the form. 
