### PR TITLE
remove pnpm version from actions

### DIFF
--- a/.github/workflows/deploy-ui-components.yml
+++ b/.github/workflows/deploy-ui-components.yml
@@ -50,8 +50,6 @@ jobs:
         with:
           fetch-depth: 2
       - uses: pnpm/action-setup@v2
-        with:
-          version: 9
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -41,8 +41,6 @@ jobs:
           path: ${{ inputs.repo_path }}
 
       - uses: pnpm/action-setup@v2
-        with:
-          version: 9
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v3


### PR DESCRIPTION
# Why
pnpm is releasing a minor every day

# How
stop downloading the latest pnpm ver and use what's in package json
