### PR TITLE
Updating redundant changesets 

### DIFF
--- a/.changeset/shiny-vans-call.md
+++ b/.changeset/shiny-vans-call.md
@@ -1,5 +1,0 @@
----
-"@evervault/evervault-react-native": patch
----
-
-Remove pre-made ThreeDSecure.Modal.

--- a/.changeset/spotty-dryers-promise.md
+++ b/.changeset/spotty-dryers-promise.md
@@ -4,5 +4,5 @@
 
 Added 3DS support. 
 
-* Added the `<ThreeDSecure />` provider component which allows the use of `<ThreeDSecure.Modal />` and `<ThreeDSecure.Frame />` components which can both be used for completing a 3DS Session. The modal is an out-of-the-box solution for 3DS, while the frame allows for more customisation.  
-* One new hook is available, `useThreeDSecure()`, which must be used in conjunction with the 3DS components.
+* Added the `<ThreeDSecure />` provider component which allows the use of the and `<ThreeDSecure.Frame />` component which can be used for completing a 3DS Session.
+* One new hook is available, `useThreeDSecure()`, which must be used in conjunction with the 3DS component.


### PR DESCRIPTION
# Why
One changeset mentions the addition of ThreeDSecure.Modal and then the next removes it. We should just never mention it at all.

# How
Update first changeset and then remove the second one that mentions removing the modal. I think this will work so that there's only one change when we release
