### PR TITLE
Move JS testing ahead of build and use staging teams

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -57,21 +57,6 @@ jobs:
           cache: "pnpm"
       - name: Install deps
         run: pnpm install --frozen-lockfile
-      - name: Build
-        run: |
-          pnpm \
-          --filter @evervault/browser \
-          --filter @evervault/inputs \
-          --filter @evervault/react \
-          --filter @evervault/card-validator \
-          --filter @evervault/react-native \
-          build
-      - name: Build ui-components and 3ds
-        run: pnpm --filter @evervault/ui-components --filter @evervault/3ds build
-        env: 
-          VITE_API_URL: ${{secrets.vite_api_url}}
-          VITE_EVERVAULT_JS_URL: ${{secrets.vite_evervault_js_url}}
-          VITE_KEYS_URL: ${{secrets.vite_keys_url}}
       - name: Formats check
         run: pnpm run format:check
       - name: Typescript check
@@ -84,6 +69,13 @@ jobs:
         run: pnpm test
       - name: E2E test
         run: pnpm run e2e:test
+      - name: Build
+        run: |
+          pnpm build
+        env: 
+          VITE_API_URL: ${{secrets.vite_api_url}}
+          VITE_EVERVAULT_JS_URL: ${{secrets.vite_evervault_js_url}}
+          VITE_KEYS_URL: ${{secrets.vite_keys_url}}
       - name: Upload browser build
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,9 +15,9 @@ jobs:
       vite-keys-url: "https://keys.evervault.io"
       vite-api-url: "https://api.evervault.io"
     secrets:
-      tests_team_uuid: ${{ secrets.TESTS_TEAM_UUID }}
-      tests_app_uuid: ${{ secrets.TESTS_APP_UUID }}
-      tests_decrypt_fn_key: ${{ secrets.TESTS_DECRYPT_FN_KEY }}
+      tests_team_uuid: ${{ secrets.STAGING_TESTS_TEAM_UUID }}
+      tests_app_uuid: ${{ secrets.STAGING_TESTS_APP_UUID }}
+      tests_decrypt_fn_key: ${{ secrets.STAGING_TESTS_DECRYPT_FN_KEY }}
       turbo_token: ${{ secrets.TURBO_TOKEN }}
   deploy-browser:
     needs: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,9 @@ jobs:
       vite-keys-url: "https://keys.evervault.com"
       vite-api-url: "https://api.evervault.com"
     secrets:
-      tests_team_uuid: ${{ secrets.TESTS_TEAM_UUID }}
-      tests_app_uuid: ${{ secrets.TESTS_APP_UUID }}
-      tests_decrypt_fn_key: ${{ secrets.TESTS_DECRYPT_FN_KEY }}
+      tests_team_uuid: ${{ secrets.STAGING_TESTS_TEAM_UUID }}
+      tests_app_uuid: ${{ secrets.STAGING_TESTS_APP_UUID }}
+      tests_decrypt_fn_key: ${{ secrets.STAGING_TESTS_DECRYPT_FN_KEY }}
       turbo_token: ${{ secrets.TURBO_TOKEN }}
   deploy-js:
     if: contains(github.event.release.tag_name, '@evervault/browser')

--- a/e2e-tests/inputs/tests/default.spec.js
+++ b/e2e-tests/inputs/tests/default.spec.js
@@ -1,11 +1,14 @@
 import { test, expect } from "@playwright/test";
 import { CardLib } from "../utils.js";
 
