### PR TITLE
Overwrite playwright report if conflict

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -70,6 +70,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
+          overwrite: true
           name: ui-components-playwright-report
           path: e2e-tests/ui-components/playwright-report
           retention-days: 5


### PR DESCRIPTION
Due to use calling build-and-test multiple times during a deployment workflow, the playwright reports are being uploaded multiple times which causes a workflow to fail. Obviously we need to actually improve the overall structure for these workflows but in the meantime we can overwrite the report.