### PR TITLE
Add version key to test packages

### DIFF
--- a/e2e-apps/browser/package.json
+++ b/e2e-apps/browser/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "name": "@evervault/browser-e2e-app",
+	"version": "1.0.0",
   "engines": {
     "node": "~18",
     "pnpm": "~9"

--- a/e2e-apps/decrypt-backend/package.json
+++ b/e2e-apps/decrypt-backend/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "name": "@evervault/e2e-decrypt-backend",
+  "version": "1.0.0",
   "engines": {
     "node": "~18",
     "pnpm": "~9"

--- a/e2e-tests/browser/package.json
+++ b/e2e-tests/browser/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "name": "@evervault/browser-e2e-tests",
+	"version": "1.0.0",
   "scripts": {
     "dev:test": "playwright test",
     "e2e:test": "playwright test",

--- a/e2e-tests/inputs/package.json
+++ b/e2e-tests/inputs/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "name": "@evervault/inputs-e2e-tests",
+	"version": "1.0.0",
   "scripts": {
     "dev:test": "playwright test",
     "e2e:test": "start-server-and-test \"(cd ../../packages/inputs && pnpm run preview)\" http://localhost:4173/v2/ \"playwright test\""

--- a/e2e-tests/ui-components/package.json
+++ b/e2e-tests/ui-components/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "name": "@evervault/ui-components-e2e-tests",
+  "version": "1.0.0",
   "scripts": {
     "e2e:test": "playwright test"
   },


### PR DESCRIPTION
Turbo requires either no version key, or a valid version key. However, if no version key is set, then changeset adds "version": null which is an invalid version.
