### PR TITLE
autoProgress based on mask instead of validation

### DIFF
--- a/.changeset/cold-planets-drop.md
+++ b/.changeset/cold-planets-drop.md
@@ -1,0 +1,5 @@
+---
+"@evervault/ui-components": minor
+---
+
+autoProgress will now progress when the input mask is complete instead of when the input value becomes valid.

--- a/packages/ui-components/src/Card/CardExpiry.tsx
+++ b/packages/ui-components/src/Card/CardExpiry.tsx
@@ -11,6 +11,7 @@ interface CardExpiryProps {
   value: string;
   readOnly?: boolean;
   autoComplete?: boolean;
+  autoProgress?: boolean;
 }
 
 const EXPIRY_BLOCKS = {
@@ -39,12 +40,22 @@ export function CardExpiry({
   value,
   readOnly,
   autoComplete,
+  autoProgress,
 }: CardExpiryProps) {
   const ref = useRef<HTMLInputElement>(null);
-  const { setValue } = useMask(ref, onChange, {
+  const { setValue, mask } = useMask(ref, onChange, {
     mask: "MM / YY",
     blocks: EXPIRY_BLOCKS,
   });
+
+  useEffect(() => {
+    const isComplete = mask.current?.masked.isComplete ?? false;
+    const activeField = document.activeElement as HTMLElement;
+    const isFocused = activeField === ref.current;
+    if (autoProgress && isFocused && isComplete) {
+      document.getElementById("cvc")?.focus();
+    }
+  }, [value, autoProgress, mask]);
 
   useEffect(() => {
     setValue(value);

--- a/packages/ui-components/src/Card/CardNumber.tsx
+++ b/packages/ui-components/src/Card/CardNumber.tsx
@@ -13,6 +13,7 @@ interface CardNumberProps {
   value: string;
   readOnly?: boolean;
   autoComplete?: boolean;
+  autoProgress?: boolean;
   form: UseFormReturn<CardForm>;
 }
 
@@ -31,6 +32,7 @@ export function CardNumber({
   form,
   readOnly,
   autoComplete,
+  autoProgress,
 }: CardNumberProps) {
   const ref = useRef<HTMLInputElement>(null);
 
@@ -46,7 +48,7 @@ export function CardNumber({
     onChange(newValue);
   };
 
-  const { setValue } = useMask(ref, handleCardChange, {
+  const { setValue, mask } = useMask(ref, handleCardChange, {
     mask: [
       {
         mask: "0000 0000 0000 0000",
@@ -72,6 +74,15 @@ export function CardNumber({
       return mask ?? dynamicMasked.compiledMasks[0];
     },
   });
+
+  useEffect(() => {
+    const isComplete = mask.current?.masked.isComplete ?? false;
+    const activeField = document.activeElement as HTMLElement;
+    const isFocused = activeField === ref.current;
+    if (autoProgress && isFocused && isComplete) {
+      document.getElementById("expiry")?.focus();
+    }
+  }, [value, mask, autoProgress]);
 
   useEffect(() => {
     setValue(value);

--- a/packages/ui-components/src/Card/index.tsx
+++ b/packages/ui-components/src/Card/index.tsx
@@ -18,7 +18,6 @@ import { CardNumber } from "./CardNumber";
 import { DEFAULT_TRANSLATIONS } from "./translations";
 import { useCardReader } from "./useCardReader";
 import {
-  autoProgress,
   changePayload,
   collectIcons,
   isAcceptedBrand,
@@ -103,10 +102,6 @@ export function Card({ config }: { config: CardConfig }) {
       },
     },
     onChange: (formState) => {
-      if (config?.autoProgress) {
-        autoProgress(formState);
-      }
-
       const triggerChange = async () => {
         if (!ev) return;
         const cardData = await changePayload(ev, formState, fields);
@@ -221,6 +216,7 @@ export function Card({ config }: { config: CardConfig }) {
             placeholder={t("number.placeholder")}
             value={form.values.number}
             autoComplete={config.autoComplete?.number ?? true}
+            autoProgress={config.autoProgress}
             form={form}
             {...form.register("number")}
           />
@@ -245,6 +241,7 @@ export function Card({ config }: { config: CardConfig }) {
             readOnly={cardReaderListening}
             placeholder={t("expiry.placeholder")}
             autoComplete={config.autoComplete?.expiry ?? true}
+            autoProgress={config.autoProgress}
             {...form.register("expiry")}
           />
           {form.errors?.expiry && (

--- a/packages/ui-components/src/Card/utilities.ts
+++ b/packages/ui-components/src/Card/utilities.ts
@@ -48,27 +48,6 @@ export async function changePayload(
   };
 }
 
-export function autoProgress(form: UseFormReturn<CardForm>) {
-  const activeField = document.activeElement as HTMLElement;
-  if (activeField instanceof HTMLInputElement === false) return;
-
-  const field = activeField.name as CardField;
-
-  if (field === "number") {
-    const { isValid } = validateNumber(form.values.number);
-    if (isValid) {
-      document.getElementById("expiry")?.focus();
-    }
-  }
-
-  if (field === "expiry") {
-    const { isValid } = validateExpiry(form.values.expiry);
-    if (isValid) {
-      document.getElementById("cvc")?.focus();
-    }
-  }
-}
-
 function isComplete(form: UseFormReturn<CardForm>, fields: CardField[]) {
   if (fields.includes("name")) {
     if (form.values.name.length === 0) return false;

--- a/packages/ui-components/src/utilities/useMask.ts
+++ b/packages/ui-components/src/utilities/useMask.ts
@@ -3,7 +3,7 @@ import { RefObject, useCallback, useEffect, useRef } from "react";
 
 interface UseMaskReturn {
   setValue: (newValue: string) => void;
-  getUnmaskedValue: () => string | undefined;
+  mask: React.MutableRefObject<ReturnType<typeof IMask> | undefined>;
 }
 
 export function useMask(
@@ -35,10 +35,5 @@ export function useMask(
     mask.current.value = newValue;
   }, []);
 
-  const getUnmaskedValue = useCallback(() => {
-    if (!mask.current) return "";
-    return mask.current.unmaskedValue;
-  }, []);
-
-  return { setValue, getUnmaskedValue };
+  return { setValue, mask };
 }


### PR DESCRIPTION
# Why

Currently the `autoProgress` option will cause the browser focus to automatically progress to the next field once the current field becomes valid. Users have given feedback that this behaviour can feel inconsistent. e.g If a user enterers an invalid card number it wont auto progress and an error wont be shown until the user focuses on the next input.

This PR changes the approach to autoProgress to be based entirely on the input mask instead of validation. This means for card numbers, focus will switch to the expiration field as soon as the user has entered a number that matches the current input mask. If the entered number is invalid, an error will be shown as the focus moves to the expiry.

Note: This is only considered a minor change as the `autoProgress` option is not a documented option yet as we are still ironing out the details with select customers.