### PR TITLE
Add failOnChallenge option to 3DS

### DIFF
--- a/.changeset/loud-kids-bake.md
+++ b/.changeset/loud-kids-bake.md
@@ -1,0 +1,7 @@
+---
+"@evervault/ui-components": minor
+"@evervault/browser": minor
+"@evervault/react": minor
+---
+
+Add failOnChallenge option to ThreeDSecure UI Component

--- a/e2e-tests/ui-components/tests/threeDSecure.spec.js
+++ b/e2e-tests/ui-components/tests/threeDSecure.spec.js
@@ -85,6 +85,57 @@ test.describe("threeDSecure component", () => {
 
     await expect.poll(async () => called).toBeTruthy();
   });
+
+  test("can intentionally fail 3DS on challenge", async ({ page }) => {
+    let failed = false;
+
+    await page.exposeFunction("handleFailure", () => {
+      failed = true;
+    });
+
+    const session = await createThreeDSSession("4242424242424242");
+
+    await page.evaluate((sessionId) => {
+      const comp = window.evervault.ui.threeDSecure(sessionId, {
+        failOnChallenge: true,
+      });
+      comp.on("failure", window.handleFailure);
+      comp.mount();
+    }, session.id);
+
+    await expect.poll(async () => failed).toBeTruthy();
+  });
+
+  test("can intentionally fail 3DS on challenge with callback", async ({
+    page,
+  }) => {
+    let failed = false;
+    let called = false;
+
+    await page.exposeFunction("handleFailure", () => {
+      failed = true;
+    });
+
+    await page.exposeFunction("handleFailOnChallenge", () => {
+      called = true;
+    });
+
+    const session = await createThreeDSSession("4242424242424242");
+
+    await page.evaluate((sessionId) => {
+      const comp = window.evervault.ui.threeDSecure(sessionId, {
+        failOnChallenge: () => {
+          window.handleFailOnChallenge();
+        },
+      });
+
+      comp.on("failure", window.handleFailure);
+      comp.mount();
+    }, session.id);
+
+    await expect.poll(async () => failed).toBeTruthy();
+    await expect.poll(async () => called).toBeTruthy();
+  });
 });
 
 async function createThreeDSSession(number) {

--- a/examples/three-d-secure/src/main.ts
+++ b/examples/three-d-secure/src/main.ts
@@ -56,7 +56,7 @@ async function handleSubmit() {
     //   await new Promise((resolve) => setTimeout(resolve, 2000));
     //   return false;
     // },
-    failOnChallenge: false,
+    failOnChallenge: true,
   });
 
   // The 'success' event is emitted when the 3DS process has finished successfully

