### PR TITLE
Release new card validators version

### DIFF
--- a/.changeset/ten-rules-collect.md
+++ b/.changeset/ten-rules-collect.md
@@ -1,0 +1,5 @@
+---
+"@evervault/card-validator": patch
+---
+
+fix types dependency

--- a/packages/card-validator/package.json
+++ b/packages/card-validator/package.json
@@ -1,8 +1,30 @@
 {
   "name": "@evervault/card-validator",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Evervault Card Validator",
-  "main": "index.ts",
+  "main": "./dist/evervault-card-validator.main.js",
+  "module": "./dist/evervault-card-validator.umd.mjs",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/evervault/evervault-js.git",
+    "directory": "packages/react"
+  },
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/evervault-card-validator.main.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/evervault-card-validator.main.umd.js"
+      }
+    }
+  },
   "scripts": {
     "test": "vitest run",
     "build": "vite build"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -386,6 +386,9 @@ importers:
       '@commitlint/config-conventional':
         specifier: ^17.0.2
         version: 17.8.1
+      '@evervault/card-validator':
+        specifier: workspace:*
+        version: link:../card-validator
       '@react-native/eslint-config':
         specifier: ^0.72.2
         version: 0.72.2(eslint@8.55.0)(jest@28.1.3(@types/node@18.19.26)(ts-node@10.9.2(@swc/core@1.4.11)(@types/node@20.5.1)(typescript@5.4.5)))(prettier@2.8.8)(typescript@5.4.5)
@@ -437,9 +440,15 @@ importers:
       release-it:
         specifier: ^16.1.3
         version: 16.3.0(typescript@5.4.5)
+      shared:
+        specifier: workspace:*
+        version: link:../shared
       turbo:
         specifier: ^1.10.7
         version: 1.13.0
+      types:
+        specifier: workspace:*
+        version: link:../types
       typescript:
         specifier: ^5.3.3
         version: 5.4.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -386,9 +386,6 @@ importers:
       '@commitlint/config-conventional':
         specifier: ^17.0.2
         version: 17.8.1
-      '@evervault/card-validator':
-        specifier: workspace:*
-        version: link:../card-validator
       '@react-native/eslint-config':
         specifier: ^0.72.2
         version: 0.72.2(eslint@8.55.0)(jest@28.1.3(@types/node@18.19.26)(ts-node@10.9.2(@swc/core@1.4.11)(@types/node@20.5.1)(typescript@5.4.5)))(prettier@2.8.8)(typescript@5.4.5)
@@ -440,15 +437,9 @@ importers:
       release-it:
         specifier: ^16.1.3
         version: 16.3.0(typescript@5.4.5)
-      shared:
-        specifier: workspace:*
-        version: link:../shared
       turbo:
         specifier: ^1.10.7
         version: 1.13.0
-      types:
-        specifier: workspace:*
-        version: link:../types
       typescript:
         specifier: ^5.3.3
         version: 5.4.5
@@ -530,10 +521,10 @@ importers:
         version: 18.3.0
       jest:
         specifier: ^29.2.1
-        version: 29.7.0(@types/node@18.19.26)(ts-node@10.9.2(@types/node@18.19.26)(typescript@5.3.3))
+        version: 29.7.0(@types/node@18.19.26)(ts-node@10.9.2(@swc/core@1.4.11)(@types/node@18.19.26)(typescript@5.3.3))
       jest-expo:
         specifier: ~51.0.2
-        version: 51.0.2(@babel/core@7.23.5)(jest@29.7.0(@types/node@18.19.26)(ts-node@10.9.2(@types/node@18.19.26)(typescript@5.3.3)))(react@18.2.0)
+        version: 51.0.2(@babel/core@7.23.5)(jest@29.7.0(@types/node@18.19.26)(ts-node@10.9.2(@swc/core@1.4.11)(@types/node@18.19.26)(typescript@5.3.3)))(react@18.2.0)
       react-test-renderer:
         specifier: 18.2.0
         version: 18.2.0(react@18.2.0)
@@ -12275,7 +12266,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@18.19.26)(typescript@5.3.3))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.4.11)(@types/node@18.19.26)(typescript@5.3.3))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -12289,7 +12280,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@18.19.26)(ts-node@10.9.2(@types/node@18.19.26)(typescript@5.3.3))
+      jest-config: 29.7.0(@types/node@18.19.26)(ts-node@10.9.2(@swc/core@1.4.11)(@types/node@18.19.26)(typescript@5.3.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -15180,13 +15171,13 @@ snapshots:
 
   crc-32@1.2.2: {}
 
-  create-jest@29.7.0(@types/node@18.19.26)(ts-node@10.9.2(@types/node@18.19.26)(typescript@5.3.3)):
+  create-jest@29.7.0(@types/node@18.19.26)(ts-node@10.9.2(@swc/core@1.4.11)(@types/node@18.19.26)(typescript@5.3.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@18.19.26)(ts-node@10.9.2(@types/node@18.19.26)(typescript@5.3.3))
+      jest-config: 29.7.0(@types/node@18.19.26)(ts-node@10.9.2(@swc/core@1.4.11)(@types/node@18.19.26)(typescript@5.3.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -17664,16 +17655,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@18.19.26)(ts-node@10.9.2(@types/node@18.19.26)(typescript@5.3.3)):
+  jest-cli@29.7.0(@types/node@18.19.26)(ts-node@10.9.2(@swc/core@1.4.11)(@types/node@18.19.26)(typescript@5.3.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@18.19.26)(typescript@5.3.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.4.11)(@types/node@18.19.26)(typescript@5.3.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@18.19.26)(ts-node@10.9.2(@types/node@18.19.26)(typescript@5.3.3))
+      create-jest: 29.7.0(@types/node@18.19.26)(ts-node@10.9.2(@swc/core@1.4.11)(@types/node@18.19.26)(typescript@5.3.3))
       exit: 0.1.2
       import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@18.19.26)(ts-node@10.9.2(@types/node@18.19.26)(typescript@5.3.3))
+      jest-config: 29.7.0(@types/node@18.19.26)(ts-node@10.9.2(@swc/core@1.4.11)(@types/node@18.19.26)(typescript@5.3.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -17713,7 +17704,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  jest-config@29.7.0(@types/node@18.19.26)(ts-node@10.9.2(@types/node@18.19.26)(typescript@5.3.3)):
+  jest-config@29.7.0(@types/node@18.19.26)(ts-node@10.9.2(@swc/core@1.4.11)(@types/node@18.19.26)(typescript@5.3.3)):
     dependencies:
       '@babel/core': 7.23.5
       '@jest/test-sequencer': 29.7.0
@@ -17739,7 +17730,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 18.19.26
-      ts-node: 10.9.2(@types/node@18.19.26)(typescript@5.3.3)
+      ts-node: 10.9.2(@swc/core@1.4.11)(@types/node@18.19.26)(typescript@5.3.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -17815,7 +17806,7 @@ snapshots:
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
-  jest-expo@51.0.2(@babel/core@7.23.5)(jest@29.7.0(@types/node@18.19.26)(ts-node@10.9.2(@types/node@18.19.26)(typescript@5.3.3)))(react@18.2.0):
+  jest-expo@51.0.2(@babel/core@7.23.5)(jest@29.7.0(@types/node@18.19.26)(ts-node@10.9.2(@swc/core@1.4.11)(@types/node@18.19.26)(typescript@5.3.3)))(react@18.2.0):
     dependencies:
       '@expo/config': 9.0.2
       '@expo/json-file': 8.3.3
@@ -17824,7 +17815,7 @@ snapshots:
       find-up: 5.0.0
       jest-environment-jsdom: 29.7.0
       jest-watch-select-projects: 2.0.0
-      jest-watch-typeahead: 2.2.1(jest@29.7.0(@types/node@18.19.26)(ts-node@10.9.2(@types/node@18.19.26)(typescript@5.3.3)))
+      jest-watch-typeahead: 2.2.1(jest@29.7.0(@types/node@18.19.26)(ts-node@10.9.2(@swc/core@1.4.11)(@types/node@18.19.26)(typescript@5.3.3)))
       json5: 2.2.3
       lodash: 4.17.21
       react-test-renderer: 18.2.0(react@18.2.0)
@@ -18184,11 +18175,11 @@ snapshots:
       chalk: 3.0.0
       prompts: 2.4.2
 
-  jest-watch-typeahead@2.2.1(jest@29.7.0(@types/node@18.19.26)(ts-node@10.9.2(@types/node@18.19.26)(typescript@5.3.3))):
+  jest-watch-typeahead@2.2.1(jest@29.7.0(@types/node@18.19.26)(ts-node@10.9.2(@swc/core@1.4.11)(@types/node@18.19.26)(typescript@5.3.3))):
     dependencies:
       ansi-escapes: 6.2.1
       chalk: 4.1.2
-      jest: 29.7.0(@types/node@18.19.26)(ts-node@10.9.2(@types/node@18.19.26)(typescript@5.3.3))
+      jest: 29.7.0(@types/node@18.19.26)(ts-node@10.9.2(@swc/core@1.4.11)(@types/node@18.19.26)(typescript@5.3.3))
       jest-regex-util: 29.6.3
       jest-watcher: 29.7.0
       slash: 5.1.0
@@ -18241,12 +18232,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@18.19.26)(ts-node@10.9.2(@types/node@18.19.26)(typescript@5.3.3)):
+  jest@29.7.0(@types/node@18.19.26)(ts-node@10.9.2(@swc/core@1.4.11)(@types/node@18.19.26)(typescript@5.3.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@18.19.26)(typescript@5.3.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.4.11)(@types/node@18.19.26)(typescript@5.3.3))
       '@jest/types': 29.6.3
       import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@18.19.26)(ts-node@10.9.2(@types/node@18.19.26)(typescript@5.3.3))
+      jest-cli: 29.7.0(@types/node@18.19.26)(ts-node@10.9.2(@swc/core@1.4.11)(@types/node@18.19.26)(typescript@5.3.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -21528,6 +21519,27 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
+  ts-node@10.9.2(@swc/core@1.4.11)(@types/node@18.19.26)(typescript@5.3.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 18.19.26
+      acorn: 8.11.3
+      acorn-walk: 8.3.2
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.3.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.4.11
+    optional: true
+
   ts-node@10.9.2(@swc/core@1.4.11)(@types/node@18.19.26)(typescript@5.4.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -21587,25 +21599,6 @@ snapshots:
       yn: 3.1.1
     optionalDependencies:
       '@swc/core': 1.4.11
-    optional: true
-
-  ts-node@10.9.2(@types/node@18.19.26)(typescript@5.3.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.11
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 18.19.26
-      acorn: 8.11.3
-      acorn-walk: 8.3.2
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.3.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
     optional: true
 
   tsconfig-paths@3.14.2:


### PR DESCRIPTION
# Why
changeset didn't apply previously and release never happened. We actually want to publish this again now that we can't use shared packages in react native

# How
add back the distribution stuff to package.json 
