### PR TITLE
Synchronously update session outcome before unmounting 3DS frame

### DIFF
--- a/packages/browser/lib/ui/threeDSecure.ts
+++ b/packages/browser/lib/ui/threeDSecure.ts
@@ -67,7 +67,7 @@ export default class ThreeDSecure {
     this.#events.dispatch(outcome === "success" ? "success" : "failure");
     this.unmount();
   }
-  
+
   async #updateOutcome(outcome: string, cres?: string | null): Promise<void> {
     const api = this.#client.config.http.apiUrl;
     await fetch(`${api}/frontend/3ds/browser-sessions/${this.#session}`, {

--- a/packages/browser/lib/ui/threeDSecure.ts
+++ b/packages/browser/lib/ui/threeDSecure.ts
@@ -39,22 +39,22 @@ export default class ThreeDSecure {
     this.#frame = new EvervaultFrame(client, "ThreeDSecure");
     this.#client = client;
 
-    this.#frame.on("EV_SUCCESS", (cres) => {
+    this.#frame.on("EV_SUCCESS", async (cres) => {
+      await this.#updateOutcome("success", cres);
       this.#events.dispatch("success");
       this.unmount();
-      this.#updateOutcome("success", cres);
     });
 
-    this.#frame.on("EV_FAILURE", (cres) => {
+    this.#frame.on("EV_FAILURE", async (cres) => {
+      await this.#updateOutcome("failure", cres);
       this.#events.dispatch("failure");
       this.unmount();
-      this.#updateOutcome("failure", cres);
     });
 
-    this.#frame.on("EV_CANCEL", () => {
+    this.#frame.on("EV_CANCEL", async () => {
+      await this.#updateOutcome("cancelled");
       this.#events.dispatch("failure");
       this.unmount();
-      this.#updateOutcome("cancelled");
     });
 
     this.#frame.on("EV_FRAME_READY", () => {
@@ -68,9 +68,9 @@ export default class ThreeDSecure {
     });
   }
 
-  #updateOutcome(outcome: string, cres?: string | null) {
+  async #updateOutcome(outcome: string, cres?: string | null): Promise<void> {
     const api = this.#client.config.http.apiUrl;
-    void fetch(`${api}/frontend/3ds/browser-sessions/${this.#session}`, {
+    await fetch(`${api}/frontend/3ds/browser-sessions/${this.#session}`, {
       method: "PATCH",
       headers: {
         "X-Evervault-App-Id": this.#client.config.appId,

--- a/packages/browser/lib/ui/threeDSecure.ts
+++ b/packages/browser/lib/ui/threeDSecure.ts
@@ -39,22 +39,25 @@ export default class ThreeDSecure {
     this.#frame = new EvervaultFrame(client, "ThreeDSecure");
     this.#client = client;
 
-    this.#frame.on("EV_SUCCESS", async (cres) => {
-      void await this.#updateOutcome("success", cres);
-      this.#events.dispatch("success");
-      this.unmount();
+    this.#frame.on("EV_SUCCESS", (cres) => {
+      this.#updateOutcome("success", cres).then(() => {
+        this.#events.dispatch("success");
+        this.unmount();  
+      });
     });
 
-    this.#frame.on("EV_FAILURE", async (cres) => {
-      void await this.#updateOutcome("failure", cres);
-      this.#events.dispatch("failure");
-      this.unmount();
+    this.#frame.on("EV_FAILURE", (cres) => {
+      this.#updateOutcome("failure", cres).then(() => {
+        this.#events.dispatch("failure");
+        this.unmount();
+      });
     });
 
-    this.#frame.on("EV_CANCEL", async () => {
-      void await this.#updateOutcome("cancelled");
-      this.#events.dispatch("failure");
-      this.unmount();
+    this.#frame.on("EV_CANCEL", () => {
+      this.#updateOutcome("cancelled").then(() => {
+        this.#events.dispatch("failure");
+        this.unmount();  
+      });
     });
 
     this.#frame.on("EV_FRAME_READY", () => {

--- a/packages/browser/lib/ui/threeDSecure.ts
+++ b/packages/browser/lib/ui/threeDSecure.ts
@@ -42,7 +42,7 @@ export default class ThreeDSecure {
     this.#frame.on("EV_SUCCESS", (cres) => {
       this.#updateOutcome("success", cres).then(() => {
         this.#events.dispatch("success");
-        this.unmount();  
+        this.unmount();
       });
     });
 
@@ -56,7 +56,7 @@ export default class ThreeDSecure {
     this.#frame.on("EV_CANCEL", () => {
       this.#updateOutcome("cancelled").then(() => {
         this.#events.dispatch("failure");
-        this.unmount();  
+        this.unmount();
       });
     });
 

--- a/packages/browser/lib/ui/threeDSecure.ts
+++ b/packages/browser/lib/ui/threeDSecure.ts
@@ -40,19 +40,19 @@ export default class ThreeDSecure {
     this.#client = client;
 
     this.#frame.on("EV_SUCCESS", async (cres) => {
-      await this.#updateOutcome("success", cres);
+      void await this.#updateOutcome("success", cres);
       this.#events.dispatch("success");
       this.unmount();
     });
 
     this.#frame.on("EV_FAILURE", async (cres) => {
-      await this.#updateOutcome("failure", cres);
+      void await this.#updateOutcome("failure", cres);
       this.#events.dispatch("failure");
       this.unmount();
     });
 
     this.#frame.on("EV_CANCEL", async () => {
-      await this.#updateOutcome("cancelled");
+      void await this.#updateOutcome("cancelled");
       this.#events.dispatch("failure");
       this.unmount();
     });

--- a/packages/browser/lib/ui/threeDSecure.ts
+++ b/packages/browser/lib/ui/threeDSecure.ts
@@ -40,24 +40,15 @@ export default class ThreeDSecure {
     this.#client = client;
 
     this.#frame.on("EV_SUCCESS", (cres) => {
-      this.#updateOutcome("success", cres).then(() => {
-        this.#events.dispatch("success");
-        this.unmount();
-      });
+      void this.#handleOutcome("success", cres);
     });
 
     this.#frame.on("EV_FAILURE", (cres) => {
-      this.#updateOutcome("failure", cres).then(() => {
-        this.#events.dispatch("failure");
-        this.unmount();
-      });
+      void this.#handleOutcome("failure", cres);
     });
 
     this.#frame.on("EV_CANCEL", () => {
-      this.#updateOutcome("cancelled").then(() => {
-        this.#events.dispatch("failure");
-        this.unmount();
-      });
+      void this.#handleOutcome("cancelled");
     });
 
     this.#frame.on("EV_FRAME_READY", () => {
@@ -71,6 +62,12 @@ export default class ThreeDSecure {
     });
   }
 
+  async #handleOutcome(outcome: string, cres?: string | null) {
+    await this.#updateOutcome(outcome, cres);
+    this.#events.dispatch(outcome === "success" ? "success" : "failure");
+    this.unmount();
+  }
+  
   async #updateOutcome(outcome: string, cres?: string | null): Promise<void> {
     const api = this.#client.config.http.apiUrl;
     await fetch(`${api}/frontend/3ds/browser-sessions/${this.#session}`, {


### PR DESCRIPTION
# Why
It is crucial to ensure that the session outcome is fully saved before unmounting the frame and dispatching the completion event. Failing to do so previously caused a race condition, where users could access session data before it was fully finalised.

# How
This PR makes the request to update the session outcome synchronous.
