### PR TITLE
Add packages for testing pre releases

### DIFF
--- a/e2e-tests/browser-pre-release/index.html
+++ b/e2e-tests/browser-pre-release/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script src="%VITE_EVERVAULT_JS_URL%"></script>
+  </head>
+
+  <body>
+    <script>
+      window.evervault = new Evervault(
+        "%VITE_EV_TEAM_UUID%",
+        "%VITE_EV_APP_UUID%"
+      );
+    </script>
+  </body>
+</html>

--- a/e2e-tests/browser-pre-release/package.json
+++ b/e2e-tests/browser-pre-release/package.json
@@ -1,0 +1,13 @@
+{
+  "private": true,
+  "name": "@repo/browser-pre-release-tests",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "vite --port 4000",
+    "test-prerelease": "playwright test",
+    "clean": "rm -rf .turbo node_modules dist"
+  },
+  "devDependencies": {
+    "vite": "catalog:"
+  }
+}

--- a/e2e-tests/browser-pre-release/playwright.config.js
+++ b/e2e-tests/browser-pre-release/playwright.config.js
@@ -1,0 +1,32 @@
+import { defineConfig, devices } from "@playwright/test";
+import dotenv from "dotenv";
+dotenv.config({ path: "../../.env" });
+
+export default defineConfig({
+  testDir: "./tests",
+  timeout: 30 * 1000,
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: "html",
+  use: {
+    trace: "retain-on-failure",
+    video: "retain-on-failure",
+  },
+
+  projects: [
+    {
+      name: "chromium",
+      use: devices["Desktop Chrome"],
+    },
+  ],
+
+  webServer: [
+    {
+      command: "pnpm --filter @repo/browser-pre-release-tests dev --port 4000",
+      url: "http://localhost:4000",
+      timeout: 20 * 3000,
+    },
+  ],
+});

