### PR TITLE
Add events for Card component field interactions 

### DIFF
--- a/.changeset/wet-peaches-cry.md
+++ b/.changeset/wet-peaches-cry.md
@@ -1,0 +1,12 @@
+---
+"example-ui-components": minor
+"@evervault/card-validator": minor
+"@evervault/ui-components": minor
+"@evervault/browser": minor
+"shared": minor
+"@evervault/react": minor
+"types": minor
+---
+
+- Adds focus, blur, keyup and keydown events to the Card component to track interactions with inputs inside of the Card component.
+- Updates the payload from the card component to include the parsed month & year even when the entered expiry is invalid. Previously the expiry value would only be returned when the entered value is valid.

--- a/examples/collect-card-details/src/main.ts
+++ b/examples/collect-card-details/src/main.ts
@@ -29,6 +29,22 @@ card.on("validate", (values) => {
   console.log("validate", values);
 });
 
+card.on("blur", (field) => {
+  console.log("blur", field);
+});
+
+card.on("focus", (field) => {
+  console.log("focus", field);
+});
+
+card.on("keyup", (field) => {
+  console.log("keyup", field);
+});
+
+card.on("keydown", (field) => {
+  console.log("keydown", field);
+});
+
 card.mount("#form");
 
 const btn = document.getElementById("purchase");

--- a/packages/browser/lib/ui/card.ts
+++ b/packages/browser/lib/ui/card.ts
@@ -8,13 +8,8 @@ import type {
   CardFrameClientMessages,
   CardFrameHostMessages,
   SelectorType,
-  CardField,
+  FieldEvent,
 } from "types";
