### PR TITLE
Validate CVC when no card number present

### DIFF
--- a/.changeset/silent-worms-nail.md
+++ b/.changeset/silent-worms-nail.md
@@ -1,0 +1,5 @@
+---
+"@evervault/card-validator": patch
+---
+
+validate cvc when no card number is present

--- a/packages/card-validator/index.ts
+++ b/packages/card-validator/index.ts
@@ -107,16 +107,23 @@ export function validateCVC(
   cvc: string,
   cardNumber: string
 ): CardCVCValidationResult {
-  const validatedCard = validateNumber(cardNumber);
-  if (!validatedCard.isValid) {
+  // Check if the CVC only contains numbers with 3 or 4 digits
+  if (!/^\d{3,4}$/.test(cvc)) {
     return {
       cvc: null,
       isValid: false,
     };
   }
 
-  // Check if the CVC only contains numbers
-  if (!/^\d*$/.test(cvc)) {
+  if (!cardNumber) {
+    return {
+      cvc: cvc,
+      isValid: true,
+    };
+  }
+
+  const validatedCard = validateNumber(cardNumber);
+  if (!validatedCard.isValid) {
     return {
       cvc: null,
       isValid: false,

--- a/packages/card-validator/test/validate-cvc.test.ts
+++ b/packages/card-validator/test/validate-cvc.test.ts
@@ -51,13 +51,37 @@ const testCases: TestCase[] = [
     cardNumber: "378282246310005",
     cvc: "1234",
     expectedResult: { cvc: "1234", isValid: true },
-  }
+  },
+  {
+    scope: "Valid CVC Mastercard with no card number",
+    cardNumber: "",
+    cvc: "123",
+    expectedResult: { cvc: "123", isValid: true },
+  },
+  {
+    scope: "Valid CVC Amex with no card number",
+    cardNumber: "",
+    cvc: "1234",
+    expectedResult: { cvc: "1234", isValid: true },
+  },
+  {
+    scope: "2 digit CVC",
+    cardNumber: "",
+    cvc: "12",
+    expectedResult: { cvc: null, isValid: false },
+  },
+  {
+    scope: "5 digit CVC",
+    cardNumber: "",
+    cvc: "12345",
+    expectedResult: { cvc: null, isValid: false },
+  },
 ];
 
 describe('validateCvc function tests', () => {
   testCases.forEach(({ scope, cardNumber, cvc, expectedResult }) => {
     describe(`${scope}`, () => {
-      it(`should validate the expiry`, () => {
+      it(`should validate the cvc`, () => {
         const result = validateCVC(cvc, cardNumber);
         expect(result).toEqual(expectedResult);
       });


### PR DESCRIPTION
# Why
A `Card` could be used to collect only CVC, in which case the type of the card should not be considered

# How
When no card number is present, only check that CVC is a 3 or 4 digit number
