### PR TITLE
Update react native sdk to invalidate previously valid cvcs when card number changes

### DIFF
--- a/.changeset/twelve-months-rule.md
+++ b/.changeset/twelve-months-rule.md
@@ -1,0 +1,7 @@
+---
+"@evervault/ui-components": patch
+"@evervault/evervault-react-native": patch
+"shared": patch
+---
+
+Update form validation to support cvcs being invalidated by a change in card number.

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,10 +2,6 @@ name: Build & Test
 on:
   workflow_call:
     inputs:
-      turbo_team:
-        type: string
-        description: "Turbo team name"
-        required: true
       vite-evervault-js-url:
         description: "URL where the JS SDK should be loaded from"
         required: true
@@ -25,8 +21,6 @@ on:
         required: true
       tests_decrypt_fn_key:
         required: true
-      turbo_token:
-        required: true
 jobs:
   build:
     name: Build and Test
@@ -37,8 +31,6 @@ jobs:
       EV_APP_UUID: ${{ secrets.tests_app_uuid }}
       EV_DECRYPT_FN_KEY: ${{ secrets.tests_decrypt_fn_key }}
       EV_TEAM_UUID: ${{ secrets.tests_team_uuid }}
-      TURBO_TEAM: ${{ inputs.turbo_team }}
-      TURBO_TOKEN: ${{ secrets.turbo_token }}
       VITE_EV_APP_UUID: ${{ secrets.tests_app_uuid }}
       VITE_EV_TEAM_UUID: ${{ secrets.tests_team_uuid }}
       VITE_API_URL: "https://api.evervault.com"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,7 +9,6 @@ jobs:
   build:
     uses: ./.github/workflows/build-and-test.yml
     with:
-      turbo_team: ${{ vars.TURBO_TEAM }}
       vite-evervault-js-url: "https://js.evervault.io/v2"
       vite-keys-url: "https://keys.evervault.io"
       vite-api-url: "https://api.evervault.io"
@@ -17,4 +16,3 @@ jobs:
       tests_team_uuid: ${{ secrets.TESTS_TEAM_UUID }}
       tests_app_uuid: ${{ secrets.TESTS_APP_UUID }}
       tests_decrypt_fn_key: ${{ secrets.TESTS_DECRYPT_FN_KEY }}
