### PR TITLE
fix: make prod release happen after staging, and namespace artefacts to avoid conflicts

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,6 +14,10 @@ on:
         description: "API endpoint"
         required: true
         type: string
+      environment:
+        description: "The environment that the URLs reference"
+        required: true
+        type: string
 jobs:
   build:
     name: Build and Test
@@ -71,7 +75,7 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           overwrite: true
-          name: ui-components-playwright-report
+          name: ${{ inputs.environment }}-ui-components-playwright-report
           path: e2e-tests/ui-components/playwright-report
           retention-days: 5
       - name: Coverage report
@@ -86,60 +90,60 @@ jobs:
       - name: Upload browser build
         uses: actions/upload-artifact@v4
         with:
-          overwrite: true
-          name: browser-sdk-build
+          overwrite: false
+          name: ${{ inputs.environment }}-browser-sdk-build
           path: packages/browser/dist
       - name: Upload inputs build
         uses: actions/upload-artifact@v4
         with:
-          overwrite: true
-          name: inputs-sdk-build
+          overwrite: false
+          name: ${{ inputs.environment }}-inputs-sdk-build
           path: packages/inputs/dist
       - name: Upload ui-components build
         uses: actions/upload-artifact@v4
         with:
-          overwrite: true
-          name: ui-components-build
+          overwrite: false
+          name: ${{ inputs.environment }}-ui-components-build
           path: packages/ui-components/dist
       - name: Upload 3ds build
         uses: actions/upload-artifact@v4
         with:
-          overwrite: true
-          name: 3ds-build
+          overwrite: false
+          name: ${{ inputs.environment }}-3ds-build
           path: packages/3ds/dist
       - name: Upload react build
         uses: actions/upload-artifact@v4
         with:
-          overwrite: true
-          name: react-sdk-build
+          overwrite: false
+          name: ${{ inputs.environment }}-react-sdk-build
           path: packages/react/dist
       - name: Upload card validator build
         uses: actions/upload-artifact@v4
         with:
-          overwrite: true
-          name: card-validator-build
+          overwrite: false
+          name: ${{ inputs.environment }}-card-validator-build
           path: packages/card-validator/dist
       - name: Upload React Native build
         uses: actions/upload-artifact@v4
         with:
-          overwrite: true
-          name: react-native-build
+          overwrite: false
+          name: ${{ inputs.environment }}-react-native-build
           path: packages/react-native-v2
       - name: Upload React Native v1 build
         uses: actions/upload-artifact@v4
         with:
-          overwrite: true
-          name: react-native-v1-build
+          overwrite: false
+          name: ${{ inputs.environment }}-react-native-v1-build
           path: packages/react-native
       - name: Upload eql build
         uses: actions/upload-artifact@v4
         with:
-          overwrite: true
-          name: eql-build
+          overwrite: false
+          name: ${{ inputs.environment }}-eql-build
           path: packages/eql/dist
       - name: Upload JS build
         uses: actions/upload-artifact@v4
         with:
-          overwrite: true
-          name: evervault-js
+          overwrite: false
+          name: ${{ inputs.environment }}-evervault-js
           path: packages/js/dist

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -75,7 +75,7 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           overwrite: true
-          name: ${{ inputs.environment }}-ui-components-playwright-report
+          name: "${{ inputs.environment }}-ui-components-playwright-report"
           path: e2e-tests/ui-components/playwright-report
           retention-days: 5
       - name: Coverage report
@@ -91,59 +91,59 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           overwrite: true
-          name: ${{ inputs.environment }}-browser-sdk-build
+          name: "${{ inputs.environment }}-browser-sdk-build"
           path: packages/browser/dist
       - name: Upload inputs build
         uses: actions/upload-artifact@v4
         with:
           overwrite: true
-          name: ${{ inputs.environment }}-inputs-sdk-build
+          name: "${{ inputs.environment }}-inputs-sdk-build"
           path: packages/inputs/dist
       - name: Upload ui-components build
         uses: actions/upload-artifact@v4
         with:
           overwrite: true
