### PR TITLE
Add changeset for React SDK

### DIFF
--- a/.changeset/smart-waves-crash.md
+++ b/.changeset/smart-waves-crash.md
@@ -1,0 +1,5 @@
+---
+"@evervault/react": minor
+---
+
+Add acceptedBrands option to the Card component


### PR DESCRIPTION
# Why
We're introducing a new acceptedBrands option and a new unsupportedBrand translation. This requires a bump of the browser sdk.

# How
Add changeset