--- a/e2e-tests/browser-pre-release/tests/encrypt.spec.js
+++ b/e2e-tests/browser-pre-release/tests/encrypt.spec.js
@@ -1,0 +1,43 @@
+import { test, expect } from "@playwright/test";
+
+test("can encrypt a string", async ({ page }) => {
+  await page.goto("http://localhost:4000");
+  await page.waitForFunction(() => window.Evervault);
+
+  let result = null;
+
+  await page.exposeFunction("setResult", (data) => {
+    result = data;
+  });
+
+  await page.evaluate(async () => {
+    const encrypted = await window.evervault.encrypt("hello world");
+    document.body.append(encrypted);
+    window.setResult(encrypted);
+  });
+
+  const decrypted = await decrypt(result);
+  expect(decrypted).toEqual("hello world");
+});
+
+async function decrypt(payload) {
+  const token = btoa(
+    `${process.env.VITE_EV_APP_UUID}:${process.env.EV_API_KEY}`
+  );
+
+  try {
+    const response = await fetch(`https://api.evervault.com/decrypt`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Basic ${token}`,
+      },
+      body: JSON.stringify(payload),
+    });
+
+    return response.json();
+  } catch (e) {
+    console.log("decrypt error");
+    console.error(e);
+  }
+}

--- a/e2e-tests/ui-components-pre-release/index.html
+++ b/e2e-tests/ui-components-pre-release/index.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script src="https://js.evervault.com/v2"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap"
+      rel="stylesheet"
+    />
+
+    <style>
+      * {
+        margin: 0;
+        padding: 0;
+        font-family: "Inter", sans-serif;
+      }
+
+      body {
+        -webkit-font-smoothing: antialiased;
+      }
+
+      input,
+      button,
+      textarea,
+      select {
+        font: inherit;
+      }
+
+      button {
+        border: none;
+        height: 40px;
+        color: white;
+        font-size: 14px;
+        padding: 0 20px;
+        appearance: none;
+        background: black;
+      }
+    </style>
+  </head>
+
+  <body>
+    <h1>Checkout</h1>
+    <div id="form"></div>
+    <button id="submit">Submit</button>
+    <script>
+      window.evervault = new Evervault(
+        "%VITE_EV_TEAM_UUID%",
+        "%VITE_EV_APP_UUID%",
+        {
+          urls: {
+            componentsUrl: "%VITE_UI_COMPONENTS_URL%",
+          },
+        }
+      );
+    </script>
+  </body>
+</html>

--- a/e2e-tests/ui-components-pre-release/package.json
+++ b/e2e-tests/ui-components-pre-release/package.json
@@ -1,0 +1,13 @@
+{
+  "private": true,
+  "name": "@repo/ui-components-pre-release-tests",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "vite --port 4000",
+    "test-prerelease": "playwright test",
+    "clean": "rm -rf .turbo node_modules dist"
+  },
+  "devDependencies": {
+    "vite": "catalog:"
+  }
+}

--- a/e2e-tests/ui-components-pre-release/playwright.config.js
+++ b/e2e-tests/ui-components-pre-release/playwright.config.js
@@ -1,0 +1,33 @@
+import { defineConfig, devices } from "@playwright/test";
+import dotenv from "dotenv";
+dotenv.config({ path: "../../.env" });
+
+export default defineConfig({
+  testDir: "./tests",
+  timeout: 30 * 1000,
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: "html",
+  use: {
+    trace: "retain-on-failure",
+    video: "retain-on-failure",
+  },
+
+  projects: [
+    {
+      name: "chromium",
+      use: devices["Desktop Chrome"],
+    },
+  ],
+
+  webServer: [
+    {
+      command:
+        "pnpm --filter @repo/ui-components-prerelease-tests dev --port 4000",
+      url: "http://localhost:4000",
+      timeout: 20 * 3000,
+    },
+  ],
+});

--- a/e2e-tests/ui-components-pre-release/tests/cards.spec.js
+++ b/e2e-tests/ui-components-pre-release/tests/cards.spec.js
@@ -1,0 +1,49 @@
+import { test, expect } from "@playwright/test";
+
+test("can encrypt a card", async ({ page }) => {
+  await page.goto("http://localhost:4000");
+  await page.waitForFunction(() => window.Evervault);
+
+  let values = {};
+
+  await page.exposeFunction("handleChange", (newValues) => {
+    values = newValues;
+  });
+
+  await page.evaluate(() => {
+    const comp = window.evervault.ui.card();
+    comp.on("change", window.handleChange);
+    comp.mount("#form");
+  });
+
+  const frame = page.frameLocator("iframe[data-evervault]");
+  await frame.getByLabel("Number").fill("4242424242424242");
+  await frame.getByLabel("Expiration").fill("12/35");
+  await frame.getByLabel("CVC").fill("123");
+  await expect.poll(async () => values.card?.brand).toEqual("visa");
+  const decrypted = await decrypt(values.card);
+  expect(decrypted.number).toEqual("4242424242424242");
+  expect(decrypted.cvc).toEqual("123");
+});
+
+async function decrypt(payload) {
+  const token = btoa(
+    `${process.env.VITE_EV_APP_UUID}:${process.env.EV_API_KEY}`
+  );
+
+  try {
+    const response = await fetch(`https://api.evervault.com/decrypt`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Basic ${token}`,
+      },
+      body: JSON.stringify(payload),
+    });
+
+    return response.json();
+  } catch (e) {
+    console.log("decrypt error");
+    console.error(e);
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ catalogs:
     express:
       specifier: ^4
       version: 4.21.0
+    globals:
+      specifier: ^15.10.0
+      version: 15.14.0
     husky:
       specifier: ^9.1.1
       version: 9.1.7
@@ -159,6 +162,9 @@ catalogs:
     peggy:
       specifier: ^4.0.2
       version: 4.2.0
+    pino:
+      specifier: ^9
+      version: 9.6.0
     pino-http:
       specifier: ^10
       version: 10.3.0
@@ -343,6 +349,12 @@ importers:
         specifier: 'catalog:'
         version: 5.4.11(@types/node@22.10.7)(lightningcss@1.27.0)(terser@5.31.0)
 
+  e2e-tests/browser-pre-release:
+    devDependencies:
+      vite:
+        specifier: 'catalog:'
+        version: 5.4.11(@types/node@22.10.7)(lightningcss@1.27.0)(terser@5.31.0)
+
   e2e-tests/inputs:
     dependencies:
       '@evervault/inputs':
@@ -361,6 +373,12 @@ importers:
       v8-to-istanbul:
         specifier: 'catalog:'
         version: 9.3.0
+
+  e2e-tests/ui-components-pre-release:
+    devDependencies:
+      vite:
+        specifier: 'catalog:'
+        version: 5.4.11(@types/node@22.10.7)(lightningcss@1.27.0)(terser@5.31.0)
 
   e2e-tests/ui-components/vanilla-test-server:
     dependencies:


### PR DESCRIPTION
# Why
Allows us to run quick asserts against a specific instance of the browser SDK and UI Components. This will allow us to do prerelease testing before promoting a release to production.


```
VITE_EV_TEAM_UUID=... VITE_EV_APP_UUID=... VITE_API_KEY=... VITE_UI_COMPONENTS_URL=https://preview-url pnpm --filter=@repo/ui-components-pre-release-tests test-prerelease

VITE_EV_TEAM_UUID=... VITE_EV_APP_UUID=... VITE_API_KEY=... VITE_EVERVAULT_JS_URL=https://preview-url pnpm --filter=@repo/browser-pre-release-tests test-prerelease
```