### PR TITLE
Skip husky hooks for change set action

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -87,6 +87,7 @@ jobs:
         with:
           version: pnpm run version
         env:
+          HUSKY: 0
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Tags


### PR DESCRIPTION
Change set is doing a push which is triggering husky to run all the linting