### PR TITLE
Unmount 3ds instance on error

### DIFF
--- a/.changeset/five-deers-whisper.md
+++ b/.changeset/five-deers-whisper.md
@@ -1,0 +1,5 @@
+---
+"@evervault/react": minor
+---
+
+Remount 3ds component after error


### PR DESCRIPTION
# Why

Context: https://evervault.slack.com/archives/C05TBHREAG7/p1731332793569229

# How

Unmount the 3DS component on error/failure

## Before
Modal renders, errors, doesn't re-render, no subsequent patch calls
![before](https://github.com/user-attachments/assets/2def50cd-2e44-49cf-aa2b-c3522c636b6e)


## After
Modal renders, errors, re-renders, subsequent patch calls
![after](https://github.com/user-attachments/assets/3dcb9112-e11f-4b98-b40b-acffb87eda30)