-
-type FieldEvent = {
-  field: CardField;
-  data: CardPayload;
-};
 
 interface CardEvents {
   ready: () => void;

--- a/packages/browser/lib/ui/card.ts
+++ b/packages/browser/lib/ui/card.ts
@@ -8,7 +8,13 @@ import type {
   CardFrameClientMessages,
   CardFrameHostMessages,
   SelectorType,
+  CardField,
 } from "types";
+
+type FieldEvent = {
+  field: CardField;
+  data: CardPayload;
+};
 
 interface CardEvents {
   ready: () => void;
@@ -17,6 +23,10 @@ interface CardEvents {
   complete: (payload: CardPayload) => void;
   swipe: (payload: SwipedCard) => void;
   validate: (payload: CardPayload) => void;
+  focus: (event: FieldEvent) => void;
+  blur: (event: FieldEvent) => void;
+  keydown: (event: FieldEvent) => void;
+  keyup: (event: FieldEvent) => void;
 }
 
 export default class Card {
@@ -47,6 +57,34 @@ export default class Card {
 
     this.#frame.on("EV_FRAME_READY", () => {
       this.#events.dispatch("ready");
+    });
+
+    this.#frame.on("EV_FOCUS", (field) => {
+      this.#events.dispatch("focus", {
+        field,
+        data: this.values,
+      });
+    });
+
+    this.#frame.on("EV_BLUR", (field) => {
+      this.#events.dispatch("blur", {
+        field,
+        data: this.values,
+      });
+    });
+
+    this.#frame.on("EV_KEYDOWN", (field) => {
+      this.#events.dispatch("keydown", {
+        field,
+        data: this.values,
+      });
+    });
+
+    this.#frame.on("EV_KEYUP", (field) => {
+      this.#events.dispatch("keyup", {
+        field,
+        data: this.values,
+      });
     });
 
     this.values = {

--- a/packages/card-validator/index.ts
+++ b/packages/card-validator/index.ts
@@ -151,29 +151,26 @@ export function validateCVC(
 }
 
 export function validateExpiry(expiry: string): CardExpiryValidationResult {
-  // Validate that the expiry is in the format MMYY
-  const regex = /^(0[1-9]|1[0-2])(\d{2})$/;
-  const match = expiry.match(regex);
+  const month_regex = /^(0[1-9]|1[[0-2]).*$/;
+  const month_match = expiry.match(month_regex);
+  const month = month_match ? parseInt(month_match[1].toString(), 10) : null;
 
-  if (match) {
-    const month = parseInt(match[1]?.toString(), 10);
-    const year = parseInt(match[2]?.toString(), 10);
+  const year_regex = /^(0[1-9]|1[[0-2])(\d{2})$/;
+  const year_match = expiry.match(year_regex);
+  const year = year_match ? parseInt(year_match[2].toString(), 10) : null;
 
+  if (month) {
     const currentYear = new Date().getFullYear() % 100;
     const currentMonth = new Date().getMonth() + 1;
-
-    if (year < currentYear || (year === currentYear && month < currentMonth)) {
-      return {
-        month: null,
-        year: null,
-        isValid: false,
-      };
-    }
+    const invalid =
+      !year ||
+      year < currentYear ||
+      (year === currentYear && month < currentMonth);
 
     return {
-      month: match[1]?.toString(),
-      year: match[2]?.toString(),
-      isValid: true,
+      month: month.toString().padStart(2, "0"),
+      year: year?.toString()?.padStart(2, "0") ?? null,
+      isValid: !invalid,
     };
   }
 

--- a/packages/card-validator/test/validate-expiry.test.ts
+++ b/packages/card-validator/test/validate-expiry.test.ts
@@ -1,4 +1,4 @@
-import { describe, assert, it, beforeEach, expect } from "vitest";
+import { describe, it, expect } from "vitest";
 import { validateExpiry } from "../index";
 import { CardExpiryValidationResult } from "../types";
 
@@ -20,18 +20,28 @@ const testCases: TestCase[] = [
     expectedResult: { month: null, year: null, isValid: false },
   },
   {
+    scope: "Just month",
+    expiry: "12",
+    expectedResult: { month: "12", year: null, isValid: false },
+  },
+  {
     scope: "Invalid year",
     expiry: "122",
-    expectedResult: { month: null, year: null, isValid: false },
+    expectedResult: { month: "12", year: null, isValid: false },
   },
   {
     scope: "Previous year",
     expiry: "1220",
-    expectedResult: { month: null, year: null, isValid: false },
+    expectedResult: { month: "12", year: "20", isValid: false },
   },
   {
     scope: "Invalid format",
     expiry: "12/20",
+    expectedResult: { month: "12", year: null, isValid: false },
+  },
+  {
+    scope: "Invalid input",
+    expiry: "  ",
     expectedResult: { month: null, year: null, isValid: false },
   },
 ];

--- a/packages/react/lib/ui/Card.tsx
+++ b/packages/react/lib/ui/Card.tsx
@@ -9,6 +9,7 @@ import type {
   CardOptions,
   CardPayload,
   CardTranslations,
+  FieldEvent,
   SwipedCard,
   ThemeDefinition,
 } from "types";
@@ -28,6 +29,10 @@ export interface CardProps {
   autoProgress?: boolean;
   acceptedBrands?: CardBrandName[];
   defaultValues?: { name?: string };
+  onFocus?: (event: FieldEvent) => void;
+  onBlur?: (event: FieldEvent) => void;
+  onKeyUp?: (event: FieldEvent) => void;
+  onKeyDown?: (event: FieldEvent) => void;
 }
 
 type CardClass = ReturnType<Evervault["ui"]["card"]>;
@@ -43,6 +48,10 @@ export function Card({
   onError,
   onChange,
   onComplete,
+  onFocus,
+  onBlur,
+  onKeyUp,
+  onKeyDown,
   autoComplete,
   autoProgress,
   acceptedBrands,
@@ -82,6 +91,30 @@ export function Card({
     if (!instance || !onComplete) return undefined;
     return instance?.on("complete", onComplete);
   }, [instance, onComplete]);
+
+  // setup focus event listener
+  useEffect(() => {
+    if (!instance || !onFocus) return undefined;
+    return instance?.on("focus", onFocus);
+  }, [instance, onFocus]);
+
+  // setup blur event listener
+  useEffect(() => {
+    if (!instance || !onBlur) return undefined;
+    return instance?.on("blur", onBlur);
+  }, [instance, onBlur]);
+
+  // setup keyup event listener
+  useEffect(() => {
+    if (!instance || !onKeyUp) return undefined;
+    return instance?.on("keyup", onKeyUp);
+  }, [instance, onKeyUp]);
+
+  // setup keydown event listener
+  useEffect(() => {
+    if (!instance || !onKeyDown) return undefined;
+    return instance?.on("keydown", onKeyDown);
+  }, [instance, onKeyDown]);
 
   const config = useMemo(
     () => ({

--- a/packages/shared/src/useForm.ts
+++ b/packages/shared/src/useForm.ts
@@ -9,7 +9,10 @@ export interface UseFormReturn<T> {
   isValid: boolean;
   validate: (cb?: ValidationCallback<T>) => void;
   register: <K extends keyof T>(
-    name: K
+    name: K,
+    events?: {
+      onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void;
+    }
   ) => {
     onChange: (value: T[K]) => void;
     //TODO(Mark): Replace with union of React.FocusEvent<HTMLInputElement> and native event
@@ -155,9 +158,15 @@ export function useForm<T extends object>({
   );
 
   const register = useCallback(
-    <K extends keyof T>(name: K) => {
-      const handleBlur = () => {
+    <K extends keyof T>(
+      name: K,
+      events?: {
+        onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void;
+      }
+    ) => {
+      const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
         validateField(name);
+        events?.onBlur?.(e);
       };
 
       const handleChange = (value: T[K]) => {

--- a/packages/types/uiComponents.ts
+++ b/packages/types/uiComponents.ts
@@ -153,6 +153,10 @@ export interface CardFrameClientMessages extends EvervaultFrameClientMessages {
   EV_CHANGE: CardPayload;
   EV_COMPLETE: CardPayload;
   EV_VALIDATED: CardPayload;
+  EV_FOCUS: CardField;
+  EV_BLUR: CardField;
+  EV_KEYDOWN: CardField;
+  EV_KEYUP: CardField;
 }
 
 export interface CardFrameHostMessages extends EvervaultFrameHostMessages {

--- a/packages/types/uiComponents.ts
+++ b/packages/types/uiComponents.ts
@@ -70,6 +70,11 @@ export interface CardPayload {
 
 export type CardField = "name" | "number" | "expiry" | "cvc";
 
+export interface FieldEvent {
+  field: CardField;
+  data: CardPayload;
+}
+
 interface CardFieldTranslations<E extends TranslationsObject>
   extends TranslationsObject {
   label?: string;

--- a/packages/ui-components/src/Card/CardCVC.tsx
+++ b/packages/ui-components/src/Card/CardCVC.tsx
@@ -12,6 +12,9 @@ import { useMask } from "../utilities/useMask";
 interface CVCProps {
   onChange: (v: string) => void;
   onBlur?: (e: FocusEvent<HTMLInputElement>) => void;
+  onFocus?: (e: FocusEvent<HTMLInputElement>) => void;
+  onKeyUp?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
   disabled: boolean;
   placeholder?: string;
   value: string;
@@ -31,6 +34,9 @@ export const CardCVC = forwardRef<HTMLInputElement, CVCProps>(
       value,
       readOnly,
       autoComplete,
+      onFocus,
+      onKeyUp,
+      onKeyDown,
     },
     forwardedRef
   ) => {
@@ -66,6 +72,9 @@ export const CardCVC = forwardRef<HTMLInputElement, CVCProps>(
         inputMode="numeric"
         autoComplete={autoComplete ? "billing cc-cvc" : "off"}
         readOnly={readOnly}
+        onFocus={onFocus}
+        onKeyUp={onKeyUp}
+        onKeyDown={onKeyDown}
       />
     );
   }

--- a/packages/ui-components/src/Card/CardExpiry.tsx
+++ b/packages/ui-components/src/Card/CardExpiry.tsx
@@ -6,6 +6,9 @@ import type { CardForm } from "./types";
 interface CardExpiryProps {
   onChange: (value: CardForm["expiry"]) => void;
   onBlur?: (e: FocusEvent<HTMLInputElement>) => void;
+  onFocus?: (e: FocusEvent<HTMLInputElement>) => void;
+  onKeyUp?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
   disabled: boolean;
   placeholder?: string;
   value: string;
@@ -41,6 +44,9 @@ export function CardExpiry({
   readOnly,
   autoComplete,
   autoProgress,
+  onFocus,
+  onKeyUp,
+  onKeyDown,
 }: CardExpiryProps) {
   const ref = useRef<HTMLInputElement>(null);
   const { setValue, mask } = useMask(ref, onChange, {
@@ -74,6 +80,9 @@ export function CardExpiry({
       inputMode="numeric"
       autoComplete={autoComplete ? "billing cc-exp" : "off"}
       readOnly={readOnly}
+      onFocus={onFocus}
+      onKeyUp={onKeyUp}
+      onKeyDown={onKeyDown}
     />
   );
 }

--- a/packages/ui-components/src/Card/CardHolder.tsx
+++ b/packages/ui-components/src/Card/CardHolder.tsx
@@ -5,6 +5,9 @@ interface CardHolderProps {
   autoFocus?: boolean;
   onChange: (v: string) => void;
   onBlur?: (e: FocusEvent<HTMLInputElement>) => void;
+  onFocus?: (e: FocusEvent<HTMLInputElement>) => void;
+  onKeyUp?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
   placeholder: string;
   value: string;
   readOnly?: boolean;
@@ -16,6 +19,9 @@ export function CardHolder({
   disabled,
   onChange,
   onBlur,
+  onFocus,
+  onKeyUp,
+  onKeyDown,
   placeholder,
   value,
   readOnly,
@@ -34,6 +40,9 @@ export function CardHolder({
       placeholder={placeholder}
       autoComplete={autoComplete ? "billing cc-name" : "off"}
       onChange={(e) => onChange(e.target.value)}
+      onFocus={onFocus}
+      onKeyUp={onKeyUp}
+      onKeyDown={onKeyDown}
     />
   );
 }

--- a/packages/ui-components/src/Card/CardNumber.tsx
+++ b/packages/ui-components/src/Card/CardNumber.tsx
@@ -9,6 +9,9 @@ interface CardNumberProps {
   autoFocus?: boolean;
   onChange: (v: string) => void;
   onBlur?: (e: FocusEvent<HTMLInputElement>) => void;
+  onFocus?: (e: FocusEvent<HTMLInputElement>) => void;
+  onKeyUp?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
   placeholder: string;
   value: string;
   readOnly?: boolean;
@@ -33,6 +36,9 @@ export function CardNumber({
   readOnly,
   autoComplete,
   autoProgress,
+  onFocus,
+  onKeyUp,
+  onKeyDown,
 }: CardNumberProps) {
   const ref = useRef<HTMLInputElement>(null);
 
@@ -102,6 +108,9 @@ export function CardNumber({
       placeholder={placeholder}
       pattern="[0-9]*"
       autoComplete={autoComplete ? "billing cc-number" : "off"}
+      onFocus={onFocus}
+      onKeyUp={onKeyUp}
+      onKeyDown={onKeyDown}
     />
   );
 }

--- a/packages/ui-components/src/Card/index.tsx
+++ b/packages/ui-components/src/Card/index.tsx
@@ -169,7 +169,6 @@ export function Card({ config }: { config: CardConfig }) {
   const hasErrors = Object.keys(form.errors ?? {}).length > 0;
 
   const handleFocus = (field: CardField) => () => {
-    console.log("FOCUS");
     send("EV_FOCUS", field);
   };
 

--- a/packages/ui-components/src/Card/index.tsx
+++ b/packages/ui-components/src/Card/index.tsx
@@ -24,7 +24,11 @@ import {
   swipePayload,
 } from "./utilities";
 import type { CardForm, CardConfig } from "./types";
-import type { CardFrameClientMessages, CardFrameHostMessages } from "types";
+import type {
+  CardField,
+  CardFrameClientMessages,
+  CardFrameHostMessages,
+} from "types";
 
 export function Card({ config }: { config: CardConfig }) {
   const cvc = useRef<HTMLInputElement | null>(null);
@@ -164,6 +168,23 @@ export function Card({ config }: { config: CardConfig }) {
 
   const hasErrors = Object.keys(form.errors ?? {}).length > 0;
 
+  const handleFocus = (field: CardField) => () => {
+    console.log("FOCUS");
+    send("EV_FOCUS", field);
+  };
+
+  const handleBlur = (field: CardField) => () => {
+    send("EV_BLUR", field);
+  };
+
+  const handleKeyDown = (field: CardField) => () => {
+    send("EV_KEYDOWN", field);
+  };
+
+  const handleKeyUp = (field: CardField) => () => {
+    send("EV_KEYUP", field);
+  };
+
   return (
     <fieldset
       ev-component="card"
@@ -184,7 +205,12 @@ export function Card({ config }: { config: CardConfig }) {
             placeholder={t("name.placeholder")}
             value={form.values.name}
             autoComplete={config.autoComplete?.name ?? true}
-            {...form.register("name")}
+            onFocus={handleFocus("name")}
+            onKeyUp={handleKeyUp("name")}
+            onKeyDown={handleKeyDown("name")}
+            {...form.register("name", {
+              onBlur: handleBlur("name"),
+            })}
           />
           {form.errors?.name && (
             <Error>{t(`name.errors.${form.errors.name}`)}</Error>
@@ -218,7 +244,12 @@ export function Card({ config }: { config: CardConfig }) {
             autoComplete={config.autoComplete?.number ?? true}
             autoProgress={config.autoProgress}
             form={form}
-            {...form.register("number")}
+            onFocus={handleFocus("number")}
+            onKeyUp={handleKeyUp("number")}
+            onKeyDown={handleKeyDown("number")}
+            {...form.register("number", {
+              onBlur: handleBlur("number"),
+            })}
           />
           {form.errors?.number && (
             <Error>{t(`number.errors.${form.errors.number}`)}</Error>
@@ -242,7 +273,12 @@ export function Card({ config }: { config: CardConfig }) {
             placeholder={t("expiry.placeholder")}
             autoComplete={config.autoComplete?.expiry ?? true}
             autoProgress={config.autoProgress}
-            {...form.register("expiry")}
+            onFocus={handleFocus("expiry")}
+            onKeyUp={handleKeyUp("expiry")}
+            onKeyDown={handleKeyDown("expiry")}
+            {...form.register("expiry", {
+              onBlur: handleBlur("expiry"),
+            })}
           />
           {form.errors?.expiry && (
             <Error>{t(`expiry.errors.${form.errors.expiry}`)}</Error>
@@ -264,7 +300,12 @@ export function Card({ config }: { config: CardConfig }) {
             cardNumber={form.values.number}
             readOnly={cardReaderListening}
             placeholder={t("cvc.placeholder")}
-            {...form.register("cvc")}
+            onFocus={handleFocus("cvc")}
+            onKeyUp={handleKeyUp("cvc")}
+            onKeyDown={handleKeyDown("cvc")}
+            {...form.register("cvc", {
+              onBlur: handleBlur("cvc"),
+            })}
           />
           {form.errors?.cvc && (
             <Error>{t(`cvc.errors.${form.errors.cvc}`)}</Error>


### PR DESCRIPTION
Some users have requested functionality to track interactions with individual fields inside of the Card component. This PR introduces 4 new events for the Card component. `focus`, `blur`, `keyup` and `keydown`. These events hook into the corresponding native events for each input, however, it's important that we don't provide the original event which would allow users to gain access to plain text data. Instead we pass an object which includes the field the event originated from, as well as the same card data payload that is sent with the `change` event.

e.g 

```
{
  field: "number",
  data: {
    card: {
      name: "",
      brand: "visa",
      localBrands: [],
      bin: "42424242",
      lastFour: "4242",
      number: "ev:QkTC:WXkiIR/el/Sihcpd:AwBL9S7F91yMdpl2kKYY8tgEJJWGQbiyOX4ciF+arpdO:Q96nNPbHVNenK1NkAAIhaElyfL3u0IDyjrQhjFNPzZxvzVkCbpc7n4e8AkA96to:$",
      expiry: {
        month: "12",
        year: "25"
      },
      cvc: null
    },
    isValid: true,
    isComplete: false,
    errors: null
  }
}
``` 

Users requesting this functionality have also stated that they would like to be able to distinguish between the user entering the expiry month vs the expiry year. Currently, we only return the expiry values once the user has entered a complete expiry date. This PR also changes the expiry validation so that the parsed month and year is returned even when the entered value is invalid.

e.g 

"03" would return `{ month: "03", year: null, isValid: false }`
"0320" would return `{ month: "03", year: "20", isValid: false }`