-      turbo_token: ${{ secrets.TURBO_TOKEN }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,7 +10,6 @@ jobs:
   build:
     uses: ./.github/workflows/build-and-test.yml
     with:
-      turbo_team: ${{ vars.TURBO_TEAM }}
       vite-evervault-js-url: "https://js.evervault.io/v2"
       vite-keys-url: "https://keys.evervault.io"
       vite-api-url: "https://api.evervault.io"
@@ -18,7 +17,6 @@ jobs:
       tests_team_uuid: ${{ secrets.TESTS_TEAM_UUID }}
       tests_app_uuid: ${{ secrets.TESTS_APP_UUID }}
       tests_decrypt_fn_key: ${{ secrets.TESTS_DECRYPT_FN_KEY }}
-      turbo_token: ${{ secrets.TURBO_TOKEN }}
   deploy-browser:
     needs: build
     uses: ./.github/workflows/deploy-browser.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,6 @@ jobs:
   build:
     uses: ./.github/workflows/build-and-test.yml
     with:
-      turbo_team: ${{ vars.TURBO_TEAM }}
       vite-evervault-js-url: "https://js.evervault.com/v2"
       vite-keys-url: "https://keys.evervault.com"
       vite-api-url: "https://api.evervault.com"
@@ -17,7 +16,6 @@ jobs:
       tests_team_uuid: ${{ secrets.TESTS_TEAM_UUID }}
       tests_app_uuid: ${{ secrets.TESTS_APP_UUID }}
       tests_decrypt_fn_key: ${{ secrets.TESTS_DECRYPT_FN_KEY }}
-      turbo_token: ${{ secrets.TURBO_TOKEN }}
   deploy-js:
     if: contains(github.event.release.tag_name, '@evervault/browser')
     needs: build

--- a/e2e-apps/browser/package.json
+++ b/e2e-apps/browser/package.json
@@ -10,7 +10,8 @@
     "start": "vite",
     "build": "vite build",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "clean": "rm -rf .turbo node_modules dist"
   },
   "license": "MIT",
   "dependencies": {

--- a/e2e-apps/decrypt-backend/package.json
+++ b/e2e-apps/decrypt-backend/package.json
@@ -7,7 +7,8 @@
     "pnpm": "~9"
   },
   "scripts": {
-    "start": "node index.mjs"
+    "start": "node index.mjs",
+    "clean": "rm -rf .turbo node_modules dist"
   },
   "license": "MIT",
   "dependencies": {

--- a/e2e-tests/browser/package.json
+++ b/e2e-tests/browser/package.json
@@ -6,7 +6,8 @@
     "dev:test": "playwright test",
     "e2e:test": "playwright test",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "clean": "rm -rf .turbo node_modules dist"
   },
   "dependencies": {
     "@evervault/browser-e2e-app": "workspace:*",

--- a/e2e-tests/inputs/package.json
+++ b/e2e-tests/inputs/package.json
@@ -4,7 +4,8 @@
   "version": "1.0.0",
   "scripts": {
     "dev:test": "playwright test",
-    "e2e:test": "start-server-and-test \"(cd ../../packages/inputs && pnpm run preview)\" http://localhost:4173/v2/ \"playwright test\""
+    "e2e:test": "start-server-and-test \"(cd ../../packages/inputs && pnpm run preview)\" http://localhost:4173/v2/ \"playwright test\"",
+    "clean": "rm -rf .turbo node_modules dist"
   },
   "dependencies": {
     "@evervault/inputs": "workspace:*"

--- a/e2e-tests/ui-components/package.json
+++ b/e2e-tests/ui-components/package.json
@@ -3,7 +3,8 @@
   "name": "@evervault/ui-components-e2e-tests",
   "version": "1.0.8",
   "scripts": {
-    "e2e:test": "playwright test"
+    "e2e:test": "playwright test",
+    "clean": "rm -rf .turbo node_modules dist"
   },
   "dependencies": {
     "@evervault/ui-components": "workspace:*"

--- a/ev-functions/js-sdk-e2e-backend/package.json
+++ b/ev-functions/js-sdk-e2e-backend/package.json
@@ -1,25 +1,26 @@
 {
-    "name": "hello-function",
-    "version": "1.0.0",
-    "description": "A sample function template that will get you up and running quickly",
-    "main": "index.js",
-    "scripts": {
-        "test": "echo \"Error: no test specified\" && exit 1"
-    },
-    "keywords": [
-        "privacy",
-        "cage",
-        "security",
-        "encryption",
-        "evervault"
-    ],
-    "author": "Evervault Inc.",
-    "license": "MIT",
-    "bugs": {
-        "url": "https://github.com/evervault/hello-function/issues"
-    },
-    "homepage": "https://github.com/evervault/hello-function#readme",
-    "devDependencies": {
-        "@evervault/sdk": "^4.2.0"
-    }
+  "name": "hello-function",
+  "version": "1.0.0",
+  "description": "A sample function template that will get you up and running quickly",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "clean": "rm -rf .turbo node_modules dist"
+  },
+  "keywords": [
+    "privacy",
+    "cage",
+    "security",
+    "encryption",
+    "evervault"
+  ],
+  "author": "Evervault Inc.",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/evervault/hello-function/issues"
+  },
+  "homepage": "https://github.com/evervault/hello-function#readme",
+  "devDependencies": {
+    "@evervault/sdk": "^4.2.0"
+  }
 }

--- a/examples/collect-card-details/package.json
+++ b/examples/collect-card-details/package.json
@@ -4,7 +4,8 @@
   "version": "0.0.20",
   "type": "module",
   "scripts": {
-    "dev": "vite --port 4000"
+    "dev": "vite --port 4000",
+    "clean": "rm -rf .turbo node_modules dist"
   },
   "dependencies": {
     "@evervault/browser": "workspace:*"

--- a/examples/custom-theme/package.json
+++ b/examples/custom-theme/package.json
@@ -4,7 +4,8 @@
   "version": "0.0.17",
   "type": "module",
   "scripts": {
-    "dev": "vite --port 4000"
+    "dev": "vite --port 4000",
+    "clean": "rm -rf .turbo node_modules dist"
   },
   "dependencies": {
     "@evervault/browser": "workspace:*"

--- a/examples/example-backend/package.json
+++ b/examples/example-backend/package.json
@@ -5,7 +5,8 @@
   "description": "A mini node server to be consumed by the react native example app.",
   "main": "index.js",
   "scripts": {
-    "start": "node index.js"
+    "start": "node index.js",
+    "clean": "rm -rf .turbo node_modules dist"
   },
   "keywords": [],
   "author": "Evervault Engineering <engineering@evervault.com>",

--- a/examples/forms/package.json
+++ b/examples/forms/package.json
@@ -4,7 +4,8 @@
   "version": "0.1.7",
   "type": "module",
   "scripts": {
-    "dev": "vite --port 4000"
+    "dev": "vite --port 4000",
+    "clean": "rm -rf .turbo node_modules dist"
   },
   "dependencies": {
     "@evervault/browser": "workspace:*"

--- a/examples/next-3ds/package.json
+++ b/examples/next-3ds/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --port 4000",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "clean": "rm -rf .turbo node_modules dist"
   },
   "dependencies": {
     "react": "^18",

--- a/examples/react-native-example/App.tsx
+++ b/examples/react-native-example/App.tsx
@@ -76,7 +76,11 @@ function Checkout({ cardData }: { cardData: CardPayload | undefined }) {
           <ThreeDSecure state={tds}>
             <ThreeDSecure.Frame />
           </ThreeDSecure>
-          <Button title="Pay" onPress={handlePayment} />
+          <Button
+            title="Pay"
+            onPress={handlePayment}
+            disabled={!(cardData?.isComplete && cardData?.isValid)}
+          />
         </>
       )}
     </>

--- a/examples/react-native-example/components/CardForm.tsx
+++ b/examples/react-native-example/components/CardForm.tsx
@@ -16,6 +16,7 @@ function CardForm({ setCardData }: CardFormProps) {
       />
       <Card.Expiry placeholder="MM / YY" style={styles.input} />
       <Card.Holder placeholder="John Doe" style={styles.input} />
+      <Card.CVC placeholder="123" style={styles.input} />
     </Card>
   );
 }

--- a/examples/react-native-example/package.json
+++ b/examples/react-native-example/package.json
@@ -7,7 +7,8 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
-    "prebuild": "expo prebuild"
+    "prebuild": "expo prebuild",
+    "clean": "rm -rf .turbo node_modules dist"
   },
   "dependencies": {
     "@evervault/evervault-react-native": "workspace:*",

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -7,7 +7,8 @@
     "dev": "vite --port 4000",
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "clean": "rm -rf .turbo node_modules dist"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/examples/three-d-secure/package.json
+++ b/examples/three-d-secure/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "concurrently --kill-others \"pnpm run client:dev\" \"pnpm run server:dev\"",
     "client:dev": "vite --port 4000",
-    "server:dev": "node api.js"
+    "server:dev": "node api.js",
+    "clean": "rm -rf .turbo node_modules dist"
   },
   "dependencies": {
     "@evervault/browser": "workspace:*"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "build": "turbo run build --filter=@evervault/*...",
     "build:browser": "dotenv -- turbo run build --filter=browser",
     "build:inputs": "dotenv -- turbo run build --filter=inputs",
+    "clean": "turbo run clean",
     "test": "dotenv -- turbo run test",
     "format": "turbo run format",
     "format:check": "turbo run format:check",

--- a/packages/3ds/package.json
+++ b/packages/3ds/package.json
@@ -4,7 +4,8 @@
   "version": "1.1.0",
   "scripts": {
     "dev": "vite",
-    "build": "vite build"
+    "build": "vite build",
+    "clean": "rm -rf .turbo node_modules dist"
   },
   "license": "MIT",
   "devDependencies": {

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -36,7 +36,8 @@
     "lint:fix": "eslint --fix .",
     "test": "vitest run",
     "test:watch": "vitest",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf .turbo node_modules dist"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/card-validator/package.json
+++ b/packages/card-validator/package.json
@@ -28,7 +28,8 @@
   },
   "scripts": {
     "test": "vitest run",
-    "build": "vite build"
+    "build": "vite build",
+    "clean": "rm -rf .turbo node_modules dist"
   },
   "dependencies": {},
   "devDependencies": {

--- a/packages/eslint-config-custom/package.json
+++ b/packages/eslint-config-custom/package.json
@@ -13,5 +13,8 @@
     "eslint-config-turbo": "^2.0.9",
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-prettier": "^5.0.0"
+  },
+  "scripts": {
+    "clean": "rm -rf .turbo node_modules dist"
   }
 }

--- a/packages/inputs/package.json
+++ b/packages/inputs/package.json
@@ -13,7 +13,8 @@
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "preview": "vite preview",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf .turbo node_modules dist"
   },
   "engines": {
     "node": "^18",

--- a/packages/react-native/src/components/Card/Card.tsx
+++ b/packages/react-native/src/components/Card/Card.tsx
@@ -6,7 +6,7 @@ import {
 import * as React from "react";
 import { ReactNode, useState } from "react";
 import { useForm } from "../useForm";
-import { changePayload, isAcceptedBrand, isComplete } from "./utilities";
+import { changePayload, isAcceptedBrand } from "./utilities";
 import type { CardForm, CardConfig, CardField, CardPayload } from "./types";
 import { CardNumber } from "./CardNumber";
 import { CardContext } from "./context";

--- a/packages/react-native/src/components/useForm.tsx
+++ b/packages/react-native/src/components/useForm.tsx
@@ -73,8 +73,14 @@ export function useForm<T extends object>({
       const nextValues = { ...values, [field]: value };
       setValues((p) => ({ ...p, [field]: value }));
 
+      const fieldsToValidate: string[] = Object.keys(errors ?? {});
+      if (field === "number" && errors?.["cvc" as keyof T] == null) {
+        fieldsToValidate.push("cvc");
+      }
+
       const nextErrors: Partial<Record<keyof T, string>> = {};
-      Object.keys(errors ?? {}).forEach((key) => {
+
+      fieldsToValidate.forEach((key) => {
         if (key === field) return;
         const validator = validators.current?.[key as keyof T];
         if (!validator) return;

--- a/packages/react-native/src/components/useForm.tsx
+++ b/packages/react-native/src/components/useForm.tsx
@@ -74,7 +74,11 @@ export function useForm<T extends object>({
       setValues((p) => ({ ...p, [field]: value }));
 
       const fieldsToValidate: string[] = Object.keys(errors ?? {});
-      if (field === "number" && errors?.["cvc" as keyof T] == null) {
+      if (
+        field === "number" &&
+        errors?.["cvc" as keyof T] == null &&
+        nextValues?.["cvc" as keyof T]
+      ) {
         fieldsToValidate.push("cvc");
       }
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -31,7 +31,8 @@
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "preinstall": "npx only-allow pnpm",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf .turbo node_modules dist"
   },
   "peerDependencies": {
     "react": ">=18.0.0"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -6,5 +6,8 @@
   "dependencies": {
     "types": "workspace:*",
     "@evervault/card-validator": "workspace:*"
+  },
+  "scripts": {
+    "clean": "rm -rf .turbo node_modules dist"
   }
 }

--- a/packages/shared/src/useForm.ts
+++ b/packages/shared/src/useForm.ts
@@ -76,8 +76,13 @@ export function useForm<T extends object>({
       const nextValues = { ...values, [field]: value };
       setValues((p) => ({ ...p, [field]: value }));
 
+      const fieldsToValidate: string[] = Object.keys(errors ?? {});
+      if (field === "number" && errors?.["cvc" as keyof T] == null) {
+        fieldsToValidate.push("cvc");
+      }
+
       const nextErrors: Partial<Record<keyof T, string>> = {};
-      Object.keys(errors ?? {}).forEach((key) => {
+      fieldsToValidate.forEach((key) => {
         if (key === field) return;
         const validator = validators.current?.[key as keyof T];
         if (!validator) return;

--- a/packages/shared/src/useForm.ts
+++ b/packages/shared/src/useForm.ts
@@ -80,7 +80,7 @@ export function useForm<T extends object>({
       if (
         field === "number" &&
         errors?.["cvc" as keyof T] == null &&
-        nextValues?.["cvc" as keyof T] != null
+        nextValues?.["cvc" as keyof T]
       ) {
         fieldsToValidate.push("cvc");
       }

--- a/packages/shared/src/useForm.ts
+++ b/packages/shared/src/useForm.ts
@@ -77,7 +77,11 @@ export function useForm<T extends object>({
       setValues((p) => ({ ...p, [field]: value }));
 
       const fieldsToValidate: string[] = Object.keys(errors ?? {});
-      if (field === "number" && errors?.["cvc" as keyof T] == null) {
+      if (
+        field === "number" &&
+        errors?.["cvc" as keyof T] == null &&
+        nextValues?.["cvc" as keyof T] != null
+      ) {
         fieldsToValidate.push("cvc");
       }
 

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -7,5 +7,8 @@
   "dependencies": {
     "types": "workspace:*",
     "typescript": "latest"
+  },
+  "scripts": {
+    "clean": "rm -rf .turbo node_modules dist"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -7,5 +7,8 @@
   "dependencies": {
     "jss": "^10.10.0",
     "typescript": "latest"
+  },
+  "scripts": {
+    "clean": "rm -rf .turbo node_modules dist"
   }
 }

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "lint": "eslint .",
-    "clean": "rm -rf .turbo && rm -rf dist",
+    "clean": "rm -rf .turbo dist node_modules",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/turbo.json
+++ b/turbo.json
@@ -40,6 +40,9 @@
     },
     "preview": {
       "dependsOn": ["build"]
+    },
+    "clean": {
+      "cache": false
     }
   }
 }


### PR DESCRIPTION
# Why

The CVC length is dependent on the card brand entered, so a previously valid CVC needs to be invalidated in the event that a card number changes its length requirement.

# How

- Update react native to revalidate the CVC every time the number changes, regardless of its current validity.
- Update e2e tests for react to account for updated behaviour.