### PR TITLE
Cleanup environment variables and tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,21 +1,11 @@
-# Team and app uuid for the SDK to download the public key
-EV_TEAM_UUID=
-EV_APP_UUID=
-VITE_EV_TEAM_UUID=$EV_TEAM_UUID
-VITE_EV_APP_UUID=$EV_APP_UUID
-
-# URLs for
+VITE_REVEAL_ENDPOINT=
+EV_API_KEY=
+VITE_EV_TEAM_UUID=
+VITE_EV_APP_UUID=
 VITE_KEYS_URL=https://keys.evervault.com
 VITE_API_URL=https://api.evervault.com
 VITE_UI_COMPONENTS_URL=http://localhost:4001
 VITE_EVERVAULT_JS_URL=http://localhost:4002/evervault-browser.main.umd.cjs
-VITE_FORM_UUID=form_
+VITE_REVEAL_ENDPOINT=https://blackhole-posterior-io-app-aae186edee7d.relay.evervault.io/kb2f9d
+VITE_UI_INPUTS_URL=http://localhost:4003
 
-# API key is useed in some e2e tests
-EV_API_KEY=
-
-# Scoped API Key for running the evervault decrypt function
-EV_DECRYPT_FN_KEY=
-
-# Endpont for reveal examples
-VITE_REVEAL_ENDPOINT=

