### PR TITLE
Add autoProgress option to Card component

### DIFF
--- a/.changeset/chilled-spiders-give.md
+++ b/.changeset/chilled-spiders-give.md
@@ -1,0 +1,8 @@
+---
+"@evervault/ui-components": minor
+"@evervault/browser": minor
+"@evervault/react": minor
+"types": minor
+---
+
+Add autoProgress option to Card component to automatically progress to the next input when an input becomes valid.

--- a/packages/browser/lib/ui/card.ts
+++ b/packages/browser/lib/ui/card.ts
@@ -59,6 +59,7 @@ export default class Card {
         fields: this.#options.fields,
         acceptedBrands: this.#options.acceptedBrands,
         autoComplete: this.#options.autoComplete,
+        autoProgress: this.#options.autoProgress,
       },
     };
   }

--- a/packages/react/lib/ui/Card.tsx
+++ b/packages/react/lib/ui/Card.tsx
@@ -22,6 +22,7 @@ export interface CardProps {
   onChange?: (data: CardPayload) => void;
   onComplete?: (data: CardPayload) => void;
   autoComplete?: CardOptions["autoComplete"];
+  autoProgress?: boolean;
 }
 
 type CardClass = ReturnType<Evervault["ui"]["card"]>;
@@ -37,6 +38,7 @@ export function Card({
   onChange,
   onComplete,
   autoComplete,
+  autoProgress,
 }: CardProps) {
   const ev = useEvervault();
   const initialized = useRef(false);
@@ -80,8 +82,9 @@ export function Card({
       autoFocus,
       translations,
       autoComplete,
+      autoProgress,
     }),
-    [theme, translations, fields, autoFocus, autoComplete]
+    [theme, translations, fields, autoFocus, autoComplete, autoProgress]
   );
 
   useLayoutEffect(() => {

--- a/packages/types/uiComponents.ts
+++ b/packages/types/uiComponents.ts
@@ -92,6 +92,7 @@ export interface CardOptions {
   fields?: CardField[];
   acceptedBrands?: CardBrandName[];
   translations?: Partial<CardTranslations>;
+  autoProgress?: boolean;
   autoComplete?: {
     name?: boolean;
     number?: boolean;

--- a/packages/ui-components/src/Card/index.tsx
+++ b/packages/ui-components/src/Card/index.tsx
@@ -16,7 +16,12 @@ import { CardHolder } from "./CardHolder";
 import { CardNumber } from "./CardNumber";
 import { DEFAULT_TRANSLATIONS } from "./translations";
 import { useCardReader } from "./useCardReader";
-import { changePayload, isAcceptedBrand, swipePayload } from "./utilities";
+import {
+  autoProgress,
+  changePayload,
+  isAcceptedBrand,
+  swipePayload,
+} from "./utilities";
 import type { CardForm, CardConfig } from "./types";
 import type { CardFrameClientMessages, CardFrameHostMessages } from "types";
 
@@ -95,6 +100,10 @@ export function Card({ config }: { config: CardConfig }) {
       },
     },
     onChange: (formState) => {
+      if (config?.autoProgress) {
+        autoProgress(formState);
+      }
+
       const triggerChange = async () => {
         if (!ev) return;
         const cardData = await changePayload(ev, formState, fields);

--- a/packages/ui-components/src/Card/types.ts
+++ b/packages/ui-components/src/Card/types.ts
@@ -12,6 +12,7 @@ export interface CardConfig {
   fields?: CardField[];
   acceptedBrands?: CardBrandName[];
   translations?: Partial<CardTranslations>;
+  autoProgress?: boolean;
   autoComplete?: {
     name?: boolean;
     number?: boolean;

--- a/packages/ui-components/src/Card/utilities.ts
+++ b/packages/ui-components/src/Card/utilities.ts
@@ -41,6 +41,27 @@ export async function changePayload(
   };
 }
 
+export function autoProgress(form: UseFormReturn<CardForm>) {
+  const activeField = document.activeElement as HTMLElement;
+  if (activeField instanceof HTMLInputElement === false) return;
+
+  const field = activeField.name as CardField;
+
+  if (field === "number") {
+    const { isValid } = validateNumber(form.values.number);
+    if (isValid) {
+      document.getElementById("expiry")?.focus();
+    }
+  }
+
+  if (field === "expiry") {
+    const { isValid } = validateExpiry(form.values.expiry);
+    if (isValid) {
+      document.getElementById("cvc")?.focus();
+    }
+  }
+}
+
 function isComplete(form: UseFormReturn<CardForm>, fields: CardField[]) {
   if (fields.includes("name")) {
     if (form.values.name.length === 0) return false;


### PR DESCRIPTION
Some users want functionality to automatically progress the browser focus to the next input when filling out card details. This adds a new `autoProgress` option to the `Card` component. When filling out a card number, if they enter a valid card number, the browser focus will move to the expiry field. The same applies to the expiry field, when it is valid, the focus moves to the cvc.

```js
ev.ui.card({ autoProgress: true })
```