### PR TITLE
Eoin/support field types

### DIFF
--- a/.changeset/six-glasses-deliver.md
+++ b/.changeset/six-glasses-deliver.md
@@ -1,0 +1,5 @@
+---
+"@evervault/ui-components": minor
+---
+
+Add validation to ui components forms

--- a/packages/ui-components/src/Form/index.tsx
+++ b/packages/ui-components/src/Form/index.tsx
@@ -6,7 +6,7 @@ import type {EvervaultFrameHostMessages, FormFrameClientMessages} from "types";
 
 type InputRenderer = (name: string, type: string, required: boolean) => JSX.Element;
 type TextareaRenderer = (name: string, required: boolean) => JSX.Element;
-type SelectRenderer = (name: string, options: { value: string, label: string }[]) => JSX.Element;
+type SelectRenderer = (name: string, options: { value: string }[]) => JSX.Element;
 type FieldRenderer = InputRenderer | TextareaRenderer | SelectRenderer;
 
 const fieldRenderers: Record<string, FieldRenderer> = {
@@ -22,7 +22,7 @@ const fieldRenderers: Record<string, FieldRenderer> = {
       <textarea name={name} id={name} required={required}></textarea>
     </div>
   ),
-  select: (name: string, options: { value: string, label: string }[]) => (
+  select: (name: string, options: { value: string }[]) => (
     <div key={name}>
       <label htmlFor={name}>{name}</label>
       <select name={name} id={name}>

--- a/packages/ui-components/src/Form/types.ts
+++ b/packages/ui-components/src/Form/types.ts
@@ -11,6 +11,8 @@ export interface FormElement {
     elementName: string;
     elementType: string;
     options?: { value: string; label: string }[];
+    type?: string;
+    required: boolean;
 }
 
 export interface FormApiResponse {

--- a/packages/ui-components/src/index.css
+++ b/packages/ui-components/src/index.css
@@ -40,6 +40,16 @@ textarea {
   background: transparent;
 }
 
+select {
+  width: 100%;
+  border: none;
+  outline: none;
+  line-height: 1;
+  appearance: none;
+  font-size: inherit;
+  background: transparent;
+}
+
 [ev-component="card"] {
   gap: 10px;
   display: grid;


### PR DESCRIPTION
# Why
The API now will return the type of input element and if the html element is required. UI components should apply basic validation based on those values.

# How
- Create JSX renderers for each type
- Apply `required` and dynamic `type` attributes to the elements
- Apply same styling to `select` as `input`
