### PR TITLE
fix: tag name is not required to support staging deployments

### DIFF
--- a/.github/workflows/deploy-3ds.yml
+++ b/.github/workflows/deploy-3ds.yml
@@ -8,7 +8,7 @@ on:
         type: string
       tag_name:
         description: "The tag to be deployed"
-        required: true
+        required: false
         type: string
 jobs:
   deploy:

--- a/.github/workflows/deploy-browser.yml
+++ b/.github/workflows/deploy-browser.yml
@@ -12,7 +12,7 @@ on:
         type: boolean
       tag_name:
         description: "The tag to be deployed"
-        required: true
+        required: false
         type: string
 jobs:
   deploy-preview:

--- a/.github/workflows/deploy-inputs.yml
+++ b/.github/workflows/deploy-inputs.yml
@@ -8,7 +8,7 @@ on:
         type: string
       tag_name:
         description: "The tag to be deployed"
-        required: true
+        required: false
         type: string
 jobs:
   deploy:

--- a/.github/workflows/deploy-ui-components.yml
+++ b/.github/workflows/deploy-ui-components.yml
@@ -12,7 +12,7 @@ on:
         type: boolean
       tag_name:
         description: "The tag to be deployed"
-        required: true
+        required: false
         type: string
 jobs:
   deploy-preview:


### PR DESCRIPTION
# Why

Release actions run against both staging and production so cannot guarantee that a tag name is always set

# How

Mark tag name as not required
