### PR TITLE
Fix RN 71 android build

### DIFF
--- a/.changeset/giant-maps-tickle.md
+++ b/.changeset/giant-maps-tickle.md
@@ -1,0 +1,5 @@
+---
+"@evervault/evervault-react-native": minor
+---
+
+Fixed android builds on old react native versions

--- a/packages/react-native/android/build.gradle
+++ b/packages/react-native/android/build.gradle
@@ -92,5 +92,7 @@ dependencies {
   implementation("com.evervault.sdk:evervault-core:1.1")
   implementation("com.facebook.react:react-android:0.74.1")
   implementation("org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version")
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlin_version")
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlin_version")
 }
 

--- a/packages/react-native/android/gradle.properties
+++ b/packages/react-native/android/gradle.properties
@@ -1,4 +1,4 @@
-EvervaultSdk_kotlinVersion=1.7.0
+EvervaultSdk_kotlinVersion=1.8.0
 EvervaultSdk_minSdkVersion=21
 EvervaultSdk_targetSdkVersion=31
 EvervaultSdk_compileSdkVersion=31


### PR DESCRIPTION
# Why
Kotlinx imports failing

resolves ETR-2117
# How
Added coroutines deps, not sure why these aren't needed on react native 74
