### PR TITLE
Perform JS repo releases in a single execution to avoid workflow recursion

### DIFF
--- a/.changeset/hip-buttons-whisper.md
+++ b/.changeset/hip-buttons-whisper.md
@@ -1,0 +1,6 @@
+---
+"@evervault/js": patch
+"@evervault/ui-components": patch
+---
+
+Run deployment process for gated packages

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -72,7 +72,11 @@ jobs:
           HUSKY: 0
           GITHUB_TOKEN: ${{ secrets.SDK_PUBLISH_TOKEN }}
       - name: Create Tags
+        # Changesets deletes the changeset files on version PR, so if false then we need to tag and release the packages
         if: steps.changesets.outputs.hasChangesets == 'false'
-        run: pnpm changeset tag && git push origin --tags
+        run: |-
+          pnpm changeset tag
+          TAGS=$(git tag --points-at=HEAD | jq -scR 'split("\n") | map(select(length > 0))')
+          echo "tags_to_publish=$TAGS" >> $GITHUB_OUTPUT
         env:
           HUSKY: 0

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -44,7 +44,8 @@ jobs:
     name: Create Tags
     runs-on: ubuntu-latest
     outputs:
-      tags_to_publish: ${{ steps.create-tags.outputs.tags_to_publish }}
+      has-changesets: ${{ steps.changesets.outputs.hasChangesets }}
+      tags-to-publish: ${{ steps.create-tags.outputs.tags-to-publish }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -74,20 +75,23 @@ jobs:
           HUSKY: 0
           GITHUB_TOKEN: ${{ secrets.SDK_PUBLISH_TOKEN }}
       - name: Create Tags
+        id: create-tags
         # Changesets deletes the changeset files on version PR, so if false then we need to tag and release the packages
         if: steps.changesets.outputs.hasChangesets == 'false'
         run: |-
           pnpm changeset tag && git push origin --tags
           TAGS=$(git tag --points-at=HEAD | jq -scR 'split("\n") | map(select(length > 0))')
-          echo "tags_to_publish=$TAGS" >> $GITHUB_OUTPUT
+          echo "tags-to-publish=$TAGS" >> $GITHUB_OUTPUT
         env:
           HUSKY: 0
   release:
     name: Release ${{ matrix.tag }}
     needs: create-tags
+    # Only attempt releases if we expect to have pushed some tags
+    if: needs.create-tags.outputs.has-changesets == 'false'
     strategy:
       matrix:
-        tag: ${{ toJson(needs.create-tags.outputs.tags_to_publish) }}
+        tag: ${{ toJson(needs.create-tags.outputs.tags-to-publish) }}
     with:
       release-tag: ${{ matrix.tag }}
     secrets: inherit

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -40,9 +40,11 @@ jobs:
     with:
       environment: "staging"
     secrets: inherit
-  release:
-    name: Release
+  create-tags:
+    name: Create Tags
     runs-on: ubuntu-latest
+    outputs:
+      tags_to_publish: ${{ steps.create-tags.outputs.tags_to_publish }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -75,8 +77,18 @@ jobs:
         # Changesets deletes the changeset files on version PR, so if false then we need to tag and release the packages
         if: steps.changesets.outputs.hasChangesets == 'false'
         run: |-
-          pnpm changeset tag
+          pnpm changeset tag && git push origin --tags
           TAGS=$(git tag --points-at=HEAD | jq -scR 'split("\n") | map(select(length > 0))')
           echo "tags_to_publish=$TAGS" >> $GITHUB_OUTPUT
         env:
           HUSKY: 0
+  release:
+    name: Release ${{ matrix.tag }}
+    needs: create-tags
+    strategy:
+      matrix:
+        tag: ${{ toJson(needs.create-tags.outputs.tags_to_publish) }}
+    with:
+      release-tag: ${{ matrix.tag }}
+    secrets: inherit
+    uses: ./.github/workflows/release.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,13 @@
 # Deploy package to production envrionment on release
 # The tag names created by `changeset tag` include the name of the package we want to release
-name: Main Release Workflow
+name: Release Workflow
 on:
-  push:
-    tags:
-      - "@evervault/**"
-      - "@evervault/*"
+  workflow_call:
+    inputs:
+      release-tag:
+        description: "The tag name of the release"
+        required: true
+        type: string
 jobs:
   build:
     uses: ./.github/workflows/build-and-test.yml
@@ -15,35 +17,35 @@ jobs:
       vite-api-url: "https://api.evervault.com"
     secrets: inherit
   deploy-browser:
-    if: contains(github.ref, 'refs/tags/@evervault/browser')
+    if: contains(inputs.release-tag, '@evervault/browser')
     needs: build
     uses: ./.github/workflows/deploy-browser.yml
     with:
       environment: "production"
     secrets: inherit
   deploy-inputs:
-    if: contains(github.ref, 'refs/tags/@evervault/inputs')
+    if: contains(inputs.release-tag, '@evervault/inputs')
     needs: build
     uses: ./.github/workflows/deploy-inputs.yml
     with:
       environment: "production"
     secrets: inherit
   deploy-ui-components:
-    if: contains(github.ref, 'refs/tags/@evervault/ui-components')
+    if: contains(inputs.release-tag, '@evervault/ui-components')
     needs: build
     uses: ./.github/workflows/deploy-ui-components.yml
     with:
       environment: "production"
     secrets: inherit
   deploy-3ds:
-    if: contains(github.ref, 'refs/tags/@evervault/3ds')
+    if: contains(inputs.release-tag, '@evervault/3ds')
     needs: build
     uses: ./.github/workflows/deploy-3ds.yml
     with:
       environment: "production"
     secrets: inherit
   publish-react:
-    if: contains(github.ref, 'refs/tags/@evervault/react')
+    if: contains(inputs.release-tag, '@evervault/react')
     needs: build
     uses: ./.github/workflows/npm-publish.yml
     with:
@@ -52,7 +54,7 @@ jobs:
       repo_path: "packages/react/dist"
     secrets: inherit
   publish-card-validator:
-    if: contains(github.ref, 'refs/tags/@evervault/card-validator')
+    if: contains(inputs.release-tag, '@evervault/card-validator')
     needs: build
     uses: ./.github/workflows/npm-publish.yml
     with:
@@ -61,7 +63,7 @@ jobs:
       repo_path: "packages/card-validator/dist"
     secrets: inherit
   publish-react-native:
-    if: contains(github.ref, 'refs/tags/@evervault/evervault-react-native')
+    if: contains(inputs.release-tag, '@evervault/evervault-react-native')
     needs: build
     uses: ./.github/workflows/npm-publish.yml
     with:
@@ -70,7 +72,7 @@ jobs:
       repo_path: "packages/react-native/lib"
     secrets: inherit
   publish-eql:
-    if: contains(github.ref, 'refs/tags/@evervault/eql')
+    if: contains(inputs.release-tag, '@evervault/eql')
     needs: build
     uses: ./.github/workflows/npm-publish.yml
     with:
@@ -79,7 +81,7 @@ jobs:
       repo_path: "packages/eql/dist"
     secrets: inherit
   publish-js:
-    if: contains(github.ref, 'refs/tags/@evervault/js')
+    if: contains(inputs.release-tag, '@evervault/js')
     needs: build
     uses: ./.github/workflows/npm-publish.yml
     with:


### PR DESCRIPTION
# Why

We were performing releases by having one workflow push tags, and another trigger from them. This is not supported by GH to avoid infinite workflow recursion. To account for this, we need to have our release logic performed in the same flow which pushes tags.

# How

- Make release workflow reusable and consume from workflow triggered on push
- Update changeset tag logic to produce a JSON array of all tags to publish, which is then provided as a matrix for the release workflow
- Update release workflow to expect a tag string, and not a fully qualified ref
