### PR TITLE
Fix TypeError on card number if not mounted

### DIFF
--- a/.changeset/loud-pans-attend.md
+++ b/.changeset/loud-pans-attend.md
@@ -1,0 +1,5 @@
+---
+"@evervault/evervault-react-native": patch
+---
+
+Correct onChange behaviour to account for unmounted card number.

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -32,7 +32,8 @@
     "prepare": "bob build",
     "typecheck": "tsc --noEmit",
     "clean": "del-cli android/build dist",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "test": "jest"
   },
   "keywords": [
     "react-native",

--- a/packages/react-native/src/__tests__/index.test.tsx
+++ b/packages/react-native/src/__tests__/index.test.tsx
@@ -1,1 +1,0 @@
-it.todo("write a test");

--- a/packages/react-native/src/components/Card/utilities.test.ts
+++ b/packages/react-native/src/components/Card/utilities.test.ts
@@ -1,0 +1,112 @@
+import { CardForm } from "./types";
+import { changePayload } from "./utilities";
+
+function getFutureExpiry() {
+  const futureExpiry = new Date();
+  futureExpiry.setFullYear(futureExpiry.getFullYear() + 4);
+  const month = futureExpiry.getMonth() + 1;
+  const year = futureExpiry.getFullYear() % 100;
+  if (month < 10) {
+    return `0${month}${year}`;
+  }
+  return `${month}${year}`;
+}
+
+it("Ignores the card number if it is not included in the fields", async () => {
+  const mockEncrypt = jest.fn();
+  const expiry = getFutureExpiry();
+  const sampleFormPayload = {
+    name: "John Doe",
+    expiry,
+    cvc: "123",
+  } as CardForm;
+
+  mockEncrypt.mockImplementation((value: string) => `ev:${value}`);
+  const result = await changePayload(
+    mockEncrypt,
+    {
+      values: sampleFormPayload,
+      isValid: true,
+      errors: {},
+      setValues: jest.fn(),
+      setValue: jest.fn(),
+      setError: jest.fn(),
+      validate: jest.fn(),
+      register: jest.fn(),
+    },
+    ["name", "expiry", "cvc"]
+  );
+
+  expect(result.card.number).toBeNull();
+  expect(result.card.cvc).toBe(`ev:${sampleFormPayload.cvc}`);
+  expect(result.isValid).toBe(true);
+  expect(result.isComplete).toBe(true);
+});
+
+it("Ignores the name if it is not included in the fields", async () => {
+  const mockEncrypt = jest.fn();
+  const expiry = getFutureExpiry();
+  const sampleFormPayload = {
+    number: "4242 4242 4242 4242",
+    expiry,
+    cvc: "123",
+  } as CardForm;
+
+  mockEncrypt.mockImplementation((value: string) => `ev:${value}`);
+  const result = await changePayload(
+    mockEncrypt,
+    {
+      values: sampleFormPayload,
+      isValid: true,
+      errors: {},
+      setValues: jest.fn(),
+      setValue: jest.fn(),
+      setError: jest.fn(),
+      validate: jest.fn(),
+      register: jest.fn(),
+    },
+    ["number", "expiry", "cvc"]
+  );
+
+  expect(result.card.name).toBeFalsy();
+  expect(result.card.number).toBe(
+    `ev:${sampleFormPayload.number.replaceAll(" ", "")}`
+  );
+  expect(result.card.cvc).toBe(`ev:${sampleFormPayload.cvc}`);
+  expect(result.isValid).toBe(true);
+  expect(result.isComplete).toBe(true);
+});
+
+it("Ignores the cvc if it is not included in the fields", async () => {
+  const mockEncrypt = jest.fn();
+  const expiry = getFutureExpiry();
+  const sampleFormPayload = {
+    number: "4242 4242 4242 4242",
+    expiry,
+    name: "John Doe",
+  } as CardForm;
+
+  mockEncrypt.mockImplementation((value: string) => `ev:${value}`);
+  const result = await changePayload(
+    mockEncrypt,
+    {
+      values: sampleFormPayload,
+      isValid: true,
+      errors: {},
+      setValues: jest.fn(),
+      setValue: jest.fn(),
+      setError: jest.fn(),
+      validate: jest.fn(),
+      register: jest.fn(),
+    },
+    ["number", "expiry", "name"]
+  );
+
+  expect(result.card.name).toBe(sampleFormPayload.name);
+  expect(result.card.number).toBe(
+    `ev:${sampleFormPayload.number.replaceAll(" ", "")}`
+  );
+  expect(result.card.cvc).toBeFalsy();
+  expect(result.isValid).toBe(true);
+  expect(result.isComplete).toBe(true);
+});

--- a/packages/react-native/src/components/Card/utilities.ts
+++ b/packages/react-native/src/components/Card/utilities.ts
@@ -14,7 +14,7 @@ export async function changePayload(
 ): Promise<CardPayload> {
   const { name, number: rawNumber, expiry, cvc } = form.values;
 
-  const number = rawNumber.replace(/\s/g, "");
+  const number = fields.includes("number") ? rawNumber.replace(/\s/g, "") : "";
 
   const {
     brand,


### PR DESCRIPTION
# Why

Card number is being formatted even if it isn't mounted, which leads to a `TypeError`

# How

- Check registered fields set to see if the card number is mounted before formatting
- Add tests for change payload callback function in react native
