### PR TITLE
Add redactCVC option to set cvc input type to password

### DIFF
--- a/.changeset/heavy-paws-walk.md
+++ b/.changeset/heavy-paws-walk.md
@@ -1,0 +1,7 @@
+---
+"@evervault/ui-components": minor
+"@evervault/browser": minor
+"@evervault/react": minor
+---
+
+Add redactCVC option to visually redact the CVC value

--- a/e2e-tests/ui-components/tests/cardDetails.spec.js
+++ b/e2e-tests/ui-components/tests/cardDetails.spec.js
@@ -783,6 +783,19 @@ test.describe("card component", () => {
 
     await expect(frame.getByLabel("Card Holder")).toHaveValue("Michael Scott");
   });
+
+  test("Can redact CVC field", async ({ page }) => {
+    await page.evaluate(() => {
+      window.card = window.evervault.ui.card({
+        redactCVC: true,
+      });
+      window.card.mount("#form");
+    });
+
+    const frame = page.frameLocator("iframe[data-evervault]");
+    const cvc = frame.getByLabel("CVC");
+    expect(await cvc.getAttribute("type")).toEqual("password");
+  });
 });
 
 async function decrypt(payload) {

--- a/examples/collect-card-details/src/main.ts
+++ b/examples/collect-card-details/src/main.ts
@@ -15,6 +15,7 @@ const evervault = new window.Evervault(
 const card = evervault.ui.card({
   icons: true,
   theme: evervault.ui.themes.clean(),
+  redactCVC: true,
 });
 
 card.on("change", (values) => {

--- a/packages/browser/lib/ui/card.ts
+++ b/packages/browser/lib/ui/card.ts
@@ -112,6 +112,7 @@ export default class Card {
         defaultValues: this.#options.defaultValues,
         autoComplete: this.#options.autoComplete,
         autoProgress: this.#options.autoProgress,
+        redactCVC: this.#options.redactCVC,
       },
     };
   }

--- a/packages/react/lib/ui/Card.tsx
+++ b/packages/react/lib/ui/Card.tsx
@@ -33,6 +33,7 @@ export interface CardProps {
   onBlur?: (event: FieldEvent) => void;
   onKeyUp?: (event: FieldEvent) => void;
   onKeyDown?: (event: FieldEvent) => void;
+  redactCVC?: boolean;
 }
 
 type CardClass = ReturnType<Evervault["ui"]["card"]>;
@@ -56,6 +57,7 @@ export function Card({
   autoProgress,
   acceptedBrands,
   defaultValues,
+  redactCVC,
 }: CardProps) {
   const ev = useEvervault();
   const initialized = useRef(false);
@@ -127,6 +129,7 @@ export function Card({
       autoProgress,
       acceptedBrands,
       defaultValues,
+      redactCVC,
     }),
     [
       theme,
@@ -138,6 +141,7 @@ export function Card({
       autoProgress,
       acceptedBrands,
       defaultValues,
+      redactCVC,
     ]
   );
 

--- a/packages/types/uiComponents.ts
+++ b/packages/types/uiComponents.ts
@@ -102,6 +102,7 @@ export interface CardOptions {
   acceptedBrands?: CardBrandName[];
   translations?: Partial<CardTranslations>;
   autoProgress?: boolean;
+  redactCVC?: boolean;
   defaultValues?: {
     name?: string;
   };

--- a/packages/ui-components/src/Card/CardCVC.tsx
+++ b/packages/ui-components/src/Card/CardCVC.tsx
@@ -21,6 +21,7 @@ interface CVCProps {
   readOnly?: boolean;
   cardNumber: string;
   autoComplete?: boolean;
+  redact?: boolean;
 }
 
 export const CardCVC = forwardRef<HTMLInputElement, CVCProps>(
@@ -37,6 +38,7 @@ export const CardCVC = forwardRef<HTMLInputElement, CVCProps>(
       onFocus,
       onKeyUp,
       onKeyDown,
+      redact,
     },
     forwardedRef
   ) => {
@@ -64,7 +66,7 @@ export const CardCVC = forwardRef<HTMLInputElement, CVCProps>(
         ref={innerRef}
         id="cvc"
         name="cvc"
-        type="text"
+        type={redact ? "password" : "text"}
         disabled={disabled}
         onBlur={onBlur}
         placeholder={placeholder}

--- a/packages/ui-components/src/Card/index.tsx
+++ b/packages/ui-components/src/Card/index.tsx
@@ -302,6 +302,7 @@ export function Card({ config }: { config: CardConfig }) {
             onFocus={handleFocus("cvc")}
             onKeyUp={handleKeyUp("cvc")}
             onKeyDown={handleKeyDown("cvc")}
+            redact={config.redactCVC}
             {...form.register("cvc", {
               onBlur: handleBlur("cvc"),
             })}

--- a/packages/ui-components/src/Card/types.ts
+++ b/packages/ui-components/src/Card/types.ts
@@ -15,6 +15,7 @@ export interface CardConfig {
   acceptedBrands?: CardBrandName[];
   translations?: Partial<CardTranslations>;
   autoProgress?: boolean;
+  redactCVC?: boolean;
   defaultValues?: {
     name?: string;
   };


### PR DESCRIPTION
Some users want the functionality to visually redact the CVC value by setting the input type to "password"

```
evervault.ui.card({ redactCVC: true })
```