### PR TITLE
Explicitly pass tag name in invoked release workflow

### DIFF
--- a/.github/workflows/deploy-3ds.yml
+++ b/.github/workflows/deploy-3ds.yml
@@ -6,6 +6,10 @@ on:
         description: "Environment to deploy to"
         required: true
         type: string
+      tag_name:
+        description: "The tag to be deployed"
+        required: true
+        type: string
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -27,3 +31,25 @@ jobs:
         run: aws s3 cp dist s3://${{ vars.TDS_AWS_S3_BUCKET }}/ --recursive
       - name: Cloudfront Cache Invalidation
         run: aws cloudfront create-invalidation --distribution-id ${{ secrets.TDS_AWS_CLOUDFRONT_DISTRIBUTION_ID }} --paths "/index.html"
+  create_release:
+    name: Create Github Release and Changelog
+    runs-on: ubuntu-latest
+    needs: deploy
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Get package name
+        env:
+          TAG: ${{ inputs.tag_name }}
+        id: parse
+        run: |
+          if [[ "$TAG" == *"evervault-react-native"* ]]; then
+            echo "name=react-native" >> $GITHUB_OUTPUT
+          else
+            name_part=${TAG##*/}
+            echo "name=${name_part%@*}" >> $GITHUB_OUTPUT
+          fi
+      - uses: softprops/action-gh-release@v2
+        with:
+          body_path: ${{ github.workspace }}/packages/${{ steps.parse.outputs.name }}/CHANGELOG.md
+          tag_name: ${{ inputs.tag_name }}

--- a/.github/workflows/deploy-3ds.yml
+++ b/.github/workflows/deploy-3ds.yml
@@ -35,6 +35,7 @@ jobs:
     name: Create Github Release and Changelog
     runs-on: ubuntu-latest
     needs: deploy
+    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/deploy-browser.yml
+++ b/.github/workflows/deploy-browser.yml
@@ -10,6 +10,10 @@ on:
         description: "Flag to enable preflight checks"
         default: true
         type: boolean
+      tag_name:
+        description: "The tag to be deployed"
+        required: true
+        type: string
 jobs:
   deploy-preview:
     runs-on: ubuntu-latest
@@ -93,3 +97,25 @@ jobs:
         run: aws s3 cp ./dist/ s3://${{ vars.BROWSER_SDK_S3_BUCKET }}/v2/ --recursive
       - name: Cloudfront Cache Invalidation
         run: aws cloudfront create-invalidation --distribution-id ${{ secrets.BROWSER_SDK_CLOUDFRONT_DISTRIBUTION_ID }} --paths "/v2/index.js"
+  create_release:
+    name: Create Github Release and Changelog
+    runs-on: ubuntu-latest
+    needs: deploy
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Get package name
+        env:
+          TAG: ${{ inputs.tag_name }}
+        id: parse
+        run: |
+          if [[ "$TAG" == *"evervault-react-native"* ]]; then
+            echo "name=react-native" >> $GITHUB_OUTPUT
+          else
+            name_part=${TAG##*/}
+            echo "name=${name_part%@*}" >> $GITHUB_OUTPUT
+          fi
+      - uses: softprops/action-gh-release@v2
+        with:
+          body_path: ${{ github.workspace }}/packages/${{ steps.parse.outputs.name }}/CHANGELOG.md
+          tag_name: ${{ inputs.tag_name }}

--- a/.github/workflows/deploy-browser.yml
+++ b/.github/workflows/deploy-browser.yml
@@ -101,6 +101,7 @@ jobs:
     name: Create Github Release and Changelog
     runs-on: ubuntu-latest
     needs: deploy
+    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/deploy-inputs.yml
+++ b/.github/workflows/deploy-inputs.yml
@@ -6,6 +6,10 @@ on:
         description: "Environment to deploy to"
         required: true
         type: string
+      tag_name:
+        description: "The tag to be deployed"
+        required: true
+        type: string
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -27,3 +31,26 @@ jobs:
         run: aws s3 cp ./dist s3://${{ vars.INPUTS_S3_BUCKET }}/v2/ --recursive
       - name: Cloudfront Cache Invalidation
         run: aws cloudfront create-invalidation --distribution-id ${{ secrets.INPUTS_CLOUDFRONT_DISTRIBUTION_ID }} --paths "/index.html" "/bundle.js" "/v2/*"
+  create_release:
+    name: Create Github Release and Changelog
+    runs-on: ubuntu-latest
+    needs: deploy
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Get package name
+        env:
+          TAG: ${{ inputs.tag_name }}
+        id: parse
+        run: |
+          if [[ "$TAG" == *"evervault-react-native"* ]]; then
+            echo "name=react-native" >> $GITHUB_OUTPUT
+          else
+            name_part=${TAG##*/}
+            echo "name=${name_part%@*}" >> $GITHUB_OUTPUT
+          fi
+      - uses: softprops/action-gh-release@v2
+        with:
+          body_path: ${{ github.workspace }}/packages/${{ steps.parse.outputs.name }}/CHANGELOG.md
+          tag_name: ${{ inputs.tag_name }}
+

--- a/.github/workflows/deploy-inputs.yml
+++ b/.github/workflows/deploy-inputs.yml
@@ -35,6 +35,7 @@ jobs:
     name: Create Github Release and Changelog
     runs-on: ubuntu-latest
     needs: deploy
+    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/deploy-ui-components.yml
+++ b/.github/workflows/deploy-ui-components.yml
@@ -99,6 +99,7 @@ jobs:
     name: Create Github Release and Changelog
     runs-on: ubuntu-latest
     needs: deploy
+    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/deploy-ui-components.yml
+++ b/.github/workflows/deploy-ui-components.yml
@@ -10,6 +10,10 @@ on:
         description: "Flag to enable preflight checks"
         default: true
         type: boolean
+      tag_name:
+        description: "The tag to be deployed"
+        required: true
+        type: string
 jobs:
   deploy-preview:
     runs-on: ubuntu-latest
@@ -91,3 +95,26 @@ jobs:
         run: aws s3 cp ./dist/index.html s3://${{ vars.UI_COMPONENTS_S3_BUCKET }}/
       - name: Cloudfront Cache Invalidation
         run: aws cloudfront create-invalidation --distribution-id ${{ secrets.UI_COMPONENTS_CLOUDFRONT_DISTRIBUTION_ID }} --paths "/index.html"
+  create_release:
+    name: Create Github Release and Changelog
+    runs-on: ubuntu-latest
+    needs: deploy
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Get package name
+        env:
+          TAG: ${{ inputs.tag_name }}
+        id: parse
+        run: |
+          if [[ "$TAG" == *"evervault-react-native"* ]]; then
+            echo "name=react-native" >> $GITHUB_OUTPUT
+          else
+            name_part=${TAG##*/}
+            echo "name=${name_part%@*}" >> $GITHUB_OUTPUT
+          fi
+      - uses: softprops/action-gh-release@v2
+        with:
+          body_path: ${{ github.workspace }}/packages/${{ steps.parse.outputs.name }}/CHANGELOG.md
+          tag_name: ${{ inputs.tag_name }}
+

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -64,6 +64,7 @@ jobs:
     name: Create Github Release and Changelog
     runs-on: ubuntu-latest
     needs: publish
+    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -15,6 +15,10 @@ on:
         description: "The artifact containing the built code"
         required: true
         type: string
+      tag_name:
+        description: "The tag to be deployed"
+        required: true
+        type: string
     secrets:
       PUBLIC_REPO_NPM_PUBLISH:
         description: "NPM Token"
@@ -56,3 +60,25 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.PUBLIC_REPO_NPM_PUBLISH }}
           NPM_CONFIG_PROVENANCE: true
+  create_release:
+    name: Create Github Release and Changelog
+    runs-on: ubuntu-latest
+    needs: publish
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Get package name
+        env:
+          TAG: ${{ inputs.tag_name }}
+        id: parse
+        run: |
+          if [[ "$TAG" == *"evervault-react-native"* ]]; then
+            echo "name=react-native" >> $GITHUB_OUTPUT
+          else
+            name_part=${TAG##*/}
+            echo "name=${name_part%@*}" >> $GITHUB_OUTPUT
+          fi
+      - uses: softprops/action-gh-release@v2
+        with:
+          body_path: ${{ github.workspace }}/packages/${{ steps.parse.outputs.name }}/CHANGELOG.md
+          tag_name: ${{ inputs.tag_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,3 +119,4 @@ jobs:
       - uses: softprops/action-gh-release@v2
         with:
           body_path: ${{ github.workspace }}/packages/${{ steps.parse.outputs.name }}/CHANGELOG.md
+          tag_name: ${{ inputs.release-tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
     uses: ./.github/workflows/deploy-browser.yml
     with:
       environment: "production"
+      tag_name: ${{ inputs.release-tag }}
     secrets: inherit
   deploy-inputs:
     if: startsWith(inputs.release-tag, '@evervault/inputs')
@@ -29,6 +30,7 @@ jobs:
     uses: ./.github/workflows/deploy-inputs.yml
     with:
       environment: "production"
+      tag_name: ${{ inputs.release-tag }}
     secrets: inherit
   deploy-ui-components:
     if: startsWith(inputs.release-tag, '@evervault/ui-components')
@@ -36,6 +38,7 @@ jobs:
     uses: ./.github/workflows/deploy-ui-components.yml
     with:
       environment: "production"
+      tag_name: ${{ inputs.release-tag }}
     secrets: inherit
   deploy-3ds:
     if: startsWith(inputs.release-tag, '@evervault/3ds')
@@ -43,6 +46,7 @@ jobs:
     uses: ./.github/workflows/deploy-3ds.yml
     with:
       environment: "production"
+      tag_name: ${{ inputs.release-tag }}
     secrets: inherit
   publish-react:
     if: startsWith(inputs.release-tag, '@evervault/react')
@@ -52,6 +56,7 @@ jobs:
       package: "@evervault/react"
       artifact: "react-sdk-build"
       repo_path: "packages/react/dist"
+      tag_name: ${{ inputs.release-tag }}
     secrets: inherit
   publish-card-validator:
     if: startsWith(inputs.release-tag, '@evervault/card-validator')
@@ -61,6 +66,7 @@ jobs:
       package: "@evervault/card-validator"
       artifact: "card-validator-build"
       repo_path: "packages/card-validator/dist"
+      tag_name: ${{ inputs.release-tag }}
     secrets: inherit
   publish-react-native-v2:
     if: startsWith(inputs.release-tag, '@evervault/react-native')
@@ -70,6 +76,7 @@ jobs:
       package: "@evervault/react-native"
       artifact: "react-native-build"
       repo_path: "packages/react-native-v2"
+      tag_name: ${{ inputs.release-tag }}
     secrets: inherit
   publish-react-native-v1:
     if: startsWith(inputs.release-tag, '@evervault/evervault-react-native')
@@ -79,6 +86,7 @@ jobs:
       package: "@evervault/evervault-react-native"
       artifact: "react-native-v1-build"
       repo_path: "packages/react-native"
+      tag_name: ${{ inputs.release-tag }}
     secrets: inherit
   publish-eql:
     if: startsWith(inputs.release-tag, '@evervault/eql')
@@ -88,6 +96,7 @@ jobs:
       package: "@evervault/eql"
       artifact: "eql-build"
       repo_path: "packages/eql/dist"
+      tag_name: ${{ inputs.release-tag }}
     secrets: inherit
   publish-js:
     if: startsWith(inputs.release-tag, '@evervault/js')
@@ -97,26 +106,5 @@ jobs:
       package: "@evervault/js"
       artifact: "evervault-js"
       repo_path: "packages/js/dist"
+      tag_name: ${{ inputs.release-tag }}
     secrets: inherit
-  release:
-    name: Release
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Get package name
-        env:
-          TAG: ${{ inputs.release-tag }}
-        id: parse
-        run: |
-          if [[ "$TAG" == *"evervault-react-native"* ]]; then
-            echo "name=react-native" >> $GITHUB_OUTPUT
-          else
-            name_part=${TAG##*/}
-            echo "name=${name_part%@*}" >> $GITHUB_OUTPUT
-          fi
-      - uses: softprops/action-gh-release@v2
-        with:
-          body_path: ${{ github.workspace }}/packages/${{ steps.parse.outputs.name }}/CHANGELOG.md
-          tag_name: ${{ inputs.release-tag }}


### PR DESCRIPTION
# Why

Release job expects there to be a tag in `github.ref` but the workflow executes on push.

# How

Pass release tag into the release workflow