### PR TITLE
Fix bug causing errors to be cleared when using autoProgress

### DIFF
--- a/.changeset/happy-windows-fold.md
+++ b/.changeset/happy-windows-fold.md
@@ -1,0 +1,5 @@
+---
+"shared": patch
+---
+
+Fix issue causing errors to be cleared when autoProgressing inputs

--- a/examples/collect-card-details/src/main.ts
+++ b/examples/collect-card-details/src/main.ts
@@ -19,6 +19,10 @@ const card = evervault.ui.card({
   autoProgress: true,
 });
 
+card.on("change", (values) => {
+  console.log("Change", values);
+});
+
 card.mount("#form");
 
 const btn = document.getElementById("purchase");

--- a/examples/collect-card-details/src/main.ts
+++ b/examples/collect-card-details/src/main.ts
@@ -16,7 +16,7 @@ const evervault = await loadEvervault(
 const card = evervault.ui.card({
   icons: true,
   theme: evervault.ui.themes.clean(),
-  redactCVC: true,
+  autoProgress: true,
 });
 
 card.mount("#form");

--- a/packages/shared/src/useForm.ts
+++ b/packages/shared/src/useForm.ts
@@ -80,30 +80,31 @@ export function useForm<T extends object>({
       const nextValues = { ...values, [field]: value };
       setValues((p) => ({ ...p, [field]: value }));
 
-      const fieldsToValidate: string[] = Object.keys(errors ?? {});
-      if (
-        field === "number" &&
-        errors?.["cvc" as keyof T] == null &&
-        nextValues?.["cvc" as keyof T]
-      ) {
-        fieldsToValidate.push("cvc");
-      }
+      setErrors((previousErrors) => {
+        const fieldsToValidate: string[] = Object.keys(previousErrors ?? {});
+        if (
+          field === "number" &&
+          previousErrors?.["cvc" as keyof T] == null &&
+          nextValues?.["cvc" as keyof T]
+        ) {
+          fieldsToValidate.push("cvc");
+        }
 
-      const nextErrors: Partial<Record<keyof T, string>> = {};
-      fieldsToValidate.forEach((key) => {
-        if (key === field) return;
-        const validator = validators.current?.[key as keyof T];
-        if (!validator) return;
-        const error = validator(nextValues);
-        if (!error) return;
-        nextErrors[key as keyof T] = error;
+        const nextErrors: Partial<Record<keyof T, string>> = {};
+        fieldsToValidate.forEach((key) => {
+          const validator = validators.current?.[key as keyof T];
+          if (!validator) return;
+          const error = validator(nextValues);
+          if (!error) return;
+          nextErrors[key as keyof T] = error;
+        });
+
+        return nextErrors;
       });
-
-      setErrors(nextErrors);
 
       triggerChange.current = true;
     },
-    [values, errors]
+    [values]
   );
 
   const isValid = useMemo(


### PR DESCRIPTION
When setting a value for an input, we re run validation for any fields that have errors. This was reading from the errors state directly which can be out of date if called in the middle of a render. By using the setErrors callback syntax we will get the most up to date values.

I've also removed a line which skipped validating the current field in this setValue call. I'm not sure why this existed in the first place.