### PR TITLE
Rerun validation for invalid card fields on changes

### DIFF
--- a/.changeset/late-dogs-dance.md
+++ b/.changeset/late-dogs-dance.md
@@ -1,0 +1,6 @@
+---
+"@evervault/ui-components": minor
+---
+
+- Invalid card fields will now be revalidated on any field change. This fixes a bug when a CVC could become invalid after changing to a card number that requires a different CVC length.
+- The CVC value will now be truncated when the card number changes to a card that requires a shorter CVC length.

--- a/e2e-tests/ui-components/tests/cardDetails.spec.js
+++ b/e2e-tests/ui-components/tests/cardDetails.spec.js
@@ -7,7 +7,7 @@ test.describe("card component", () => {
   });
 
   Object.values(VALID_CARDS).forEach((card) => {
-    test.only(`can capture valid card details for ${card.number} (${card.brand})`, async ({
+    test(`can capture valid card details for ${card.number} (${card.brand})`, async ({
       page,
     }) => {
       let values = {};

--- a/e2e-tests/ui-components/tests/cardDetails.spec.js
+++ b/e2e-tests/ui-components/tests/cardDetails.spec.js
@@ -533,4 +533,61 @@ test.describe("card component", () => {
       await expect(frame.getByLabel("Expiration")).toHaveValue(digit);
     });
   });
+
+  test("Revalidates CVC when card number changes", async ({ page }) => {
+    let values = {};
+
+    await page.exposeFunction("handleChange", (newValues) => {
+      values = newValues;
+    });
+
+    await page.evaluate(() => {
+      const card = window.evervault.ui.card();
+      card.on("change", window.handleChange);
+      card.mount("#form");
+    });
+
+    const frame = page.frameLocator("iframe[data-evervault]");
+    // anter amex card which requires 4 digit cvc
+    await frame.getByLabel("Number").fill("378282246310005");
+    await frame.getByLabel("CVC").fill("123");
+    await frame.getByLabel("CVC").blur();
+    await expect(frame.getByText("Your CVC is invalid")).toBeVisible();
+    await expect.poll(async () => values.errors?.cvc).not.toBeUndefined();
+    await frame.getByLabel("Number").clear();
+    await frame.getByLabel("Number").fill("4242424242424242");
+    await expect.poll(async () => values.errors?.cvc).toBeUndefined();
+    await expect(frame.getByText("Your CVC is invalid")).not.toBeVisible();
+  });
+
+  test("Updates the underlying CVC when switching from 4 digit CVC to 3", async ({
+    page,
+  }) => {
+    let lastChange = {};
+
+    await page.exposeFunction("handleChange", (newValues) => {
+      lastChange = newValues;
+    });
+
+    await page.evaluate(() => {
+      const card = window.evervault.ui.card();
+      card.on("change", window.handleChange);
+      card.mount("#form");
+    });
+
+    const frame = page.frameLocator("iframe[data-evervault]");
+    // anter amex card which requires 4 digit cvc
+    await frame.getByLabel("Number").fill("378282246310005");
+    await frame.getByLabel("Expiration").fill("1228");
+    await frame.getByLabel("CVC").fill("1234");
+    await expect.poll(async () => lastChange.isComplete).toBeTruthy();
+    // switch to visa card, should still be valid as CVC truncated to 123
+    await frame.getByLabel("Number").clear();
+    await frame.getByLabel("Number").fill("4242424242424242");
+    await expect.poll(async () => lastChange.isComplete).toBeTruthy();
+    // switch back to amex, should be invalid as CVC is now 3 digits
+    await frame.getByLabel("Number").clear();
+    await frame.getByLabel("Number").fill("378282246310005");
+    await expect.poll(async () => lastChange.isComplete).toBeFalsy();
+  });
 });

--- a/packages/shared/src/useForm.ts
+++ b/packages/shared/src/useForm.ts
@@ -73,18 +73,24 @@ export function useForm<T extends object>({
 
   const setValue = useCallback(
     <K extends keyof T>(field: K, value: T[K]) => {
-      if (errors?.[field]) {
-        setError(field, undefined);
-      }
+      const nextValues = { ...values, [field]: value };
+      setValues((p) => ({ ...p, [field]: value }));
 
-      setValues((previous) => ({
-        ...previous,
-        [field]: value,
-      }));
+      const nextErrors: Partial<Record<keyof T, string>> = {};
+      Object.keys(errors ?? {}).forEach((key) => {
+        if (key === field) return;
+        const validator = validators.current?.[key as keyof T];
+        if (!validator) return;
+        const error = validator(nextValues);
+        if (!error) return;
+        nextErrors[key as keyof T] = error;
+      });
+
+      setErrors(nextErrors);
 
       triggerChange.current = true;
     },
-    [errors, setError]
+    [values, errors]
   );
 
   const isValid = useMemo(

--- a/packages/ui-components/src/Card/CardCVC.tsx
+++ b/packages/ui-components/src/Card/CardCVC.tsx
@@ -45,7 +45,18 @@ export const CardCVC = forwardRef<HTMLInputElement, CVCProps>(
       return "000";
     }, [cardNumber]);
 
-    const { setValue } = useMask(innerRef, onChange, { mask });
+    const { setValue, getUnmaskedValue } = useMask(innerRef, onChange, {
+      mask,
+    });
+
+    // When the mask changes we want to ensure the correct value is set.
+    // e.g if a the user previously entered a 4 digit cvc and then enters
+    // a card that only supports 3 then we force the value to be 3 digits.
+    useEffect(() => {
+      if (value !== getUnmaskedValue()) {
+        onChange(getUnmaskedValue() || "");
+      }
+    }, [value, mask, getUnmaskedValue, onChange]);
 
     useEffect(() => {
       setValue(value);

--- a/packages/ui-components/src/Card/CardCVC.tsx
+++ b/packages/ui-components/src/Card/CardCVC.tsx
@@ -45,18 +45,9 @@ export const CardCVC = forwardRef<HTMLInputElement, CVCProps>(
       return "000";
     }, [cardNumber]);
 
-    const { setValue, getUnmaskedValue } = useMask(innerRef, onChange, {
+    const { setValue } = useMask(innerRef, onChange, {
       mask,
     });
-
-    // When the mask changes we want to ensure the correct value is set.
-    // e.g if a the user previously entered a 4 digit cvc and then enters
-    // a card that only supports 3 then we force the value to be 3 digits.
-    useEffect(() => {
-      if (value !== getUnmaskedValue()) {
-        onChange(getUnmaskedValue() || "");
-      }
-    }, [value, mask, getUnmaskedValue, onChange]);
 
     useEffect(() => {
       setValue(value);

--- a/packages/ui-components/src/Card/CardNumber.tsx
+++ b/packages/ui-components/src/Card/CardNumber.tsx
@@ -1,7 +1,7 @@
 import { validateNumber } from "@evervault/card-validator";
 import { FocusEvent, useEffect, useRef } from "react";
-import { useMask } from "../utilities/useMask";
 import { UseFormReturn } from "shared";
+import { useMask } from "../utilities/useMask";
 import { CardForm } from "./types";
 
 interface CardNumberProps {
@@ -35,7 +35,7 @@ export function CardNumber({
   const ref = useRef<HTMLInputElement>(null);
 
   const handleCardChange = (newValue: string) => {
-    const brand = validateNumber(newValue).brand;
+    const { brand } = validateNumber(newValue);
     if (brand !== "american-express" && form.values.cvc.length === 4) {
       form.setValues((previous) => ({
         ...previous,

--- a/packages/ui-components/src/Card/CardNumber.tsx
+++ b/packages/ui-components/src/Card/CardNumber.tsx
@@ -1,6 +1,8 @@
 import { validateNumber } from "@evervault/card-validator";
 import { FocusEvent, useEffect, useRef } from "react";
 import { useMask } from "../utilities/useMask";
+import { UseFormReturn } from "shared";
+import { CardForm } from "./types";
 
 interface CardNumberProps {
   disabled?: boolean;
@@ -11,6 +13,7 @@ interface CardNumberProps {
   value: string;
   readOnly?: boolean;
   autoComplete?: boolean;
+  form: UseFormReturn<CardForm>;
 }
 
 interface CardMask {
@@ -25,11 +28,25 @@ export function CardNumber({
   onBlur,
   placeholder,
   value,
+  form,
   readOnly,
   autoComplete,
 }: CardNumberProps) {
   const ref = useRef<HTMLInputElement>(null);
-  const { setValue } = useMask(ref, onChange, {
+
+  const handleCardChange = (newValue: string) => {
+    const brand = validateNumber(newValue).brand;
+    if (brand !== "american-express" && form.values.cvc.length === 4) {
+      form.setValues((previous) => ({
+        ...previous,
+        cvc: previous.cvc.slice(0, 3),
+      }));
+    }
+
+    onChange(newValue);
+  };
+
+  const { setValue } = useMask(ref, handleCardChange, {
     mask: [
       {
         mask: "0000 0000 0000 0000",

--- a/packages/ui-components/src/Card/index.tsx
+++ b/packages/ui-components/src/Card/index.tsx
@@ -202,6 +202,7 @@ export function Card({ config }: { config: CardConfig }) {
             placeholder={t("number.placeholder")}
             value={form.values.number}
             autoComplete={config.autoComplete?.number ?? true}
+            form={form}
             {...form.register("number")}
           />
           {form.errors?.number && (

--- a/packages/ui-components/src/utilities/useMask.ts
+++ b/packages/ui-components/src/utilities/useMask.ts
@@ -3,6 +3,7 @@ import { RefObject, useCallback, useEffect, useRef } from "react";
 
 interface UseMaskReturn {
   setValue: (newValue: string) => void;
+  getUnmaskedValue: () => string | undefined;
 }
 
 export function useMask(
@@ -34,5 +35,10 @@ export function useMask(
     mask.current.value = newValue;
   }, []);
 
-  return { setValue };
+  const getUnmaskedValue = useCallback(() => {
+    if (!mask.current) return;
+    return mask.current.unmaskedValue;
+  }, []);
+
+  return { setValue, getUnmaskedValue };
 }

--- a/packages/ui-components/src/utilities/useMask.ts
+++ b/packages/ui-components/src/utilities/useMask.ts
@@ -36,7 +36,7 @@ export function useMask(
   }, []);
 
   const getUnmaskedValue = useCallback(() => {
-    if (!mask.current) return;
+    if (!mask.current) return "";
     return mask.current.unmaskedValue;
   }, []);
 


### PR DESCRIPTION
# Why
- Currently if a user enters an amex card and only enters 3 digits in the CVC it is correctly marked as invalid, however, if the user then switches to a Visa card, the CVC is still marked as invalid even though a 3 digit CVC should be considered valid.
- If a user enters an amex card and a 4 digit CVC of '1234' and then switches to a Visa card the CVC mask is updated and it is truncated to '123', however, the underlying value for the CVC will still be '1234' when it should b changed to '123'.

This PR also improves our tests slightly to use the decrypt API to assert that the encrypted values match the original card values.
