### PR TITLE
Autopad expiry field when users enter a value between 2 - 9

### DIFF
--- a/.changeset/nervous-drinks-cheat.md
+++ b/.changeset/nervous-drinks-cheat.md
@@ -1,0 +1,5 @@
+---
+"@evervault/ui-components": minor
+---
+
+Automatically pad expiry month when a user enters a number betwen 2-9

--- a/e2e-tests/ui-components/tests/cardDetails.spec.js
+++ b/e2e-tests/ui-components/tests/cardDetails.spec.js
@@ -505,4 +505,32 @@ test.describe("card component", () => {
     await expect(frame.getByText("Your card number is invalid")).toBeVisible();
     await expect.poll(async () => called).toEqual(0);
   });
+
+  test("Auto pads expiry month if value starts with a digit between 2-9", async ({
+    page,
+  }) => {
+    await page.evaluate(() => {
+      const card = window.evervault.ui.card();
+      card.mount("#form");
+    });
+
+    const frame = page.frameLocator("iframe[data-evervault]");
+    await frame.getByLabel("Expiration").fill("2");
+    await expect(frame.getByLabel("Expiration")).toHaveValue("02");
+  });
+
+  ["0", "1"].forEach((digit) => {
+    test(`Does not autopad expiry month if value starts with ${digit}`, async ({
+      page,
+    }) => {
+      await page.evaluate(() => {
+        const card = window.evervault.ui.card();
+        card.mount("#form");
+      });
+
+      const frame = page.frameLocator("iframe[data-evervault]");
+      await frame.getByLabel("Expiration").fill(digit);
+      await expect(frame.getByLabel("Expiration")).toHaveValue(digit);
+    });
+  });
 });

--- a/packages/ui-components/src/Card/CardExpiry.tsx
+++ b/packages/ui-components/src/Card/CardExpiry.tsx
@@ -20,6 +20,7 @@ const EXPIRY_BLOCKS = {
     from: 1,
     to: 12,
     maxLength: 2,
+    autofix: "pad",
   },
   YY: {
     mask: IMask.MaskedRange,

--- a/packages/ui-components/src/Card/translations.ts
+++ b/packages/ui-components/src/Card/translations.ts
@@ -18,7 +18,7 @@ export const DEFAULT_TRANSLATIONS: CardTranslations = {
   },
   expiry: {
     label: "Expiration",
-    placeholder: "MM/YY",
+    placeholder: "MM / YY",
     errors: {
       invalid: "Your expiration date is invalid",
     },


### PR DESCRIPTION
# Why
Our expiration field expects a format of `[0-1][1-9]`. This means if a user has an expiration date for September they must enter `09` rather than simply `9`.

# How
Automatically pad the expiration for values between 2 - 9. Luckily imask has a built in option for this.
