### PR TITLE
[EV-878] Propgate fail on challenge to CAPI'

### DIFF
--- a/.changeset/real-crews-shave.md
+++ b/.changeset/real-crews-shave.md
@@ -1,0 +1,7 @@
+---
+"@evervault/ui-components": minor
+"@evervault/browser": minor
+"types": minor
+---
+
+Send specific outcome for failOnChallenge

--- a/packages/browser/lib/ui/threeDSecure.ts
+++ b/packages/browser/lib/ui/threeDSecure.ts
@@ -105,7 +105,7 @@ export default class ThreeDSecure {
     let updatedOutcome = outcome;
     if (abortedOnChallenge && outcome === "failure") {
       updatedOutcome = "abortedOnChallenge";
-    } 
+    }
 
     await fetch(`${api}/frontend/3ds/browser-sessions/${this.#session}`, {
       method: "PATCH",

--- a/packages/browser/lib/ui/threeDSecure.ts
+++ b/packages/browser/lib/ui/threeDSecure.ts
@@ -48,7 +48,7 @@ export default class ThreeDSecure {
     });
 
     this.#frame.on("EV_FAILURE_FORCED_DUE_TO_CHALLENGE", (cres) => {
-      void this.#handleOutcome("failure", cres);
+      void this.#handleOutcome("failure", cres, true);
     });
 
     this.#frame.on("EV_FAIL_ON_CHALLENGE", async () => {
@@ -88,9 +88,9 @@ export default class ThreeDSecure {
   async #handleOutcome(
     outcome: string,
     cres?: string | null,
-    failedDueToChallenge: boolean = false
+    abortedOnChallenge: boolean = false
   ) {
-    await this.#updateOutcome(outcome, cres, failedDueToChallenge);
+    await this.#updateOutcome(outcome, cres, abortedOnChallenge);
     this.#events.dispatch(outcome === "success" ? "success" : "failure");
     this.unmount();
   }
@@ -98,7 +98,7 @@ export default class ThreeDSecure {
   async #updateOutcome(
     outcome: string,
     cres?: string | null,
-    failedDueToChallenge?: boolean | null
+    abortedOnChallenge?: boolean | null
   ): Promise<void> {
     const api = this.#client.config.http.apiUrl;
     await fetch(`${api}/frontend/3ds/browser-sessions/${this.#session}`, {
@@ -110,7 +110,7 @@ export default class ThreeDSecure {
       body: JSON.stringify({
         outcome,
         cres: cres ?? null,
-        failedDueToChallenge,
+        abortedOnChallenge,
       }),
     });
   }

--- a/packages/browser/lib/ui/threeDSecure.ts
+++ b/packages/browser/lib/ui/threeDSecure.ts
@@ -88,9 +88,9 @@ export default class ThreeDSecure {
   async #handleOutcome(
     outcome: string,
     cres?: string | null,
-    failedDueToChallege: boolean = false
+    failedDueToChallenge: boolean = false
   ) {
-    await this.#updateOutcome(outcome, cres, failedDueToChallege);
+    await this.#updateOutcome(outcome, cres, failedDueToChallenge);
     this.#events.dispatch(outcome === "success" ? "success" : "failure");
     this.unmount();
   }
@@ -98,7 +98,7 @@ export default class ThreeDSecure {
   async #updateOutcome(
     outcome: string,
     cres?: string | null,
-    failedDueToChallege?: boolean | null
+    failedDueToChallenge?: boolean | null
   ): Promise<void> {
     const api = this.#client.config.http.apiUrl;
     await fetch(`${api}/frontend/3ds/browser-sessions/${this.#session}`, {
@@ -110,7 +110,7 @@ export default class ThreeDSecure {
       body: JSON.stringify({
         outcome,
         cres: cres ?? null,
-        failedDueToChallege,
+        failedDueToChallenge,
       }),
     });
   }

--- a/packages/browser/lib/ui/threeDSecure.ts
+++ b/packages/browser/lib/ui/threeDSecure.ts
@@ -101,6 +101,12 @@ export default class ThreeDSecure {
     abortedOnChallenge?: boolean | null
   ): Promise<void> {
     const api = this.#client.config.http.apiUrl;
+
+    let updatedOutcome = outcome;
+    if (abortedOnChallenge && outcome === "failure") {
+      updatedOutcome = "abortedOnChallenge";
+    } 
+
     await fetch(`${api}/frontend/3ds/browser-sessions/${this.#session}`, {
       method: "PATCH",
       headers: {
@@ -108,9 +114,8 @@ export default class ThreeDSecure {
         "Content-Type": "application/json",
       },
       body: JSON.stringify({
-        outcome,
+        outcome: updatedOutcome,
         cres: cres ?? null,
-        abortedOnChallenge,
       }),
     });
   }

--- a/packages/types/uiComponents.ts
+++ b/packages/types/uiComponents.ts
@@ -226,6 +226,7 @@ export interface ThreeDSecureFrameClientMessages
   extends EvervaultFrameClientMessages {
   EV_SUCCESS: string | undefined | null;
   EV_FAILURE: string | undefined | null;
+  EV_FAILURE_FORCED_DUE_TO_CHALLENGE: string | undefined | null;
   EV_FAIL_ON_CHALLENGE: undefined;
   EV_CANCEL: undefined;
 }

--- a/packages/ui-components/src/ThreeDSecure/index.tsx
+++ b/packages/ui-components/src/ThreeDSecure/index.tsx
@@ -55,7 +55,7 @@ export function ThreeDSecure({ config }: { config: ThreeDSecureConfig }) {
       // call up to the parent to see if the challenge should be shown.
       on("EV_FAIL_ON_CHALLENGE_RESULT", (shouldFail) => {
         if (shouldFail) {
-          send("EV_FAILURE");
+          send("EV_FAILURE_FORCED_DUE_TO_CHALLENGE");
         } else {
           setFailOnChallenge(false);
         }


### PR DESCRIPTION
# Why
We're marking all failures as failed on challenge. We should be more granular

# How
Add new event to mark failure from fail on challenge and if received, send a boolean in the outcome patch request to CAPI
