### PR TITLE
Revert test deployments

### DIFF
--- a/.changeset/hip-buttons-whisper.md
+++ b/.changeset/hip-buttons-whisper.md
@@ -1,6 +1,0 @@
----
-"@evervault/js": patch
-"@evervault/ui-components": patch
----
-
-Run deployment process for gated packages

--- a/.changeset/hip-buttons-whisper.md
+++ b/.changeset/hip-buttons-whisper.md
@@ -1,0 +1,6 @@
+---
+"@evervault/js": patch
+"@evervault/ui-components": patch
+---
+
+Run deployment process for gated packages

--- a/e2e-tests/ui-components/CHANGELOG.md
+++ b/e2e-tests/ui-components/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @evervault/ui-components-e2e-tests
 
-## 1.1.16
-
-### Patch Changes
-
-- Updated dependencies [01031db]
-  - @evervault/ui-components@1.27.4
-
 ## 1.1.15
 
 ### Patch Changes

--- a/e2e-tests/ui-components/package.json
+++ b/e2e-tests/ui-components/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@evervault/ui-components-e2e-tests",
-  "version": "1.1.16",
+  "version": "1.1.15",
   "scripts": {
     "e2e:test": "playwright test",
     "clean": "rm -rf .turbo node_modules dist"

--- a/examples/collect-card-details/CHANGELOG.md
+++ b/examples/collect-card-details/CHANGELOG.md
@@ -1,12 +1,5 @@
 # example-ui-components
 
-## 0.2.11
-
-### Patch Changes
-
-- Updated dependencies [01031db]
-  - @evervault/js@2.0.1
-
 ## 0.2.10
 
 ### Patch Changes

--- a/examples/collect-card-details/package.json
+++ b/examples/collect-card-details/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-ui-components",
   "private": true,
-  "version": "0.2.11",
+  "version": "0.2.10",
   "type": "module",
   "scripts": {
     "dev": "vite --port 4000",

--- a/examples/custom-theme/CHANGELOG.md
+++ b/examples/custom-theme/CHANGELOG.md
@@ -1,12 +1,5 @@
 # example-custom-theme
 
-## 0.0.33
-
-### Patch Changes
-
-- Updated dependencies [01031db]
-  - @evervault/js@2.0.1
-
 ## 0.0.32
 
 ### Patch Changes

--- a/examples/custom-theme/package.json
+++ b/examples/custom-theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-custom-theme",
   "private": true,
-  "version": "0.0.33",
+  "version": "0.0.32",
   "type": "module",
   "scripts": {
     "dev": "vite --port 4000",

--- a/examples/three-d-secure/CHANGELOG.md
+++ b/examples/three-d-secure/CHANGELOG.md
@@ -1,12 +1,5 @@
 # example-three-d-secure
 
-## 0.0.36
-
-### Patch Changes
-
-- Updated dependencies [01031db]
-  - @evervault/js@2.0.1
-
 ## 0.0.35
 
 ### Patch Changes

--- a/examples/three-d-secure/package.json
+++ b/examples/three-d-secure/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-three-d-secure",
   "private": true,
-  "version": "0.0.36",
+  "version": "0.0.35",
   "type": "module",
   "scripts": {
     "dev": "concurrently --kill-others \"pnpm run client:dev\" \"pnpm run server:dev\"",

--- a/packages/js/CHANGELOG.md
+++ b/packages/js/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @evervault/js
 
-## 2.0.1
-
-### Patch Changes
-
-- 01031db: Run deployment process for gated packages
-
 ## 2.0.0
 
 ### Major Changes

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -1,7 +1,7 @@
 {
   "private": false,
   "name": "@evervault/js",
-  "version": "2.0.1",
+  "version": "2.0.0",
   "description": "Evervault.js loader for client-side browser applications",
   "license": "MIT",
   "type": "module",

--- a/packages/ui-components/CHANGELOG.md
+++ b/packages/ui-components/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @evervault/ui-components
 
-## 1.27.4
-
-### Patch Changes
-
-- 01031db: Run deployment process for gated packages
-
 ## 1.27.3
 
 ### Patch Changes

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@evervault/ui-components",
   "private": false,
-  "version": "1.27.4",
+  "version": "1.27.3",
   "type": "module",
   "scripts": {
     "build": "vite build",


### PR DESCRIPTION
# Why

Updated release workflow appears correct following #594, so resetting the package state to remove the test deployment

# How

Revert version packages PR and delete the changeset file included in CI refactor as a test (no-op) release.