### PR TITLE
chore: deserialize tags from json

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -91,7 +91,7 @@ jobs:
     if: needs.create-tags.outputs.has-changesets == 'false'
     strategy:
       matrix:
-        tag: ${{ toJson(needs.create-tags.outputs.tags-to-publish) }}
+        tag: ${{ fromJson(needs.create-tags.outputs.tags-to-publish) }}
     with:
       release-tag: ${{ matrix.tag }}
     secrets: inherit


### PR DESCRIPTION
# Why

Release workflow was serializing JSON instead of deserializing it..

# How

Use `fromJson` instead of `toJson`