### PR TITLE
fix: cvc validation not updating when card brand changes

### DIFF
--- a/.changeset/silly-penguins-chew.md
+++ b/.changeset/silly-penguins-chew.md
@@ -1,0 +1,6 @@
+---
+"@evervault/evervault-react-native": minor
+---
+
+- Currently if a user enters an amex card and only enters 3 digits in the CVC it is correctly marked as invalid, however, if the user then switches to a Visa card, the CVC is still marked as invalid even though a 3 digit CVC should be considered valid.
+- If a user enters an amex card and a 4 digit CVC of '1234' and then switches to a Visa card the CVC mask is updated and it is truncated to '123', however, the underlying value for the CVC will still be '1234' when it should b changed to '123'.

--- a/packages/react-native/src/components/Card/utilities.ts
+++ b/packages/react-native/src/components/Card/utilities.ts
@@ -23,6 +23,14 @@ export async function changePayload(
     lastFour,
     isValid: isValidCardNumber,
   } = validateNumber(number);
+
+  if (brand !== "american-express" && cvc.length === 4) {
+    form.setValues((prev) => ({
+      ...prev,
+      cvc: cvc.slice(0, 3),
+    }))
+  }
+
   return {
     card: {
       name,

--- a/packages/react-native/src/components/Card/utilities.ts
+++ b/packages/react-native/src/components/Card/utilities.ts
@@ -24,7 +24,7 @@ export async function changePayload(
     isValid: isValidCardNumber,
   } = validateNumber(number);
 
-  if (brand !== "american-express" && cvc.length === 4) {
+  if (brand !== "american-express" && cvc?.length === 4) {
     form.setValues((prev) => ({
       ...prev,
       cvc: cvc.slice(0, 3),


### PR DESCRIPTION
# Why
- Currently if a user enters an amex card and only enters 3 digits in the CVC it is correctly marked as invalid, however, if the user then switches to a Visa card, the CVC is still marked as invalid even though a 3 digit CVC should be considered valid.

- If a user enters an amex card and a 4 digit CVC of '1234' and then switches to a Visa card the CVC mask is updated and it is truncated to '123', however, the underlying value for the CVC will still be '1234' when it should b changed to '123'.

# How
Describe how you've approached the problem