+const appUuid = process.env.VITE_EV_APP_UUID
+const teamUuid = process.env.VITE_EV_TEAM_UUID
+
 test.describe("evervault inputs", () => {
   test.describe("v2 render default inputs", () => {
     test.beforeEach(async ({ page }) => {
       await page.goto(
-        "http://localhost:4173/v2/?team=59a96deeef03&app=app_869a0605f7c3"
+        `http://localhost:4173/v2/?team=${teamUuid}&app=${appUuid}`
       );
     });
 
@@ -82,7 +85,7 @@ test.describe("evervault inputs", () => {
   test.describe("v2 render with CCV disabled", () => {
     test.beforeEach(async ({ page }) => {
       await page.goto(
-        "http://localhost:4173/v2/?team=59a96deeef03&app=app_869a0605f7c3&disableCVV=true"
+        `http://localhost:4173/v2/?team=${teamUuid}&app=${appUuid}&disableCVV=true`
       );
     });
 
@@ -126,7 +129,7 @@ test.describe("evervault inputs", () => {
   test.describe("v2 render with expiry disabled", () => {
     test.beforeEach(async ({ page }) => {
       await page.goto(
-        "http://localhost:4173/v2/?team=59a96deeef03&app=app_869a0605f7c3&disableExpiry=true"
+        `http://localhost:4173/v2/?team=${teamUuid}&app=${appUuid}&disableExpiry=true`
       );
     });
 
@@ -156,7 +159,7 @@ test.describe("evervault inputs", () => {
   test.describe("v2 render with expiry and CVV disabled", () => {
     test.beforeEach(async ({ page }) => {
       await page.goto(
-        "http://localhost:4173/v2/?team=59a96deeef03&app=app_869a0605f7c3&disableExpiry=true&disableCVV=true"
+        `http://localhost:4173/v2/?team=${teamUuid}&app=${appUuid}&disableExpiry=true&disableCVV=true`
       );
     });
 

--- a/e2e-tests/inputs/tests/events.spec.js
+++ b/e2e-tests/inputs/tests/events.spec.js
@@ -4,11 +4,14 @@ import { CardLib } from "../utils.js";
 const EV_STRING_REGEX =
   /((ev(:|%3A))(debug(:|%3A))?(([A-z0-9+/=%]+)(:|%3A))?((number|boolean|string)(:|%3A))?(([A-z0-9+/=%]+)(:|%3A)){3}(\$|%24))|(((eyJ[A-z0-9+=.]+){2})([\w]{8}(-[\w]{4}){3}-[\w]{12}))/;
 
+const appUuid = process.env.VITE_EV_APP_UUID
+const teamUuid = process.env.VITE_EV_TEAM_UUID
+
 test.describe("evervault inputs", () => {
   test.describe("v2 event testing", () => {
     test.beforeEach(async ({ page }) => {
       await page.goto(
-        "http://localhost:4173/v2/?team=59a96deeef03&app=app_869a0605f7c3"
+        `http://localhost:4173/v2/?team=${teamUuid}&app=${appUuid}`
       );
     });
 

--- a/e2e-tests/inputs/tests/fonts.spec.js
+++ b/e2e-tests/inputs/tests/fonts.spec.js
@@ -1,7 +1,8 @@
 import { test, expect } from "@playwright/test";
 
-const teamUuid = "59a96deeef03";
-const appUuid = "app_869a0605f7c3";
+const appUuid = process.env.VITE_EV_APP_UUID
+const teamUuid = process.env.VITE_EV_TEAM_UUID
+
 const fontUrl = encodeURIComponent(
   "https://fonts.googleapis.com/css2?family=Poppins:wght@100;800&display=swap"
 );

--- a/e2e-tests/inputs/tests/localization.spec.js
+++ b/e2e-tests/inputs/tests/localization.spec.js
@@ -5,11 +5,14 @@ import { CardLib } from "../utils.js";
 
 const locales = ["GA", "FR", "SV", "DE"];
 
+const appUuid = process.env.VITE_EV_APP_UUID
+const teamUuid = process.env.VITE_EV_TEAM_UUID
+
 const createLocaleUrl = (locale) => {
   const localeTranslations = translations[locale];
   let url = new URL("http://localhost:4173/v2");
-  url.searchParams.append("team", "59a96deeef03");
-  url.searchParams.append("app", "app_869a0605f7c3");
+  url.searchParams.append("team", teamUuid);
+  url.searchParams.append("app", appUuid);
   url.searchParams.append(
     "cardNumberLabel",
     localeTranslations.cardNumberLabel

--- a/e2e-tests/inputs/tests/magswipe.spec.js
+++ b/e2e-tests/inputs/tests/magswipe.spec.js
@@ -3,6 +3,9 @@ import { test, expect } from "@playwright/test";
 const EV_STRING_REGEX =
   /((ev(:|%3A))(debug(:|%3A))?(([A-z0-9+/=%]+)(:|%3A))?((number|boolean|string)(:|%3A))?(([A-z0-9+/=%]+)(:|%3A)){3}(\$|%24))|(((eyJ[A-z0-9+=.]+){2})([\w]{8}(-[\w]{4}){3}-[\w]{12}))/;
 
+const appUuid = process.env.VITE_EV_APP_UUID
+const teamUuid = process.env.VITE_EV_TEAM_UUID
+
 test.setTimeout(120000);
 
 test.describe("evervault inputs", () => {


### PR DESCRIPTION
# Why
Testing should use a staging team instead of prod.

# How
Update all tests to use vars instead of hardcoded values. 
Move tests above build so that tests are run with hardcoded ev urls. Then use the passed in env vars for building so that staging packages are built with `evervault.io` domains and prod with `evervault.com` domains.
