### PR TITLE
Support Apple Pay in third party browsers

### DIFF
--- a/.changeset/dull-ducks-occur.md
+++ b/.changeset/dull-ducks-occur.md
@@ -1,0 +1,7 @@
+---
+"@evervault/browser": minor
+---
+
+Apple Pay Beta
+A new `applePayButton` component has been introduced to render the Apple Pay Button inside of
+the main document to allow for third party browser support.

--- a/examples/apple-pay/src/main.ts
+++ b/examples/apple-pay/src/main.ts
@@ -13,41 +13,32 @@ const evervault = await loadEvervault(
   }
 );
 
-const disbursementTransaction = evervault.transactions.create({
+const transaction = evervault.transactions.create({
   amount: 100,
   currency: "USD",
   country: "US",
   merchantId: import.meta.env.VITE_MERCHANT_ID,
 });
 
-const apple = evervault.ui.applePay(disbursementTransaction, {
-  type: "contribute",
-  style: "white-outline",
-  locale: "en-US",
-  size: { width: "100%", height: "40px" },
-  borderRadius: 10,
-  requestPayerDetails: ["name", "email"],
-  allowedCardNetworks: ["visa", "masterCard"],
-  process: async (data) => {
-    console.log("data", data);
-
-    // simulate payment
-    await new Promise((resolve) => {
-      setTimeout(resolve, 1000);
-    });
+const apple = evervault.ui.applePayButton(transaction, {
+  size: { width: "100%", height: "30px" },
+  process: async (data, { fail }) => {
+    console.log("PROCESSS", data);
+    fail();
   },
+});
+
+apple.on("error", (error) => {
+  console.log("Apple Pay error", error);
+});
+
+apple.on("success", () => {
+  console.log("Apple pay success!");
 });
 
 apple.on("cancel", () => {
   console.log("Apple Pay cancelled");
 });
 
-apple.on("error", (error) => {
-  console.error("Apple Pay error", error);
-});
-
-apple.on("success", () => {
-  console.log("Apple Pay success callback triggered - setting success");
-});
-
+//
 apple.mount("#apple-pay");

--- a/examples/apple-pay/src/main.ts
+++ b/examples/apple-pay/src/main.ts
@@ -21,7 +21,6 @@ const transaction = evervault.transactions.create({
 });
 
 const apple = evervault.ui.applePayButton(transaction, {
-  requestShipping: true,
   size: { width: "100%", height: "30px" },
   process: async (data) => {
     console.log("PROCESSS", data);

--- a/examples/apple-pay/src/main.ts
+++ b/examples/apple-pay/src/main.ts
@@ -21,6 +21,7 @@ const transaction = evervault.transactions.create({
 });
 
 const apple = evervault.ui.applePayButton(transaction, {
+  requestShipping: true,
   size: { width: "100%", height: "30px" },
   process: async (data) => {
     console.log("PROCESSS", data);

--- a/examples/apple-pay/src/main.ts
+++ b/examples/apple-pay/src/main.ts
@@ -22,9 +22,8 @@ const transaction = evervault.transactions.create({
 
 const apple = evervault.ui.applePayButton(transaction, {
   size: { width: "100%", height: "30px" },
-  process: async (data, { fail }) => {
+  process: async (data) => {
     console.log("PROCESSS", data);
-    fail();
   },
 });
 

--- a/examples/apple-pay/src/main.ts
+++ b/examples/apple-pay/src/main.ts
@@ -39,5 +39,4 @@ apple.on("cancel", () => {
   console.log("Apple Pay cancelled");
 });
 
-//
 apple.mount("#apple-pay");

--- a/packages/browser/lib/ui/ApplePay/index.ts
+++ b/packages/browser/lib/ui/ApplePay/index.ts
@@ -1,0 +1,282 @@
+import EvervaultClient from "../../main";
+import type { SelectorType } from "types";
+import { resolveSelector } from "../utils";
+import { Transaction } from "../../resources/transaction";
+import { buildSession } from "./utilities";
+import EventManager from "../eventManager";
+
+const API = import.meta.env.VITE_API_URL || "https://api.evervault.com";
+const APPLE_PAY_SCRIPT_URL =
+  "https://applepay.cdn-apple.com/jsapi/1.latest/apple-pay-sdk.js";
+
+type ApplePayButtonType =
+  | "add-money"
+  | "book"
+  | "buy"
+  | "check-out"
+  | "continue"
+  | "contribute"
+  | "donate"
+  | "order"
+  | "pay"
+  | "plain"
+  | "reload"
+  | "rent"
+  | "set-up"
+  | "subscribe"
+  | "support"
+  | "tip"
+  | "top-up";
+
+type ApplePayButtonStyle = "black" | "white" | "white-outline";
+
+type ApplePayButtonLocale =
+  | "ar-AB"
+  | "ca-ES"
+  | "cs-CZ"
+  | "da-DK"
+  | "de-DE"
+  | "el-GR"
+  | "en-AU"
+  | "en-GB"
+  | "en-US"
+  | "es-ES"
+  | "es-MX"
+  | "fi-FI"
+  | "fr-CA"
+  | "fr-FR"
+  | "he-IL"
+  | "hi-IN"
+  | "hr-HR"
+  | "hu-HU"
+  | "id-ID"
+  | "it-IT"
+  | "ja-JP"
+  | "ko-KR"
+  | "ms-MY"
+  | "nb-NO"
+  | "nl-NL"
+  | "pl-PL"
+  | "pt-BR"
+  | "pt-PT"
+  | "ro-RO"
+  | "ru-RU"
+  | "sk-SK"
+  | "sv-SE"
+  | "th-TH"
+  | "tr-TR"
+  | "uk-UA"
+  | "vi-VN"
+  | "zh-CN"
+  | "zh-HK"
+  | "zh-TW";
+
+type ApplePayCardNetwork =
+  | "amex"
+  | "bancomat"
+  | "bancontact"
+  | "cartesBancaires"
+  | "chinaUnionPay"
+  | "dankort"
+  | "discover"
+  | "eftpos"
+  | "electron"
+  | "elo"
+  | "girocard"
+  | "interac"
+  | "jcb"
+  | "mada"
+  | "maestro"
+  | "masterCard"
+  | "mir"
+  | "privateLabel"
+  | "visa"
+  | "vPay";
+
+export type ApplePayButtonOptions = {
+  type?: ApplePayButtonType;
+  style?: ApplePayButtonStyle;
+  locale?: ApplePayButtonLocale;
+  padding?: string;
+  borderRadius?: string;
+  size?: { width: string; height: string };
+  allowedCardNetworks?: ApplePayCardNetwork[];
+  requestPayerDetails?: ("name" | "email" | "phone")[];
+  paymentOverrides?: {
+    paymentMethodData?: PaymentMethodData[];
+    paymentDetails?: PaymentDetailsInit;
+  };
+  disbursementOverrides?: {
+    disbursementDetails?: PaymentDetailsInit;
+  };
+  process: (
+    data: unknown,
+    helpers: {
+      fail: () => void;
+    }
+  ) => Promise<void>;
+};
+
+interface ApplePayEvents {
+  success: () => void;
+  error: () => void;
+  cancel: () => void;
+}
+
+export default class ApplePayButton {
+  client: EvervaultClient;
+  transaction: Transaction;
+  #button: HTMLElement | null = null;
+  #options: ApplePayButtonOptions;
+  #events = new EventManager<ApplePayEvents>();
+
+  constructor(
+    client: EvervaultClient,
+    transaction: Transaction,
+    options: ApplePayButtonOptions
+  ) {
+    this.client = client;
+    this.#options = options;
+    this.transaction = transaction;
+    this.#injectScript();
+  }
+
+  #injectScript() {
+    const script = document.createElement("script");
+    script.src = APPLE_PAY_SCRIPT_URL;
+    script.async = true;
+    script.crossOrigin = "anonymous";
+    document.body.appendChild(script);
+  }
+
+  async #handleClick() {
+    try {
+      const merchant = await this.#getMerchant();
+
+      const session = buildSession(this.client.config.appId, merchant, {
+        transaction: this.transaction.details,
+        allowedCardNetworks: this.#options.allowedCardNetworks,
+        requestPayerDetails: this.#options.requestPayerDetails,
+        paymentOverrides: this.#options.paymentOverrides,
+        disbursementOverrides: this.#options.disbursementOverrides,
+      });
+
+      const response = await session.show();
+
+      const encrypted = await this.#exchangeApplePaymentData(response);
+
+      let failed = false;
+
+      await this.#options.process(encrypted, {
+        fail: () => {
+          failed = true;
+        },
+      });
+
+      if (failed) {
+        await response.complete("fail");
+        this.#events.dispatch("error");
+      } else {
+        this.#events.dispatch("success");
+        await response.complete("success");
+      }
+    } catch (error) {
+      if (error instanceof Error && error.name === "AbortError") {
+        this.#events.dispatch("cancel");
+      }
+    }
+  }
+
+  async #getMerchant() {
+    const id = this.transaction.details.merchantId;
+    const response = await fetch(`${API}/frontend/merchants/${id}`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Evervault-App-Id": this.client.config.appId,
+      },
+    });
+
+    if (!response.ok) {
+      console.error(
+        `Failed to fetch merchant details for ${id}`,
+
+        response.status
+      );
+      return undefined;
+    }
+
+    return response.json();
+  }
+
+  async #exchangeApplePaymentData(response) {
+    const requestBody = {
+      merchantId: this.transaction.details.merchantId,
+      encryptedCredentials: response.details.token.paymentData,
+    };
+
+    const res = await fetch(`${API}/frontend/apple-pay/credentials`, {
+      method: "POST",
+      headers: {
+        "x-Evervault-App-Id": this.client.config.appId,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(requestBody),
+    });
+
+    return res.json();
+  }
+
+  on(event: keyof ApplePayEvents, callback: () => void) {
+    return this.#events.on(event, callback);
+  }
+
+  mount(selector: SelectorType) {
+    console.log("mount");
+    const element = resolveSelector(selector);
+    this.#button = document.createElement("apple-pay-button");
+
+    if (this.#options.type) {
+      this.#button.setAttribute("type", this.#options.type);
+    }
+
+    if (this.#options.style) {
+      this.#button.setAttribute("buttonstyle", this.#options.style);
+    }
+
+    if (this.#options.locale) {
+      this.#button.setAttribute("locale", this.#options.locale);
+    }
+
+    if (this.#options.padding) {
+      this.#button.style.setProperty(
+        "--apple-pay-button-padding",
+        this.#options.padding
+      );
+    }
+
+    if (this.#options.borderRadius) {
+      this.#button.style.setProperty(
+        "--apple-pay-button-border-radius",
+        this.#options.borderRadius
+      );
+    }
+
+    if (this.#options.size) {
+      this.#button.style.setProperty(
+        "--apple-pay-button-width",
+        this.#options.size.width
+      );
+      this.#button.style.setProperty(
+        "--apple-pay-button-height",
+        this.#options.size.height
+      );
+    }
+
+    this.#button.addEventListener("click", () => {
+      this.#handleClick();
+    });
+
+    element.appendChild(this.#button);
+  }
+}

--- a/packages/browser/lib/ui/ApplePay/index.ts
+++ b/packages/browser/lib/ui/ApplePay/index.ts
@@ -30,6 +30,7 @@ export type ApplePayButtonOptions = {
   allowedCardNetworks?: ApplePayCardNetwork[];
   requestPayerDetails?: ("name" | "email" | "phone")[];
   requestBillingAddress?: boolean;
+  requestShipping?: boolean;
   paymentOverrides?: {
     paymentMethodData?: PaymentMethodData[];
     paymentDetails?: PaymentDetailsInit;
@@ -85,6 +86,7 @@ export default class ApplePayButton {
       paymentOverrides: this.#options.paymentOverrides,
       disbursementOverrides: this.#options.disbursementOverrides,
       requestBillingAddress: this.#options.requestBillingAddress,
+      requestShipping: this.#options.requestShipping,
     });
 
     const [response, responseError] = await tryCatch(session.show());
@@ -158,17 +160,7 @@ export default class ApplePayButton {
     return this.#events.on(event, callback);
   }
 
-  get available(): boolean {
-    // TODO
-    return true;
-  }
-
   mount(selector: SelectorType) {
-    if (!this.available) {
-      console.error("Apple pay is not available for this transaction");
-      return;
-    }
-
     const element = resolveSelector(selector);
     this.#button = document.createElement("apple-pay-button");
 

--- a/packages/browser/lib/ui/ApplePay/types.ts
+++ b/packages/browser/lib/ui/ApplePay/types.ts
@@ -84,6 +84,16 @@ export type ApplePayCardNetwork =
   | "visa"
   | "vPay";
 
+interface OnMerchantValidationEvent extends Event {
+  complete: (data: unknown) => Promise<unknown>;
+  validationURL: string;
+}
+
+export interface ApplePayPaymentRequest extends PaymentRequest {
+  onshippingaddresschange?: (event: PaymentRequestUpdateEvent) => void;
+  onmerchantvalidation?: (event: OnMerchantValidationEvent) => void;
+}
+
 export interface ApplePayConfig {
   transaction: TransactionDetailsWithDomain;
   type: ApplePayButtonType;

--- a/packages/browser/lib/ui/ApplePay/types.ts
+++ b/packages/browser/lib/ui/ApplePay/types.ts
@@ -1,0 +1,59 @@
+import {
+  ApplePayButtonStyle,
+  ApplePayButtonType,
+  TransactionDetailsWithDomain,
+  ApplePayButtonLocale,
+} from "types";
+
+export interface ApplePayConfig {
+  transaction: TransactionDetailsWithDomain;
+  type: ApplePayButtonType;
+  style: ApplePayButtonStyle;
+  locale: ApplePayButtonLocale;
+  padding?: string;
+  borderRadius?: number;
+  allowedCardNetworks?: string[];
+  //These two allow users to add any additional data to the Apple Pay request that we don't currently support
+  paymentOverrides?: {
+    paymentMethodData?: PaymentMethodData[];
+    paymentDetails?: PaymentDetailsInit;
+  };
+  disbursementOverrides?: {
+    disbursementDetails?: PaymentDetailsInit;
+  };
+  requestPayerDetails?: ("name" | "email" | "phone")[];
+}
+
+export interface ValidateMerchantResponse {
+  sessionData: {
+    displayName: string;
+    domainName: string;
+    epochTimestamp: number;
+    expiresAt: number;
+    merchantIdentifier: string;
+    merchantSessionIdentifier: string;
+    nonce: string;
+    operationalAnalyticsIdentifier: string;
+    pspId: string;
+    retries: number;
+    signature: string;
+  };
+}
+
+export interface DisbursementContactDetails extends DisbursementContactAddress {
+  emailAddress?: string;
+  familyName?: string;
+  givenName?: string;
+  phoneNumber?: string;
+}
+
+export interface DisbursementContactAddress {
+  addressLines?: string[];
+  administrativeArea?: string;
+  country?: string;
+  countryCode?: string;
+  locality?: string;
+  postalCode?: string;
+  subAdministrativeArea?: string;
+  subLocality?: string;
+}

--- a/packages/browser/lib/ui/ApplePay/types.ts
+++ b/packages/browser/lib/ui/ApplePay/types.ts
@@ -1,9 +1,88 @@
-import {
-  ApplePayButtonStyle,
-  ApplePayButtonType,
-  TransactionDetailsWithDomain,
-  ApplePayButtonLocale,
-} from "types";
+import { TransactionDetailsWithDomain } from "types";
+
+export type ApplePayButtonType =
+  | "add-money"
+  | "book"
+  | "buy"
+  | "check-out"
+  | "continue"
+  | "contribute"
+  | "donate"
+  | "order"
+  | "pay"
+  | "plain"
+  | "reload"
+  | "rent"
+  | "set-up"
+  | "subscribe"
+  | "support"
+  | "tip"
+  | "top-up";
+
+export type ApplePayButtonStyle = "black" | "white" | "white-outline";
+
+export type ApplePayButtonLocale =
+  | "ar-AB"
+  | "ca-ES"
+  | "cs-CZ"
+  | "da-DK"
+  | "de-DE"
+  | "el-GR"
+  | "en-AU"
+  | "en-GB"
+  | "en-US"
+  | "es-ES"
+  | "es-MX"
+  | "fi-FI"
+  | "fr-CA"
+  | "fr-FR"
+  | "he-IL"
+  | "hi-IN"
+  | "hr-HR"
+  | "hu-HU"
+  | "id-ID"
+  | "it-IT"
+  | "ja-JP"
+  | "ko-KR"
+  | "ms-MY"
+  | "nb-NO"
+  | "nl-NL"
+  | "pl-PL"
+  | "pt-BR"
+  | "pt-PT"
+  | "ro-RO"
+  | "ru-RU"
+  | "sk-SK"
+  | "sv-SE"
+  | "th-TH"
+  | "tr-TR"
+  | "uk-UA"
+  | "vi-VN"
+  | "zh-CN"
+  | "zh-HK"
+  | "zh-TW";
+
+export type ApplePayCardNetwork =
+  | "amex"
+  | "bancomat"
+  | "bancontact"
+  | "cartesBancaires"
+  | "chinaUnionPay"
+  | "dankort"
+  | "discover"
+  | "eftpos"
+  | "electron"
+  | "elo"
+  | "girocard"
+  | "interac"
+  | "jcb"
+  | "mada"
+  | "maestro"
+  | "masterCard"
+  | "mir"
+  | "privateLabel"
+  | "visa"
+  | "vPay";
 
 export interface ApplePayConfig {
   transaction: TransactionDetailsWithDomain;
@@ -56,4 +135,17 @@ export interface DisbursementContactAddress {
   postalCode?: string;
   subAdministrativeArea?: string;
   subLocality?: string;
+}
+
+export interface ApplePayToken {
+  version: string;
+  data: string;
+  signature: string;
+  header: {
+    ephemeralPublicKey?: string;
+    wrappedKey?: string;
+    publicKeyHash: string;
+    transactionId: string;
+    applicatoinData?: string;
+  };
 }

--- a/packages/browser/lib/ui/ApplePay/utilities.ts
+++ b/packages/browser/lib/ui/ApplePay/utilities.ts
@@ -1,5 +1,4 @@
 import {
-  ApplePayToken,
   DisbursementTransactionDetails,
   EncryptedApplePayData,
   MerchantDetail,
@@ -7,6 +6,7 @@ import {
   TransactionDetailsWithDomain,
 } from "types";
 import {
+  ApplePayToken,
   ApplePayConfig,
   DisbursementContactAddress,
   DisbursementContactDetails,

--- a/packages/browser/lib/ui/ApplePay/utilities.ts
+++ b/packages/browser/lib/ui/ApplePay/utilities.ts
@@ -1,0 +1,261 @@
+import {
+  ApplePayToken,
+  DisbursementTransactionDetails,
+  EncryptedApplePayData,
+  MerchantDetail,
+  PaymentTransactionDetails,
+  TransactionDetailsWithDomain,
+} from "types";
+import {
+  ApplePayConfig,
+  DisbursementContactAddress,
+  DisbursementContactDetails,
+  ValidateMerchantResponse,
+} from "./types";
+
+const API = import.meta.env.VITE_API_URL as string;
+
+export function buildSession(
+  app: string,
+  merchant: MerchantDetail,
+  config: ApplePayConfig
+) {
+  const { transaction: tx } = config;
+
+  let baseRequest;
+  if (tx.type === "payment") {
+    baseRequest = buildPaymentSession(merchant, config, tx);
+  } else {
+    baseRequest = buildDisbursementSession(merchant, config, tx);
+  }
+
+  // @ts-expect-error - onmerchantvalidation is added by apple and not on the PaymentRequest type
+  baseRequest.onmerchantvalidation = async (event) => {
+    const merchantSessionPromise = await validateMerchant(
+      app,
+      event.validationURL,
+      tx
+    );
+    event.complete(merchantSessionPromise.sessionData);
+  };
+
+  return baseRequest;
+}
+
+function buildPaymentSession(
+  merchant: MerchantDetail,
+  config: ApplePayConfig,
+  tx: PaymentTransactionDetails
+) {
+  const lineItems =
+    tx.lineItems?.map((item) => ({
+      label: item.label,
+      amount: {
+        value: (item.amount / 100).toFixed(2).toString(),
+        currency: tx.currency,
+      },
+    })) || [];
+
+  const paymentMethodData: PaymentMethodData[] = [
+    {
+      supportedMethods: "https://apple.com/apple-pay",
+      data: {
+        version: 3,
+        merchantIdentifier: `merchant.com.evervault.${merchant.id}`,
+        merchantCapabilities: ["supports3DS"],
+        supportedNetworks: config.allowedCardNetworks?.map((network) =>
+          network.toLowerCase()
+        ) || ["visa", "masterCard", "amex", "discover"],
+        countryCode: tx.country,
+      },
+    },
+  ];
+
+  const paymentDetails: PaymentDetailsInit = {
+    total: {
+      label: `${merchant.name}`,
+      amount: { currency: tx.currency, value: (tx.amount / 100).toFixed(2) },
+    },
+    displayItems: lineItems,
+  };
+
+  const paymentOptions = {
+    requestPayerName: config.requestPayerDetails?.includes("name") ?? false,
+    requestBillingAddress: false,
+    requestPayerEmail: config.requestPayerDetails?.includes("email") ?? false,
+    requestPayerPhone: config.requestPayerDetails?.includes("phone") ?? false,
+    requestShipping: false,
+    shippingType: "shipping",
+  };
+
+  const paymentOverrides = config.paymentOverrides || {};
+
+  const request = new PaymentRequest(
+    paymentOverrides.paymentMethodData || paymentMethodData,
+    paymentOverrides.paymentDetails || paymentDetails,
+    // @ts-expect-error - apple overrides the payment request
+    paymentOptions
+  );
+
+  return request;
+}
+
+function buildDisbursementSession(
+  merchant: MerchantDetail,
+  config: ApplePayConfig,
+  tx: DisbursementTransactionDetails
+) {
+  const lineItems =
+    tx.lineItems?.map((item) => ({
+      label: item.label,
+      amount: {
+        value: (item.amount / 100).toFixed(2).toString(),
+        currency: tx.currency,
+      },
+    })) || [];
+
+  const merchantCapabilities = ["supports3DS"];
+
+  if (tx.instantTransfer) {
+    merchantCapabilities.push("supportsInstantFundsOut");
+  }
+
+  const paymentMethodData = [
+    {
+      supportedMethods: "https://apple.com/apple-pay",
+      data: {
+        version: 3,
+        merchantIdentifier: `merchant.com.evervault.${merchant.id}`,
+        merchantCapabilities,
+        supportedNetworks: config.allowedCardNetworks,
+        countryCode: tx.country,
+      },
+    },
+  ];
+
+  let calculatedTotal = tx.amount;
+
+  if (tx.instantTransfer) {
+    calculatedTotal = tx.amount - tx.instantTransfer.amount;
+  }
+
+  const paymentDetails = {
+    total: {
+      label: merchant.name,
+      amount: {
+        value: calculatedTotal.toString(),
+        currency: tx.currency,
+      },
+    },
+    modifiers: [
+      {
+        supportedMethods: "https://apple.com/apple-pay",
+        data: {
+          disbursementRequest: tx.requiredRecipientDetails
+            ? {
+                requiredRecipientContactFields: tx.requiredRecipientDetails.map(
+                  (field) => {
+                    if (field === "address") {
+                      return "postalAddress";
+                    } else return field;
+                  }
+                ),
+              }
+            : {},
+          // ORDER OF THESE IS IMPORTANT - IT BREAKS IF NOT IN THIS ORDER
+          additionalLineItems: [
+            {
+              label: "Total Amount",
+              amount: tx.amount,
+            },
+            ...(lineItems ? lineItems : []),
+            ...(tx.instantTransfer
+              ? [
+                  {
+                    label: tx.instantTransfer.label,
+                    amount: tx.instantTransfer.amount,
+                    disbursementLineItemType: "instantFundsOutFee",
+                  },
+                ]
+              : []),
+            {
+              label: "Apple Pay Demo",
+              amount: calculatedTotal,
+              disbursementLineItemType: "disbursement",
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  const paymentOptions = {};
+  const disbursementOverrides = config.disbursementOverrides || {};
+
+  const request = new PaymentRequest(
+    paymentMethodData,
+    disbursementOverrides.disbursementDetails || paymentDetails,
+    // @ts-expect-error - apple overrides the payment request
+    paymentOptions
+  );
+
+  return request;
+}
+
+export function buildAddressObject(
+  billingContact: DisbursementContactDetails
+): DisbursementContactAddress {
+  return {
+    addressLines: billingContact.addressLines,
+    administrativeArea: billingContact.administrativeArea,
+    country: billingContact.country,
+    countryCode: billingContact.countryCode,
+    locality: billingContact.locality,
+    postalCode: billingContact.postalCode,
+    subAdministrativeArea: billingContact.subAdministrativeArea,
+    subLocality: billingContact.subLocality,
+  };
+}
+
+async function validateMerchant(
+  app: string,
+  validationUrl: string,
+  tx: TransactionDetailsWithDomain
+): Promise<ValidateMerchantResponse> {
+  const response = await fetch(`${API}/frontend/apple-pay/merchant-session`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Evervault-App-Id": app,
+    },
+    body: JSON.stringify({
+      validationUrl: validationUrl,
+      merchantUuid: tx.merchantId,
+      domain: tx.domain,
+    }),
+  });
+
+  return response.json();
+}
+
+export async function exchangeApplePaymentData(
+  app: string,
+  token: ApplePayToken,
+  merchantId: string
+): Promise<EncryptedApplePayData> {
+  const requestBody = {
+    merchantId,
+    encryptedCredentials: token,
+  };
+
+  const response = await fetch(`${API}/frontend/apple-pay/credentials`, {
+    method: "POST",
+    headers: {
+      "x-Evervault-App-Id": app,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(requestBody),
+  });
+
+  return response.json();
+}

--- a/packages/browser/lib/ui/index.ts
+++ b/packages/browser/lib/ui/index.ts
@@ -16,6 +16,7 @@ import type {
 import { Transaction } from "../resources/transaction";
 import GooglePay from "./googlePay";
 import ApplePay from "./applePay";
+import ApplePayButton, { ApplePayButtonOptions } from "./ApplePay/index";
 
 export default class UIComponents {
   client: EvervaultClient;
@@ -51,5 +52,9 @@ export default class UIComponents {
 
   applePay(tx: Transaction, opts: ApplePayOptions) {
     return new ApplePay(this.client, tx, opts);
+  }
+
+  applePayButton(tx: Transaction, opts: ApplePayButtonOptions) {
+    return new ApplePayButton(this.client, tx, opts);
   }
 }

--- a/packages/browser/lib/utilities.ts
+++ b/packages/browser/lib/utilities.ts
@@ -1,0 +1,16 @@
+type Success<T> = [T, null];
+
+type Failure<E> = [null, E];
+
+type Result<T, E = Error> = Success<T> | Failure<E>;
+
+export async function tryCatch<T, E = Error>(
+  promise: Promise<T>
+): Promise<Result<T, E>> {
+  try {
+    const data = await promise;
+    return [data, null];
+  } catch (error) {
+    return [null, error as E];
+  }
+}


### PR DESCRIPTION
# Why
 Apple Pay now supports third party browsers by rendering a modal window with a scannable code for the user to handle auth on their iPhone. However, this does not work for our current implementation due to it being inside of an iframe. The modal window opens inside of the iframe document and Apple provides no way to control where the modal is mounted.

# How
Rewrite the Apple Pay component to render inside of the parent document. This is only possible because Apple Pay deals with tokens instead of raw PANs and so the compliance requirements do not require an iframe boundary. I've resisted the urge to do much refactoring to try to keep the API contracts and functionality the same as the other implementation.

For now I have nested this under a new `ui.applePayButton` component in order to keep the old implementation around. Once we are happy with the changes we can move it to `ui.applePay` and alias the `ui.applePayButton` method.

Also includes:
- Support for requesting shipping information with the `requestShipping` option.
- Support for requesting billing address with the `requestBillingAddress` option.

The API contract is the exact same as the previous implementation except for one breaking change: Previously we reformatted the `bililngContact` that apple provided us to nest the address fields. Now we just pass the fields through as provided by Apple. This will only affect those using disbursements as before there wasn't a way to request billing details outside of disbursements.

```
Before
{
  ...,
  billingContact: {
    givenName: '...',
    familyName: '...',
    emailAddress: '...',
    phoneNumber: '...'.
    address: { 
      addressLines: [],
      administrativeArea: '',
      country: '',
      ...
  }
}

After: The billing contact as apple provides it
{
  ...,
  billingContact: {
    givenName: '...',
    familyName: '...',
    emailAddress: '...',
    phoneNumber: '...'.
    addressLines: [],
    administrativeArea: '',
    country: '',
    ...
}
```