### PR TITLE
Infer Google Pay environment from deployment environment

### DIFF
--- a/packages/browser/lib/ui/googlePay.ts
+++ b/packages/browser/lib/ui/googlePay.ts
@@ -84,7 +84,6 @@ export default class GooglePay {
         color: this.#options.color,
         locale: this.#options.locale,
         borderRadius: this.#options.borderRadius,
-        environment: this.#options.environment,
         allowedAuthMethods: this.#options.allowedAuthMethods,
         allowedCardNetworks: this.#options.allowedCardNetworks,
       },

--- a/packages/types/uiComponents.ts
+++ b/packages/types/uiComponents.ts
@@ -351,7 +351,6 @@ export interface GooglePayOptions {
   size?: { width: WalletDimension; height: WalletDimension };
   allowedAuthMethods?: google.payments.api.CardAuthMethod[];
   allowedCardNetworks?: google.payments.api.CardNetwork[];
-  environment?: "TEST" | "PRODUCTION";
 }
 
 export type ApplePayButtonType =

--- a/packages/ui-components/src/GooglePay/index.tsx
+++ b/packages/ui-components/src/GooglePay/index.tsx
@@ -32,7 +32,7 @@ export function GooglePay({ config }: GooglePayProps) {
 
     async function onLoad() {
       const paymentsClient = new google.payments.api.PaymentsClient({
-        environment: config.environment,
+        environment: process.env.VITE_STAGING ? "TEST" : "PRODUCTION",
         paymentDataCallbacks: {
           onPaymentAuthorized: async (data) => {
             const encrypted = await exchangePaymentData(

--- a/packages/ui-components/src/GooglePay/types.ts
+++ b/packages/ui-components/src/GooglePay/types.ts
@@ -10,7 +10,6 @@ export interface GooglePayConfig {
   color: GooglePayButtonColor;
   locale?: string;
   borderRadius: number;
-  environment: "TEST" | "PRODUCTION";
   allowedAuthMethods?: string[];
   allowedCardNetworks?: string[];
 }

--- a/turbo.json
+++ b/turbo.json
@@ -13,6 +13,7 @@
       "inputs": ["$TURBO_DEFAULT$", ".env"]
     },
     "e2e:test": {
+      "cache": false,
       "dependsOn": ["build"],
       "outputs": ["playwright-report/**", "test-results/**", ".nyc_output/**"]
     },


### PR DESCRIPTION
# Why

CAPI has separate config in Staging and Prod. When google pay targets the 'TEST' environment, it uses the Staging config. This means it will always error in Prod. We have two options, implement both sets of config in CAPI Prod and allow users to set 'TEST' | 'PRODUCTION', or remove the choice entirely so that only the relevant config for the given environment can be targeted.

For now, we'll take the easy route. I can see in time that we might go the other way - it is probably beneficial if users can test their integration without executing real transactions.

# How

Remove the config.environment field from GooglePayOptions, set the value based on the environment when creating the paymentsClient.