--- a/examples/three-d-secure/src/main.ts
+++ b/examples/three-d-secure/src/main.ts
@@ -52,7 +52,11 @@ async function handleSubmit() {
   // a 3DS UI Component to handle the 3DS process.
   const tds = evervault.ui.threeDSecure(session, {
     // The 'failOnChallenge' option will cause the 3DS process to fail if a challenge is required.
-    // failOnChallenge: true,
+    // failOnChallenge: async () => {
+    //   await new Promise((resolve) => setTimeout(resolve, 2000));
+    //   return false;
+    // },
+    failOnChallenge: false,
   });
 
   // The 'success' event is emitted when the 3DS process has finished successfully

--- a/examples/three-d-secure/src/main.ts
+++ b/examples/three-d-secure/src/main.ts
@@ -50,7 +50,10 @@ async function handleSubmit() {
 
   // Once a 3DS session has be initiated we can use the session ID to create
   // a 3DS UI Component to handle the 3DS process.
-  const tds = evervault.ui.threeDSecure(session);
+  const tds = evervault.ui.threeDSecure(session, {
+    // The 'failOnChallenge' option will cause the 3DS process to fail if a challenge is required.
+    // failOnChallenge: true,
+  });
 
   // The 'success' event is emitted when the 3DS process has finished successfully
   tds.on("success", () => {

--- a/examples/three-d-secure/src/main.ts
+++ b/examples/three-d-secure/src/main.ts
@@ -50,14 +50,7 @@ async function handleSubmit() {
 
   // Once a 3DS session has be initiated we can use the session ID to create
   // a 3DS UI Component to handle the 3DS process.
-  const tds = evervault.ui.threeDSecure(session, {
-    // The 'failOnChallenge' option will cause the 3DS process to fail if a challenge is required.
-    // failOnChallenge: async () => {
-    //   await new Promise((resolve) => setTimeout(resolve, 2000));
-    //   return false;
-    // },
-    failOnChallenge: true,
-  });
+  const tds = evervault.ui.threeDSecure(session);
 
   // The 'success' event is emitted when the 3DS process has finished successfully
   tds.on("success", () => {

--- a/packages/browser/lib/ui/threeDSecure.ts
+++ b/packages/browser/lib/ui/threeDSecure.ts
@@ -3,7 +3,6 @@ import { EvervaultFrame } from "./evervaultFrame";
 import type EvervaultClient from "../main";
 import type {
   SelectorType,
-  EvervaultFrameHostMessages,
   ThreeDSecureFrameClientMessages,
   ThreeDSecureOptions,
   ComponentError,

--- a/packages/browser/lib/ui/threeDSecure.ts
+++ b/packages/browser/lib/ui/threeDSecure.ts
@@ -47,6 +47,13 @@ export default class ThreeDSecure {
       void this.#handleOutcome("failure", cres);
     });
 
+    this.#frame.on("EV_FAIL_ON_CHALLENGE", () => {
+      void this.#handleOutcome("failure");
+      if (typeof this.#options.failOnChallenge === "function") {
+        this.#options.failOnChallenge();
+      }
+    });
+
     this.#frame.on("EV_CANCEL", () => {
       void this.#handleOutcome("cancelled");
     });
@@ -90,6 +97,7 @@ export default class ThreeDSecure {
         session: this.#session,
         size: this.#options.size,
         isOverlay: this.#isOverlay,
+        failOnChallenge: Boolean(this.#options.failOnChallenge),
       },
     };
   }

--- a/packages/browser/lib/ui/threeDSecure.ts
+++ b/packages/browser/lib/ui/threeDSecure.ts
@@ -7,6 +7,7 @@ import type {
   ThreeDSecureFrameClientMessages,
   ThreeDSecureOptions,
   ComponentError,
+  ThreeDSecureFrameHostMessages,
 } from "types";
 
 interface ThreeDSecureEvents {
@@ -23,7 +24,7 @@ export default class ThreeDSecure {
   #client: EvervaultClient;
   #frame: EvervaultFrame<
     ThreeDSecureFrameClientMessages,
-    EvervaultFrameHostMessages
+    ThreeDSecureFrameHostMessages
   >;
 
   #events = new EventManager<ThreeDSecureEvents>();
@@ -47,11 +48,9 @@ export default class ThreeDSecure {
       void this.#handleOutcome("failure", cres);
     });
 
-    this.#frame.on("EV_FAIL_ON_CHALLENGE", () => {
-      void this.#handleOutcome("failure");
-      if (typeof this.#options.failOnChallenge === "function") {
-        this.#options.failOnChallenge();
-      }
+    this.#frame.on("EV_FAIL_ON_CHALLENGE", async () => {
+      const result = await this.#failOnChallenge();
+      this.#frame.send("EV_FAIL_ON_CHALLENGE_RESULT", result);
     });
 
     this.#frame.on("EV_CANCEL", () => {
@@ -67,6 +66,20 @@ export default class ThreeDSecure {
       this.#events.dispatch("error", error);
       if (error) console.error(error.message);
     });
+  }
+
+  async #failOnChallenge(): Promise<boolean> {
+    if (typeof this.#options.failOnChallenge === "function") {
+      const result = this.#options.failOnChallenge();
+
+      if (result instanceof Promise) {
+        return await result;
+      }
+
+      return result;
+    }
+
+    return this.#options.failOnChallenge ?? false;
   }
 
   async #handleOutcome(outcome: string, cres?: string | null) {

--- a/packages/react/lib/ui/ThreeDSecure.tsx
+++ b/packages/react/lib/ui/ThreeDSecure.tsx
@@ -11,6 +11,7 @@ export interface ThreeDSecureProps {
   onSuccess?: () => void;
   onFailure?: () => void;
   onError?: (error: ComponentError) => void;
+  failOnChallenge?: boolean | (() => void);
 }
 
 type ThreeDSecureInstance = ReturnType<Evervault["ui"]["threeDSecure"]>;
