### PR TITLE
Add changeset for browser sdk

### DIFF
--- a/.changeset/red-buttons-refuse.md
+++ b/.changeset/red-buttons-refuse.md
@@ -1,0 +1,5 @@
+---
+"@evervault/browser": minor
+---
+
+Add acceptedBrands option


### PR DESCRIPTION
# Why
We're introducing a new `acceptedBrands` option and a new `unsupportedBrand` translation. This requires a bump of the browser sdk.

# How
Create changeset