### PR TITLE
bundle internal types package in distribution

### DIFF
--- a/packages/card-validator/vite.config.mts
+++ b/packages/card-validator/vite.config.mts
@@ -17,6 +17,6 @@ export default defineConfig({
     },
   },
   plugins: [
-    dts({ rollupTypes: true }),
+    dts({ rollupTypes: true, bundledPackages: ["types"] }),
   ],
 });


### PR DESCRIPTION
# Why
vite is adding `"types": "0.0.0"` dep to our package json which isn't what we want
# How
Describe how you've approached the problem
