### PR TITLE
dave/wallet api/merchant id domain changes

### DIFF
--- a/.changeset/orange-wombats-raise.md
+++ b/.changeset/orange-wombats-raise.md
@@ -1,0 +1,7 @@
+---
+"example-react-google-wallet": minor
+"@evervault/ui-components": minor
+"types": minor
+---
+
+Remove merchant.domain field and infer value from window

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,6 +31,7 @@ jobs:
       EV_APP_UUID: ${{ secrets.tests_app_uuid }}
       EV_DECRYPT_FN_KEY: ${{ secrets.tests_decrypt_fn_key }}
       EV_TEAM_UUID: ${{ secrets.tests_team_uuid }}
+      VITE_GOOGLE_PAY_MERCHANT_ID: ${{ vars.GOOGLE_PAY_MERCHANT_ID }}
       VITE_EV_APP_UUID: ${{ secrets.tests_app_uuid }}
       VITE_EV_TEAM_UUID: ${{ secrets.tests_team_uuid }}
       VITE_API_URL: "https://api.evervault.com"

--- a/examples/react-google-wallet/src/App.tsx
+++ b/examples/react-google-wallet/src/App.tsx
@@ -22,7 +22,6 @@ function App() {
         merchant: {
           id: "merchant_d8e4353154df",
           name: "Test Merchant",
-          domain: "ev-wallet.ngrok.app",
         },
       });
 

--- a/packages/types/uiComponents.ts
+++ b/packages/types/uiComponents.ts
@@ -475,7 +475,6 @@ export interface TransactionDetails {
   merchant: {
     id: string;
     name: string;
-    domain?: string;
   };
   lineItems?: TransactionLineItem[];
 }

--- a/packages/ui-components/src/ApplePay/index.tsx
+++ b/packages/ui-components/src/ApplePay/index.tsx
@@ -161,12 +161,6 @@ export function ApplePay({ config }: ApplePayProps) {
     return null;
   }
 
-  if (!config.transaction.merchant.domain) {
-    throw new Error(
-      "Apple Pay Merchant Identifier not found, please set merchant.domain on the transaction"
-    );
-  }
-
   const containerStyle: CSSProperties = {
     position: "relative",
     width: "100vw",

--- a/packages/ui-components/src/ApplePay/utilities.ts
+++ b/packages/ui-components/src/ApplePay/utilities.ts
@@ -55,7 +55,7 @@ async function validateMerchant(
     },
     body: JSON.stringify({
       merchantUuid: tx.merchant.id,
-      domain: tx.merchant.domain,
+      domain: window.location.origin,
     }),
   });
 

--- a/packages/ui-components/src/Card/CardExpiry.tsx
+++ b/packages/ui-components/src/Card/CardExpiry.tsx
@@ -51,7 +51,7 @@ export function CardExpiry({
   const ref = useRef<HTMLInputElement>(null);
   const { setValue, mask } = useMask(ref, onChange, {
     mask: "MM / YY",
-    blocks: EXPIRY_BLOCKS,
+    blocks: EXPIRY_BLOCKS as typeof useMask.prototype.blocks,
   });
 
   useEffect(() => {

--- a/packages/ui-components/src/GooglePay/utilities.ts
+++ b/packages/ui-components/src/GooglePay/utilities.ts
@@ -1,5 +1,6 @@
 import { EncryptedGooglePayData } from "types";
 import { GooglePayConfig } from "./types";
+import { apiConfig } from "../utilities/config";
 
 export function buildPaymentRequest(
   config: GooglePayConfig
@@ -38,7 +39,7 @@ export function buildPaymentRequest(
       },
     ],
     merchantInfo: {
-      merchantId: tx.merchant.id,
+      merchantId: apiConfig.googlePayMerchantId,
       merchantName: tx.merchant.name,
       merchantOrigin: window.location.origin, // merchantOrigin is not present in the GooglePayConfig type but is noted as required by the GooglePay API
     } as unknown as google.payments.api.MerchantInfo,

--- a/packages/ui-components/src/GooglePay/utilities.ts
+++ b/packages/ui-components/src/GooglePay/utilities.ts
@@ -40,7 +40,7 @@ export function buildPaymentRequest(
     merchantInfo: {
       merchantId: tx.merchant.id,
       merchantName: tx.merchant.name,
-      merchantOrigin: tx.merchant.domain, // merchantOrigin is not present in the GooglePayConfig type but is noted as required by the GooglePay API
+      merchantOrigin: window.location.origin, // merchantOrigin is not present in the GooglePayConfig type but is noted as required by the GooglePay API
     } as unknown as google.payments.api.MerchantInfo,
     transactionInfo: {
       totalPriceStatus: "FINAL",

--- a/packages/ui-components/src/utilities/config.ts
+++ b/packages/ui-components/src/utilities/config.ts
@@ -10,15 +10,16 @@ const googlePayEnvironment: google.payments.api.Environment = isProduction
   ? "PRODUCTION"
   : "TEST";
 
-const apiUrl = isProduction
+const apiUrl: string = isProduction
   ? "https://api.evervault.com"
   : import.meta.env.VITE_API_URL ?? "https://api.evervault.io";
 
-const keysUrl = isProduction
+const keysUrl: string = isProduction
   ? "https://keys.evervault.com"
   : import.meta.env.VITE_KEYS_URL ?? "https://keys.evervault.io";
 
-const GOOGLE_PAY_MERCHANT_ID = isProduction ? "BCR2DN4TX7AOD7BD" : undefined;
+const GOOGLE_PAY_MERCHANT_ID: string | undefined = import.meta.env
+  .VITE_GOOGLE_PAY_MERCHANT_ID;
 
 const apiConfig = {
   environment,

--- a/packages/ui-components/src/utilities/config.ts
+++ b/packages/ui-components/src/utilities/config.ts
@@ -18,11 +18,14 @@ const keysUrl = isProduction
   ? "https://keys.evervault.com"
   : import.meta.env.VITE_KEYS_URL ?? "https://keys.evervault.io";
 
+const GOOGLE_PAY_MERCHANT_ID = isProduction ? "BCR2DN4TX7AOD7BD" : undefined;
+
 const apiConfig = {
   environment,
   googlePayEnvironment,
   apiUrl,
   keysUrl,
+  googlePayMerchantId: GOOGLE_PAY_MERCHANT_ID,
 } as const;
 
 export { apiConfig };


### PR DESCRIPTION
# Why

Fix Google Pay and improve Transaction API ergonomics

# How

- Use a static merchant ID value as provided by Google for Google Pay merchant.id
- Infer the merchant domain from the window for both Google and Apple Pay, remove the domain field from the merchant object.