@@ -23,6 +24,7 @@ export function ThreeDSecure({
   onError,
   onSuccess,
   onFailure,
+  failOnChallenge,
 }: ThreeDSecureProps) {
   const ev = useEvervault();
   const initialized = React.useRef(false);
@@ -55,8 +57,9 @@ export function ThreeDSecure({
     () => ({
       theme,
       size,
+      failOnChallenge,
     }),
-    [theme, size]
+    [theme, size, failOnChallenge]
   );
 
   React.useLayoutEffect(() => {

--- a/packages/react/lib/ui/ThreeDSecure.tsx
+++ b/packages/react/lib/ui/ThreeDSecure.tsx
@@ -11,7 +11,7 @@ export interface ThreeDSecureProps {
   onSuccess?: () => void;
   onFailure?: () => void;
   onError?: (error: ComponentError) => void;
-  failOnChallenge?: boolean | (() => void);
+  failOnChallenge?: boolean | (() => boolean) | (() => Promise<boolean>);
 }
 
 type ThreeDSecureInstance = ReturnType<Evervault["ui"]["threeDSecure"]>;

--- a/packages/react/lib/ui/useThreeDSecure.ts
+++ b/packages/react/lib/ui/useThreeDSecure.ts
@@ -6,7 +6,7 @@ import { useEvervault } from "../useEvervault";
 interface UseThreeDSecureOptions {
   theme?: ThemeDefinition;
   size?: { width: string; height: string };
-  failOnChallenge?: boolean | (() => void);
+  failOnChallenge?: boolean | (() => boolean) | (() => Promise<boolean>);
 }
 
 interface UseThreeDSecureCallbacks {

--- a/packages/react/lib/ui/useThreeDSecure.ts
+++ b/packages/react/lib/ui/useThreeDSecure.ts
@@ -6,6 +6,7 @@ import { useEvervault } from "../useEvervault";
 interface UseThreeDSecureOptions {
   theme?: ThemeDefinition;
   size?: { width: string; height: string };
+  failOnChallenge?: boolean | (() => void);
 }
 
 interface UseThreeDSecureCallbacks {

--- a/packages/types/uiComponents.ts
+++ b/packages/types/uiComponents.ts
@@ -213,12 +213,14 @@ export interface FormFrameClientMessages extends EvervaultFrameClientMessages {
 export interface ThreeDSecureOptions {
   theme?: ThemeDefinition;
   size?: { width: string; height: string };
+  failOnChallenge?: boolean | (() => void);
 }
 
 export interface ThreeDSecureFrameClientMessages
   extends EvervaultFrameClientMessages {
   EV_SUCCESS: string | undefined | null;
   EV_FAILURE: string | undefined | null;
+  EV_FAIL_ON_CHALLENGE: undefined;
   EV_CANCEL: undefined;
 }
 

--- a/packages/types/uiComponents.ts
+++ b/packages/types/uiComponents.ts
@@ -213,7 +213,12 @@ export interface FormFrameClientMessages extends EvervaultFrameClientMessages {
 export interface ThreeDSecureOptions {
   theme?: ThemeDefinition;
   size?: { width: string; height: string };
-  failOnChallenge?: boolean | (() => void);
+  failOnChallenge?: boolean | (() => boolean) | (() => Promise<boolean>);
+}
+
+export interface ThreeDSecureFrameHostMessages
+  extends EvervaultFrameHostMessages {
+  EV_FAIL_ON_CHALLENGE_RESULT: boolean;
 }
 
 export interface ThreeDSecureFrameClientMessages

--- a/packages/ui-components/src/ThreeDSecure/index.tsx
+++ b/packages/ui-components/src/ThreeDSecure/index.tsx
@@ -46,6 +46,10 @@ export function ThreeDSecure({ config }: { config: ThreeDSecureConfig }) {
     if (session?.status === "failure") {
       send("EV_FAILURE");
     }
+
+    if (isChallengeAction(session?.nextAction) && config.failOnChallenge) {
+      send("EV_FAIL_ON_CHALLENGE");
+    }
   }, [session]);
 
   return (
@@ -63,7 +67,7 @@ export function ThreeDSecure({ config }: { config: ThreeDSecureConfig }) {
           />
         )}
 
-        {isChallengeAction(session?.nextAction) && (
+        {isChallengeAction(session?.nextAction) && !config.failOnChallenge && (
           <ChallengeFrame
             nextAction={session.nextAction}
             onLoad={() => setChallengeFrameReady(true)}

--- a/packages/ui-components/src/ThreeDSecure/types.ts
+++ b/packages/ui-components/src/ThreeDSecure/types.ts
@@ -24,6 +24,7 @@ export interface ThreeDSecureConfig {
   isOverlay: boolean;
   session: string;
   size?: { width: number; height: number };
+  failOnChallenge?: boolean;
 }
 
 export type TrampolineMessage = MessageEvent<{

--- a/packages/ui-components/src/ThreeDSecure/utilities.ts
+++ b/packages/ui-components/src/ThreeDSecure/utilities.ts
@@ -1,6 +1,5 @@
 import { RefObject, useCallback, useEffect, useRef, useState } from "react";
 import {
-  EvervaultFrameHostMessages,
   ThreeDSecureFrameClientMessages,
   ThreeDSecureFrameHostMessages,
 } from "types";

--- a/packages/ui-components/src/ThreeDSecure/utilities.ts
+++ b/packages/ui-components/src/ThreeDSecure/utilities.ts
@@ -2,6 +2,7 @@ import { RefObject, useCallback, useEffect, useRef, useState } from "react";
 import {
   EvervaultFrameHostMessages,
   ThreeDSecureFrameClientMessages,
+  ThreeDSecureFrameHostMessages,
 } from "types";
 import { useMessaging } from "../utilities/useMessaging";
 import { useSearchParams } from "../utilities/useSearchParams";
@@ -58,7 +59,7 @@ export async function getBrowserSession(
 
 export function useThreeDSMessaging() {
   return useMessaging<
-    EvervaultFrameHostMessages,
+    ThreeDSecureFrameHostMessages,
     ThreeDSecureFrameClientMessages
   >();
 }


### PR DESCRIPTION
> [!IMPORTANT] 
> Currently blocked by API requirements.

Some users only want to use frictionless 3DS and want to fail if a challenge is requested. This adds support for a new `failOnChallenge` option.

It can either be set to a boolean or a function which returns a boolean or promise that resolves to a boolean.

```js
const tds = evervault.ui.threeDSecure('session', {
  failOnChallenge: true
})

tds.on('failure', () => {
  console.log('failed')
})

// or

const tds = evervault.ui.threeDSecure('session', {
  failOnChallenge: async () => {
    console.log('3DS was challenged')
    return false
  }
})
```