-          name: ${{ inputs.environment }}-ui-components-build
+          name: "${{ inputs.environment }}-ui-components-build"
           path: packages/ui-components/dist
       - name: Upload 3ds build
         uses: actions/upload-artifact@v4
         with:
           overwrite: true
-          name: ${{ inputs.environment }}-3ds-build
+          name: "${{ inputs.environment }}-3ds-build"
           path: packages/3ds/dist
       - name: Upload react build
         uses: actions/upload-artifact@v4
         with:
           overwrite: true
-          name: ${{ inputs.environment }}-react-sdk-build
+          name: "${{ inputs.environment }}-react-sdk-build"
           path: packages/react/dist
       - name: Upload card validator build
         uses: actions/upload-artifact@v4
         with:
           overwrite: true
-          name: ${{ inputs.environment }}-card-validator-build
+          name: "${{ inputs.environment }}-card-validator-build"
           path: packages/card-validator/dist
       - name: Upload React Native build
         uses: actions/upload-artifact@v4
         with:
           overwrite: true
-          name: ${{ inputs.environment }}-react-native-build
+          name: "${{ inputs.environment }}-react-native-build"
           path: packages/react-native-v2
       - name: Upload React Native v1 build
         uses: actions/upload-artifact@v4
         with:
           overwrite: true
-          name: ${{ inputs.environment }}-react-native-v1-build
+          name: "${{ inputs.environment }}-react-native-v1-build"
           path: packages/react-native
       - name: Upload eql build
         uses: actions/upload-artifact@v4
         with:
           overwrite: true
-          name: ${{ inputs.environment }}-eql-build
+          name: "${{ inputs.environment }}-eql-build"
           path: packages/eql/dist
       - name: Upload JS build
         uses: actions/upload-artifact@v4
         with:
           overwrite: true
-          name: ${{ inputs.environment }}-evervault-js
+          name: "${{ inputs.environment }}-evervault-js"
           path: packages/js/dist

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -90,60 +90,60 @@ jobs:
       - name: Upload browser build
         uses: actions/upload-artifact@v4
         with:
-          overwrite: false
+          overwrite: true
           name: ${{ inputs.environment }}-browser-sdk-build
           path: packages/browser/dist
       - name: Upload inputs build
         uses: actions/upload-artifact@v4
         with:
-          overwrite: false
+          overwrite: true
           name: ${{ inputs.environment }}-inputs-sdk-build
           path: packages/inputs/dist
       - name: Upload ui-components build
         uses: actions/upload-artifact@v4
         with:
-          overwrite: false
+          overwrite: true
           name: ${{ inputs.environment }}-ui-components-build
           path: packages/ui-components/dist
       - name: Upload 3ds build
         uses: actions/upload-artifact@v4
         with:
-          overwrite: false
+          overwrite: true
           name: ${{ inputs.environment }}-3ds-build
           path: packages/3ds/dist
       - name: Upload react build
         uses: actions/upload-artifact@v4
         with:
-          overwrite: false
+          overwrite: true
           name: ${{ inputs.environment }}-react-sdk-build
           path: packages/react/dist
       - name: Upload card validator build
         uses: actions/upload-artifact@v4
         with:
-          overwrite: false
+          overwrite: true
           name: ${{ inputs.environment }}-card-validator-build
           path: packages/card-validator/dist
       - name: Upload React Native build
         uses: actions/upload-artifact@v4
         with:
-          overwrite: false
+          overwrite: true
           name: ${{ inputs.environment }}-react-native-build
           path: packages/react-native-v2
       - name: Upload React Native v1 build
         uses: actions/upload-artifact@v4
         with:
-          overwrite: false
+          overwrite: true
           name: ${{ inputs.environment }}-react-native-v1-build
           path: packages/react-native
       - name: Upload eql build
         uses: actions/upload-artifact@v4
         with:
-          overwrite: false
+          overwrite: true
           name: ${{ inputs.environment }}-eql-build
           path: packages/eql/dist
       - name: Upload JS build
         uses: actions/upload-artifact@v4
         with:
