### PR TITLE
Add validate event

### DIFF
--- a/.changeset/wild-apes-mate.md
+++ b/.changeset/wild-apes-mate.md
@@ -1,0 +1,6 @@
+---
+"@evervault/ui-components": minor
+"@evervault/browser": minor
+---
+
+Add 'validate' event to card components

--- a/examples/collect-card-details/src/main.ts
+++ b/examples/collect-card-details/src/main.ts
@@ -24,6 +24,10 @@ card.on("swipe", (values) => {
   console.log("swipe", values);
 });
 
+card.on("validate", (values) => {
+  console.log("validate", values);
+});
+
 card.mount("#form");
 
 const btn = document.getElementById("purchase");

--- a/examples/collect-card-details/src/main.ts
+++ b/examples/collect-card-details/src/main.ts
@@ -38,7 +38,7 @@ btn?.addEventListener("click", () => {
   output.innerText = "";
   card.validate();
 
-  if (card.values?.isValid) {
+  if (card.values.isComplete) {
     console.log("Valid!", card.values);
     const { number, expiry, cvc } = card.values.card;
     output.innerHTML += "Thank you for your purchase! <br /><br />";

--- a/packages/browser/lib/ui/card.ts
+++ b/packages/browser/lib/ui/card.ts
@@ -20,7 +20,7 @@ interface CardEvents {
 }
 
 export default class Card {
-  values?: CardPayload;
+  values: CardPayload;
   #options: CardOptions;
   #frame: EvervaultFrame<CardFrameClientMessages, CardFrameHostMessages>;
 
@@ -48,6 +48,22 @@ export default class Card {
     this.#frame.on("EV_FRAME_READY", () => {
       this.#events.dispatch("ready");
     });
+
+    this.values = {
+      card: {
+        name: null,
+        brand: null,
+        localBrands: [],
+        bin: null,
+        lastFour: null,
+        number: null,
+        expiry: { month: null, year: null },
+        cvc: null,
+      },
+      isValid: true,
+      isComplete: false,
+      errors: null,
+    };
   }
 
   get config() {

--- a/packages/browser/lib/ui/card.ts
+++ b/packages/browser/lib/ui/card.ts
@@ -16,6 +16,7 @@ interface CardEvents {
   change: (payload: CardPayload) => void;
   complete: (payload: CardPayload) => void;
   swipe: (payload: SwipedCard) => void;
+  validate: (payload: CardPayload) => void;
 }
 
 export default class Card {
@@ -94,6 +95,9 @@ export default class Card {
 
   validate() {
     this.#frame.send("EV_VALIDATE");
-    return this;
+    this.#frame.once("EV_VALIDATED", (payload) => {
+      this.values = payload;
+      this.#events.dispatch("validate", payload);
+    });
   }
 }

--- a/packages/browser/lib/ui/card.ts
+++ b/packages/browser/lib/ui/card.ts
@@ -60,7 +60,7 @@ export default class Card {
         expiry: { month: null, year: null },
         cvc: null,
       },
-      isValid: true,
+      isValid: false,
       isComplete: false,
       errors: null,
     };

--- a/packages/browser/lib/ui/card.ts
+++ b/packages/browser/lib/ui/card.ts
@@ -115,5 +115,6 @@ export default class Card {
       this.values = payload;
       this.#events.dispatch("validate", payload);
     });
+    return this;
   }
 }

--- a/packages/browser/lib/ui/evervaultFrame.ts
+++ b/packages/browser/lib/ui/evervaultFrame.ts
@@ -166,6 +166,22 @@ export class EvervaultFrame<
     return () => window.removeEventListener("message", handleMessage);
   }
 
+  once<K extends keyof ReceivableMessages>(
+    event: K,
+    callback: (message: ReceivableMessages[K]) => void
+  ) {
+    const handleMessage = (e: MessageEvent<EvervaultFrameMessageDetail>) => {
+      if (e.data.frame !== this.#id) return;
+      if (e.data.type === event) {
+        callback(e.data.payload as ReceivableMessages[K]);
+        window.removeEventListener("message", handleMessage);
+      }
+    };
+
+    window.addEventListener("message", handleMessage);
+    return () => window.removeEventListener("message", handleMessage);
+  }
+
   // The send method is used to send messages to the iframe.
   send<K extends keyof SendableMessages>(
     type: K,

--- a/packages/types/uiComponents.ts
+++ b/packages/types/uiComponents.ts
@@ -145,6 +145,7 @@ export interface CardFrameClientMessages extends EvervaultFrameClientMessages {
   EV_SWIPE: SwipedCard;
   EV_CHANGE: CardPayload;
   EV_COMPLETE: CardPayload;
+  EV_VALIDATED: CardPayload;
 }
 
 export interface CardFrameHostMessages extends EvervaultFrameHostMessages {

--- a/packages/ui-components/src/Card/index.tsx
+++ b/packages/ui-components/src/Card/index.tsx
@@ -144,9 +144,14 @@ export function Card({ config }: { config: CardConfig }) {
   useEffect(
     () =>
       on("EV_VALIDATE", () => {
-        form.validate();
+        if (!ev) return;
+
+        form.validate(async (formState) => {
+          const data = await changePayload(ev, formState, fields);
+          send("EV_VALIDATED", data);
+        });
       }),
-    [on, form]
+    [ev, on, send, form, fields]
   );
 
   const hasErrors = Object.keys(form.errors ?? {}).length > 0;

--- a/packages/ui-components/src/Card/index.tsx
+++ b/packages/ui-components/src/Card/index.tsx
@@ -146,9 +146,11 @@ export function Card({ config }: { config: CardConfig }) {
       on("EV_VALIDATE", () => {
         if (!ev) return;
 
-        form.validate(async (formState) => {
-          const data = await changePayload(ev, formState, fields);
-          send("EV_VALIDATED", data);
+        form.validate((formState) => {
+          void (async () => {
+            const data = await changePayload(ev, formState, fields);
+            send("EV_VALIDATED", data);
+          })();
         });
       }),
     [ev, on, send, form, fields]


### PR DESCRIPTION
The `validate` method on the card component can be used to manually trigger validation to display any error messages inside of the component. Due to everything having to be done via messaging in the iframe this is an async call and does not immediately provide results when called. The `validate` method was not intended to provide results but instead to simply cause any error messages to be shown, when the user hasn't interacted with the inputs. e.g Submits without filling out any details. 

It could be useful however, to provide some way for users to run logic after validation has occurred. In an ideal world, we would simply make this method return a promise which can be awaited, however, unfortunately that would be a breaking change and so isn't an option. This PR adds a new `validate` event which is fired after validation has completed and is passed the latest form state.

This also updates the `card.values` attribute to have a default empty values object instead of `undefined`