### PR TITLE
Remove spaces from CC Num before encryption

### DIFF
--- a/.changeset/sweet-baboons-remain.md
+++ b/.changeset/sweet-baboons-remain.md
@@ -1,0 +1,5 @@
+---
+"@evervault/evervault-react-native": patch
+---
+
+Strip spaces from card number before encryption

--- a/packages/react-native/src/components/Card/utilities.ts
+++ b/packages/react-native/src/components/Card/utilities.ts
@@ -12,7 +12,10 @@ export async function changePayload(
   form: UseFormReturn<CardForm>,
   fields: CardField[]
 ): Promise<CardPayload> {
-  const { name, number, expiry, cvc } = form.values;
+  const { name, number: rawNumber, expiry, cvc } = form.values;
+
+  const number = rawNumber.replace(/\s/g, '');
+
   const {
     brand,
     localBrands,


### PR DESCRIPTION
# Why
Causing issues with payment processors

# How
Remove spaces before encryption occurs