-          overwrite: false
+          overwrite: true
           name: ${{ inputs.environment }}-evervault-js
           path: packages/js/dist

--- a/.github/workflows/deploy-3ds.yml
+++ b/.github/workflows/deploy-3ds.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Download Build Artifacts
         uses: actions/download-artifact@v4.1.8
         with:
-          name: ${{ inputs.environment }}-3ds-build
+          name: "${{ inputs.environment }}-3ds-build"
           path: dist
       - name: S3 Deploy
         run: aws s3 cp dist s3://${{ vars.TDS_AWS_S3_BUCKET }}/ --recursive

--- a/.github/workflows/deploy-3ds.yml
+++ b/.github/workflows/deploy-3ds.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Download Build Artifacts
         uses: actions/download-artifact@v4.1.8
         with:
-          name: 3ds-build
+          name: ${{ inputs.environment }}-3ds-build
           path: dist
       - name: S3 Deploy
         run: aws s3 cp dist s3://${{ vars.TDS_AWS_S3_BUCKET }}/ --recursive

--- a/.github/workflows/deploy-browser.yml
+++ b/.github/workflows/deploy-browser.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Download Build Artifacts
         uses: actions/download-artifact@v4.1.8
         with:
-          name: browser-sdk-build
+          name: ${{ inputs.environment }}-browser-sdk-build
           path: dist
       - name: Rename Build Artifacts
         run: cp ./dist/evervault-browser.main.umd.cjs ./dist/index.js && cp ./dist/evervault-browser.main.js ./dist/index.es.js
@@ -89,7 +89,7 @@ jobs:
       - name: Download Build Artifacts
         uses: actions/download-artifact@v4.1.8
         with:
-          name: browser-sdk-build
+          name: ${{ inputs.environment }}-browser-sdk-build
           path: dist
       - name: Rename Build Artifacts
         run: cp ./dist/evervault-browser.main.umd.cjs ./dist/index.js && cp ./dist/evervault-browser.main.js ./dist/index.es.js

--- a/.github/workflows/deploy-browser.yml
+++ b/.github/workflows/deploy-browser.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Download Build Artifacts
         uses: actions/download-artifact@v4.1.8
         with:
-          name: ${{ inputs.environment }}-browser-sdk-build
+          name: "${{ inputs.environment }}-browser-sdk-build"
           path: dist
       - name: Rename Build Artifacts
         run: cp ./dist/evervault-browser.main.umd.cjs ./dist/index.js && cp ./dist/evervault-browser.main.js ./dist/index.es.js
@@ -89,7 +89,7 @@ jobs:
       - name: Download Build Artifacts
         uses: actions/download-artifact@v4.1.8
         with:
-          name: ${{ inputs.environment }}-browser-sdk-build
+          name: "${{ inputs.environment }}-browser-sdk-build"
           path: dist
       - name: Rename Build Artifacts
         run: cp ./dist/evervault-browser.main.umd.cjs ./dist/index.js && cp ./dist/evervault-browser.main.js ./dist/index.es.js

--- a/.github/workflows/deploy-inputs.yml
+++ b/.github/workflows/deploy-inputs.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Download Build Artifacts
         uses: actions/download-artifact@v4.1.8
         with:
-          name: ${{ inputs.environment }}-inputs-sdk-build
+          name: "${{ inputs.environment }}-inputs-sdk-build"
           path: dist
       - name: S3 Deploy
         run: aws s3 cp ./dist s3://${{ vars.INPUTS_S3_BUCKET }}/v2/ --recursive

--- a/.github/workflows/deploy-inputs.yml
+++ b/.github/workflows/deploy-inputs.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Download Build Artifacts
         uses: actions/download-artifact@v4.1.8
         with:
-          name: inputs-sdk-build
+          name: ${{ inputs.environment }}-inputs-sdk-build
           path: dist
       - name: S3 Deploy
         run: aws s3 cp ./dist s3://${{ vars.INPUTS_S3_BUCKET }}/v2/ --recursive