--- a/e2e-apps/browser/package.json
+++ b/e2e-apps/browser/package.json
@@ -7,6 +7,7 @@
     "pnpm": "~9"
   },
   "scripts": {
+		"start": "vite",
     "build": "vite build",
     "format": "prettier --write .",
     "format:check": "prettier --check ."

--- a/e2e-apps/browser/src/scaffold-test-object.js
+++ b/e2e-apps/browser/src/scaffold-test-object.js
@@ -30,8 +30,9 @@ encryptForm.addEventListener("submit", async (e) => {
     unencrypted: objectToEncrypt,
   };
 
-  const result = await fetch("/api/test_decryption", {
+  const result = await fetch("http://localhost:3010/api/test_decryption", {
     method: "POST",
+    credentials: "omit",
     headers: {
       "Content-Type": "application/json",
     },

--- a/e2e-apps/browser/src/scaffold-test-single.js
+++ b/e2e-apps/browser/src/scaffold-test-single.js
@@ -23,7 +23,7 @@ encryptForm.addEventListener("submit", async (e) => {
     unencrypted: value,
   };
 
-  const result = await fetch("/api/test_decryption", {
+  const result = await fetch("http://localhost:3010/api/test_decryption", {
     method: "POST",
     mode: "cors",
     headers: {
@@ -32,14 +32,17 @@ encryptForm.addEventListener("submit", async (e) => {
     body: JSON.stringify(fnPlayload),
   });
 
-  const resultToken = await fetch("/api/create-decrypt-token", {
-    method: "POST",
-    mode: "cors",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(tokenPayload),
-  });
+  const resultToken = await fetch(
+    "http://localhost:3010/api/create-decrypt-token",
+    {
+      method: "POST",
+      mode: "cors",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(tokenPayload),
+    }
+  );
   const parsedTokenResponse = await resultToken.json();
   const decryptTokenResponse = await ev.decrypt(
     parsedTokenResponse,

--- a/e2e-tests/browser/package.json
+++ b/e2e-tests/browser/package.json
@@ -4,7 +4,7 @@
   "name": "@evervault/browser-e2e-tests",
   "scripts": {
     "dev:test": "playwright test",
-    "e2e:test": "start-server-and-test \"(cd ../../e2e-apps/decrypt-backend && pnpm run start)\" http://localhost:3010 \"playwright test\"",
+    "e2e:test": "playwright test",
     "format": "prettier --write .",
     "format:check": "prettier --check ."
   },

--- a/e2e-tests/browser/playwright.config.ts
+++ b/e2e-tests/browser/playwright.config.ts
@@ -1,10 +1,11 @@
+import dotenv from "dotenv";
 import { defineConfig, devices } from "@playwright/test";
 
 /**
  * Read environment variables from file.
  * https://github.com/motdotla/dotenv
  */
-// require('dotenv').config();
+dotenv.config({ path: "../../.env" });
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -83,8 +84,18 @@ export default defineConfig({
   // outputDir: 'test-results/',
 
   /* Run your local dev server before starting the tests */
-  // webServer: {
-  //   command: 'npm run test-serve',
-  //   port: 3000,
-  // },
+  webServer: [
+    {
+      command: "pnpm --filter @evervault/browser-e2e-app start --port=3005",
+      port: 3005,
+      reuseExistingServer: !process.env.CI,
+    },
+    {
+      command: "pnpm --filter @evervault/e2e-decrypt-backend start",
+      port: 3010,
+      reuseExistingServer: !process.env.CI,
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+  ],
 });

--- a/e2e-tests/browser/tests/basic.spec.ts
+++ b/e2e-tests/browser/tests/basic.spec.ts
@@ -1,14 +1,14 @@
 import { test, expect } from "@playwright/test";
 import * as dotenv from "dotenv";
 
-dotenv.config();
+dotenv.config({ path: "../../.env" });
 
 const encryptedStringRegex =
   /((ev(:|%3A))(debug(:|%3A))?(([A-z0-9+/=%]+)(:|%3A))?((number|boolean|string)(:|%3A))?(([A-z0-9+/=%]+)(:|%3A)){3}(\$|%24))|(((eyJ[A-z0-9+=.]+){2})([\w]{8}(-[\w]{4}){3}-[\w]{12}))/;
 
 test("encrypts a string", async ({ page }) => {
   await page.goto(
-    `http://localhost:3010/?team=${process.env.EV_TEAM_UUID}&app=${process.env.EV_APP_UUID}`
+    `http://localhost:3005/?team=${process.env.VITE_EV_TEAM_UUID}&app=${process.env.VITE_EV_APP_UUID}`
   );
 
   const output = await page.getByTestId("ev-encrypt-output");
@@ -25,7 +25,7 @@ test("encrypts a string", async ({ page }) => {
 
 test("encrypts an object", async ({ page }) => {
   await page.goto(
-    `http://localhost:3010/object_test?team=${process.env.EV_TEAM_UUID}&app=${process.env.EV_APP_UUID}`
+    `http://localhost:3005/object_test.html?team=${process.env.VITE_EV_TEAM_UUID}&app=${process.env.VITE_EV_APP_UUID}`
   );
 
   const output = await page.getByTestId("ev-encrypt-output");

--- a/e2e-tests/inputs/playwright.config.js
+++ b/e2e-tests/inputs/playwright.config.js
@@ -1,4 +1,6 @@
 import { defineConfig, devices } from "@playwright/test";
+import dotenv from "dotenv";
+dotenv.config({ path: "../../.env" });
 
 /**
  * Read environment variables from file.

--- a/e2e-tests/ui-components/playwright.config.js
+++ b/e2e-tests/ui-components/playwright.config.js
@@ -1,4 +1,6 @@
 import { defineConfig, devices } from "@playwright/test";
+import dotenv from "dotenv";
+dotenv.config({ path: "../../.env" });
 
 /**
  * Read environment variables from file.

--- a/e2e-tests/ui-components/tests/reveal.spec.js
+++ b/e2e-tests/ui-components/tests/reveal.spec.js
@@ -6,7 +6,9 @@ test.describe("reveal", () => {
     await page.waitForFunction(() => window.Evervault);
     // Create a window function for creating a decrypt request inside of the page. This is just a
     // helper to prevent having to have this code in every test.
-    const auth = btoa(process.env.EV_APP_UUID + ":" + process.env.EV_API_KEY);
+    const auth = btoa(
+      process.env.VITE_EV_APP_UUID + ":" + process.env.EV_API_KEY
+    );
     await page.evaluate(
       ([authToken, apiUrl]) => {
         window.decryptRequest = (data) =>
@@ -141,7 +143,9 @@ test.describe("reveal", () => {
 });
 
 async function encryptWithAPI(data) {
-  const auth = btoa(process.env.EV_APP_UUID + ":" + process.env.EV_API_KEY);
+  const auth = btoa(
+    process.env.VITE_EV_APP_UUID + ":" + process.env.EV_API_KEY
+  );
   const response = await fetch(`${process.env.VITE_API_URL}/encrypt`, {
     method: "POST",
     headers: {

--- a/packages/browser/vite.config.mts
+++ b/packages/browser/vite.config.mts
@@ -1,6 +1,9 @@
 import { resolve } from "node:path";
+import dotenv from "dotenv";
 import dts from "vite-plugin-dts";
 import { defineConfig } from "vitest/config";
+
+dotenv.config({ path: "../../.env" });
 
 export default defineConfig({
   server: {


### PR DESCRIPTION
Our tests are in need of a bit of love and have started failing both in CI and locally. We also have some duplication of environment variables which makes configuring the repo locally painful.

- Removes duplicate environment variables
- Always source the root `.env` when running tests so that they will work whether you are running them from root or inside of the package.
- Fix browser tests