### PR TITLE
Support 3 digit CVCs for amex

### DIFF
--- a/.changeset/ninety-candles-compare.md
+++ b/.changeset/ninety-candles-compare.md
@@ -1,0 +1,5 @@
+---
+"@evervault/card-validator": minor
+---
+
+Updates card brand configuration to support multiple lengths for CVCs and support 3 character CVCs for Amex cards

--- a/e2e-tests/ui-components/tests/cardDetails.spec.js
+++ b/e2e-tests/ui-components/tests/cardDetails.spec.js
@@ -570,62 +570,6 @@ test.describe("card component", () => {
     });
   });
 
-  test("Revalidates previously invalid CVC when card number changes", async ({
-    page,
-  }) => {
-    let values = {};
-
-    await page.exposeFunction("handleChange", (newValues) => {
-      values = newValues;
-    });
-
-    await page.evaluate(() => {
-      const card = window.evervault.ui.card();
-      card.on("change", window.handleChange);
-      card.mount("#form");
-    });
-
-    const frame = page.frameLocator("iframe[data-evervault]");
-    // enter amex card which requires 4 digit cvc
-    await frame.getByLabel("Number").fill("378282246310005");
-    await frame.getByLabel("CVC").fill("123");
-    await frame.getByLabel("CVC").blur();
-    await expect(frame.getByText("Your CVC is invalid")).toBeVisible();
-    await expect.poll(async () => values.errors?.cvc).not.toBeUndefined();
-    await frame.getByLabel("Number").clear();
-    await frame.getByLabel("Number").fill("4242424242424242");
-    await expect.poll(async () => values.errors?.cvc).toBeUndefined();
-    await expect(frame.getByText("Your CVC is invalid")).not.toBeVisible();
-  });
-
-  test("Invalidates previously valid CVC when card number changes", async ({
-    page,
-  }) => {
-    let values = {};
-
-    await page.exposeFunction("handleChange", (newValues) => {
-      values = newValues;
-    });
-
-    await page.evaluate(() => {
-      const card = window.evervault.ui.card();
-      card.on("change", window.handleChange);
-      card.mount("#form");
-    });
-
-    const frame = page.frameLocator("iframe[data-evervault]");
-    await frame.getByLabel("Number").fill("4242424242424242");
-    await frame.getByLabel("CVC").fill("123");
-    await frame.getByLabel("CVC").blur();
-    await expect(frame.getByText("Your CVC is invalid")).not.toBeVisible();
-    await expect.poll(async () => values.errors?.cvc).toBeUndefined();
-    await frame.getByLabel("Number").clear();
-    // enter amex card which requires 4 digit cvc
-    await frame.getByLabel("Number").fill("378282246310005");
-    await expect.poll(async () => values.errors?.cvc).not.toBeUndefined();
-    await expect(frame.getByText("Your CVC is invalid")).toBeVisible();
-  });
-
   test("Updates the underlying CVC when switching from 4 digit CVC to 3", async ({
     page,
   }) => {

--- a/packages/card-validator/brands.ts
+++ b/packages/card-validator/brands.ts
@@ -10,7 +10,7 @@ const brands = [
       lengths: [16, 18, 19],
     },
     securityCodeValidationRules: {
-      length: 3,
+      lengths: [3],
     },
   },
   {
@@ -22,7 +22,7 @@ const brands = [
       lengths: [16],
     },
     securityCodeValidationRules: {
-      length: 3,
+      lengths: [3],
     },
   },
   {
@@ -34,7 +34,7 @@ const brands = [
       lengths: [15],
     },
     securityCodeValidationRules: {
-      length: 4,
+      lengths: [3, 4],
     },
   },
   {
@@ -46,7 +46,7 @@ const brands = [
       lengths: [14, 16, 19],
     },
     securityCodeValidationRules: {
-      length: 3,
+      lengths: [3],
     },
   },
   {
@@ -58,7 +58,7 @@ const brands = [
       lengths: [16, 19],
     },
     securityCodeValidationRules: {
-      length: 3,
+      lengths: [3],
     },
   },
   {
@@ -70,7 +70,7 @@ const brands = [
       lengths: [16, 17, 18, 19],
     },
     securityCodeValidationRules: {
-      length: 3,
+      lengths: [3],
     },
   },
   {
@@ -105,7 +105,7 @@ const brands = [
       lengths: [14, 15, 16, 17, 18, 19],
     },
     securityCodeValidationRules: {
-      length: 3,
+      lengths: [3],
     },
   },
   {
@@ -129,7 +129,7 @@ const brands = [
       lengths: [12, 13, 14, 15, 16, 17, 18, 19],
     },
     securityCodeValidationRules: {
-      length: 3,
+      lengths: [3],
     },
   },
   {
@@ -167,7 +167,7 @@ const brands = [
       lengths: [16],
     },
     securityCodeValidationRules: {
-      length: 3,
+      lengths: [3],
     },
   },
   {
@@ -179,7 +179,7 @@ const brands = [
       lengths: [16, 17, 18, 19],
     },
     securityCodeValidationRules: {
-      length: 3,
+      lengths: [3],
     },
   },
   {
@@ -191,7 +191,7 @@ const brands = [
       lengths: [16],
     },
     securityCodeValidationRules: {
-      length: 3,
+      lengths: [3],
     },
   },
   {
@@ -203,7 +203,7 @@ const brands = [
       lengths: [16],
     },
     securityCodeValidationRules: {
-      length: 3,
+      lengths: [3],
     },
   },
   {
@@ -215,7 +215,7 @@ const brands = [
       lengths: [16],
     },
     securityCodeValidationRules: {
-      length: 3,
+      lengths: [3],
     },
   },
   {
@@ -227,7 +227,7 @@ const brands = [
       lengths: [15],
     },
     securityCodeValidationRules: {
-      length: 0,
+      lengths: [0],
     },
   },
 ] as CardBrand[];

--- a/packages/card-validator/index.ts
+++ b/packages/card-validator/index.ts
@@ -141,7 +141,7 @@ export function validateCVC(
   const isCVCValid = defaultBrands
     .filter((brand) => brands.includes(brand.name))
     .some((brand) => {
-      return brand.securityCodeValidationRules.length === cvc.length;
+      return brand.securityCodeValidationRules.lengths.includes(cvc.length);
     });
 
   return {

--- a/packages/card-validator/test/validate-cvc.test.ts
+++ b/packages/card-validator/test/validate-cvc.test.ts
@@ -37,7 +37,7 @@ const testCases: TestCase[] = [
   {
     scope: "CVC with wrong length amex",
     cardNumber: "378282246310005",
-    cvc: "123",
+    cvc: "12",
     expectedResult: { cvc: null, isValid: false },
   },
   {
@@ -51,6 +51,12 @@ const testCases: TestCase[] = [
     cardNumber: "378282246310005",
     cvc: "1234",
     expectedResult: { cvc: "1234", isValid: true },
+  },
+  {
+    scope: "3 digit CVC Amex",
+    cardNumber: "378282246310005",
+    cvc: "123",
+    expectedResult: { cvc: "123", isValid: true },
   },
   {
     scope: "Valid CVC Mastercard with empty card number",

--- a/packages/card-validator/types.ts
+++ b/packages/card-validator/types.ts
@@ -7,7 +7,7 @@ export type NumberValidationRules = {
 };
 
 export type SecurityCodeValidationRules = {
-  length: number;
+  lengths: number[];
 };
 
 export type CardBrand = {


### PR DESCRIPTION
It's possible for older Amex cards to have both 3 and 4 digit CVCs.