--- a/.github/workflows/deploy-ui-components.yml
+++ b/.github/workflows/deploy-ui-components.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Download Build Artifacts
         uses: actions/download-artifact@v4.1.8
         with:
-          name: ui-components-build
+          name: ${{ inputs.environment }}-ui-components-build
           path: dist
       - name: S3 Deploy assets
         run: aws s3 cp ./dist/assets s3://${{ vars.UI_COMPONENTS_S3_BUCKET }}/assets/ --recursive
@@ -89,7 +89,7 @@ jobs:
       - name: Download Build Artifacts
         uses: actions/download-artifact@v4.1.8
         with:
-          name: ui-components-build
+          name: ${{ inputs.environment }}-ui-components-build
           path: dist
       - name: S3 Deploy
         run: aws s3 cp ./dist/index.html s3://${{ vars.UI_COMPONENTS_S3_BUCKET }}/

--- a/.github/workflows/deploy-ui-components.yml
+++ b/.github/workflows/deploy-ui-components.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Download Build Artifacts
         uses: actions/download-artifact@v4.1.8
         with:
-          name: ${{ inputs.environment }}-ui-components-build
+          name: "${{ inputs.environment }}-ui-components-build"
           path: dist
       - name: S3 Deploy assets
         run: aws s3 cp ./dist/assets s3://${{ vars.UI_COMPONENTS_S3_BUCKET }}/assets/ --recursive
@@ -89,7 +89,7 @@ jobs:
       - name: Download Build Artifacts
         uses: actions/download-artifact@v4.1.8
         with:
-          name: ${{ inputs.environment }}-ui-components-build
+          name: "${{ inputs.environment }}-ui-components-build"
           path: dist
       - name: S3 Deploy
         run: aws s3 cp ./dist/index.html s3://${{ vars.UI_COMPONENTS_S3_BUCKET }}/

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Download Build Artifacts
         uses: actions/download-artifact@v4.1.8
         with:
-          name: ${{ inputs.artifact }}
+          name: production-${{ inputs.artifact }}
           path: ${{ inputs.repo_path }}
 
       - uses: pnpm/action-setup@v4

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,4 +12,5 @@ jobs:
       vite-evervault-js-url: "https://js.evervault.io/v2"
       vite-keys-url: "https://keys.evervault.io"
       vite-api-url: "https://api.evervault.io"
+      environment: "staging"
     secrets: inherit

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,6 +13,7 @@ jobs:
       vite-evervault-js-url: "https://js.evervault.io/v2"
       vite-keys-url: "https://api.evervault.io/teams"
       vite-api-url: "https://api.evervault.io"
+      environment: "staging"
     secrets: inherit
   deploy-browser:
     needs: build
@@ -43,6 +44,7 @@ jobs:
   create-tags:
     name: Create Tags
     runs-on: ubuntu-latest
+    needs: build
     outputs:
       has-changesets: ${{ steps.changesets.outputs.hasChangesets }}
       tags-to-publish: ${{ steps.create-tags.outputs.tags-to-publish }}
@@ -86,7 +88,7 @@ jobs:
           HUSKY: 0
   release:
     name: Release ${{ matrix.tag }}
-    needs: create-tags
+    needs: [build,create-tags]
     # Only attempt releases if we expect to have pushed some tags
     if: needs.create-tags.outputs.has-changesets == 'false'
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
       vite-evervault-js-url: "https://js.evervault.com/v2"
       vite-keys-url: "https://keys.evervault.com"
       vite-api-url: "https://api.evervault.com"
+      environment: "production"
     secrets: inherit
   deploy-browser:
     if: startsWith(inputs.release-tag, '@evervault/browser')


### PR DESCRIPTION
# Why

Potential race condition between staging and production builds due to artefacts sharing a namespace, and running in parallel.

# How

- Give production release workflow a dependency on the staging release to avoid race condition
- Namespace the artefacts by environment