### PR TITLE
Clear timeout on fingerprint success

### DIFF
--- a/.changeset/nervous-drinks-type.md
+++ b/.changeset/nervous-drinks-type.md
@@ -1,0 +1,5 @@
+---
+"@evervault/ui-components": patch
+---
+
+Fix potential race condition during browser fingerprinting

--- a/packages/ui-components/src/ThreeDSecure/BrowserFingerprint.tsx
+++ b/packages/ui-components/src/ThreeDSecure/BrowserFingerprint.tsx
@@ -26,13 +26,15 @@ export function BrowserFingerprint({
       });
     }
 
+    const timeout = setTimeout(onTimeout, 5000);
+
     const handleMessage = (e: MessageEvent) => {
       if (isTrampolineMessage(e)) {
         onComplete();
+        clearTimeout(timeout);
       }
     };
 
-    const timeout = setTimeout(onTimeout, 5000);
     window.addEventListener("message", handleMessage);
 
     return () => {


### PR DESCRIPTION
We render different stages of the 3DS flow based on the state of the session. e.g browser fingerprint, challenge, etc. After each step, we refresh the session and trigger any callbacks or actions based on the new state. The browser fingerprint step has a 5 second timeout, however, the listener for this timeout isn't actually cleaned up until the browser fingerprint step is unmounted. This means that there is a race condition where it would be possible that even after a successful fingerprint, the timeout could still fire as the timeout wont be cancelled until the request to refresh the session has completed.