### PR TITLE
Isolate build and lint into smaller workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,72 @@
+name: Build Package
+on:
+  workflow_call:
+    inputs:
+      vite-evervault-js-url:
+        description: "URL where the JS SDK should be loaded from"
+        required: true
+        type: string
+      vite-keys-url:
+        description: "URL where keys will be fetched from"
+        required: true
+        type: string
+      vite-api-url:
+        description: "API endpoint"
+        required: true
+        type: string
+      environment:
+        description: "The environment that the URLs reference"
+        required: true
+        type: string
+      package-name:
+        description: "The name of the package to build. This must equal the name in the package.json"
+        required: true
+        type: string
+      upload-artifact:
+        description: "Whether to upload the artefact or not"
+        required: true
+        type: boolean
+      artifact-name:
+        description: "The name of the artifact to upload. Will be uploaded with the environment name as a prefix e.g. staging-<artifact-name>"
+        required: false
+        type: string
+jobs:
+  build:
+    name: "[${{ inputs.environment }}] Build ${{ inputs.package-name }}"
+    runs-on: ubuntu-latest
+    env:
+      VITE_API_URL: ${{ inputs.vite-api-url }}
+      VITE_EVERVAULT_JS_URL: ${{ inputs.vite-evervault-js-url}}
+      VITE_KEYS_URL: ${{ inputs.vite-keys-url }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Cache turbo build setup
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+      - uses: pnpm/action-setup@v4
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
+      - name: Install deps
+        run: pnpm install --frozen-lockfile
+      - name: Build ${{ inputs.package-name }}
+        run: pnpm run --if-present --filter ${{ inputs.package-name }} build
+      - name: Get path to package
+        id: get-path-to-package
+        run: |-
+          PATH_TO_PACKAGE=$(pnpm list --filter ${{ inputs.package-name }} --json | jq -r '.[0].path')
+          echo "path-to-package=$PATH_TO_PACKAGE" >> $GITHUB_OUTPUT
+      - name: Upload Build Artifacts
+        if: ${{ inputs.upload-artifact }}
+        uses: actions/upload-artifact@v4
+        with:
+          overwrite: false
+          name: "${{ inputs.environment }}-${{ inputs.artifact-name }}"
+          path: ${{ steps.get-path-to-package.outputs.path-to-package }}/dist

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,0 +1,167 @@
+name: E2E Test
+on:
+  workflow_call:
+    inputs:
+      vite-evervault-js-url:
+        description: "URL where the JS SDK should be loaded from"
+        required: true
+        type: string
+      vite-keys-url:
+        description: "URL where keys will be fetched from"
+        required: true
+        type: string
+      vite-api-url:
+        description: "API endpoint"
+        required: true
+        type: string
+      run-code-coverage-checks:
+        description: "Whether to run code coverage checks or not"
+        required: true
+        type: boolean
+jobs:
+  # Dedicated job to install playwright and save it to cache if its unset
+  # This should let us run the e2e tests in parallel with everything loading playwright from cache
+  prepare-cache:
+    name: "Prepare Cache for E2E Tests"
+    runs-on: ubuntu-latest
+    outputs:
+      cache-key: ${{ steps.playwright-cache.outputs.cache-primary-key }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Cache turbo build setup
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
+      - name: Install deps
+        run: pnpm install --frozen-lockfile
+      - name: Find playwright version
+        id: playwright-version
+        run: |-
+          PLAYWRIGHT_VERSION=$(ls --json @playwright/test | jq -r '.[].devDependencies."@playwright/test".version')
+          echo "playwright-version=$PLAYWRIGHT_VERSION" >> $GITHUB_OUTPUT
+      # Caching playwright, ref: https://github.com/microsoft/playwright/issues/7249
+      - name: Try to restore Playwright from cache
+        uses: actions/cache/restore@v4
+        id: playwright-cache
+        with:
+          path: "~/.cache/ms-playwright"
+          key: "${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.playwright-version }}"
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+      - name: "[cache-miss] Install Playwright browser binaries & OS dependencies"
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm exec playwright install --with-deps 
+      # Save playwright version to cache
+      - name: Save Playwright to cache if cache-miss
+        uses: actions/cache/save@v4
+        if: always() && steps.playwright-cache.outputs.cache-hit != 'true'
+        with:
+          path: "~/.cache/ms-playwright"
+          key: ${{ steps.playwright-cache.outputs.cache-primary-key }}
+  get-e2e-targets:
+    name: "Build list of E2E test projects"
+    runs-on: ubuntu-latest
+    outputs:
+      e2e-test-projects: ${{ steps.e2e-targets.outputs.e2e-test-projects }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Cache turbo build setup
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
+      - name: Install deps
+        run: pnpm install --frozen-lockfile
+      - name: Create list of E2E test projects
+        id: e2e-targets
+        run: |-
+          E2E_TEST_PROJECTS=$(pnpm m ls --depth=1 --json | jq -cr '[.[] | select(.name|endswith("e2e-tests")) | .name]')
+          echo "e2e-test-projects=$E2E_TEST_PROJECTS" >> $GITHUB_OUTPUT
+  e2e-test:
+    name: "Run E2E Tests for ${{ matrix.project }}"
+    needs: [prepare-cache, get-e2e-targets]
+    strategy:
+      matrix: 
+        project: ${{ fromJson(needs.get-e2e-targets.outputs.e2e-test-projects) }}
+    timeout-minutes: 25
+    runs-on: ubuntu-latest
+    env:
+      EV_API_KEY: ${{ secrets.TESTS_DECRYPT_FN_KEY }}
+      EV_APP_UUID: ${{ secrets.TESTS_APP_UUID }}
+      EV_TEAM_UUID: ${{ secrets.TESTS_TEAM_UUID }}
+      VITE_GOOGLE_PAY_MERCHANT_ID: ${{ vars.GOOGLE_PAY_MERCHANT_ID }}
+      VITE_EV_APP_UUID: ${{ secrets.TESTS_APP_UUID }}
+      VITE_EV_TEAM_UUID: ${{ secrets.TESTS_TEAM_UUID }}
+      VITE_API_URL: ${{ inputs.vite-api-url }}
+      VITE_EVERVAULT_JS_URL: ${{ inputs.vite-evervault-js-url }}
+      VITE_KEYS_URL: ${{ inputs.vite-keys-url }}
+      VITE_TEST_COVERAGE: "${{ inputs.run-code-coverage-checks }}"
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Cache turbo build setup
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
+      - name: Install deps
+        run: pnpm install --frozen-lockfile
+      - name: Build ${{ matrix.project }} with coverage tooling
+        run: pnpm run -r --filter="${{ matrix.project }}..." --if-present build
+      # Caching playwright, ref: https://github.com/microsoft/playwright/issues/7249
+      - name: Try to restore Playwright from cache
+        uses: actions/cache/restore@v4
+        id: playwright-cache
+        with:
+          path: "~/.cache/ms-playwright"
+          key: ${{ needs.prepare-cache.outputs.cache-key }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+      - name: "[cache-miss] Install Playwright browser binaries & OS dependencies"
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm exec playwright install --with-deps 
+      - name: "[cache-hit] Install Playwright OS Deps"
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm exec playwright install-deps
+      - name: E2E test
+        run: pnpm run --filter="${{ matrix.project }}" --if-present e2e:test
+      - name: Generate Coverage Report
+        # Inputs does not export a coverage report
+        if: ${{ inputs.run-code-coverage-checks && matrix.project != '@evervault/inputs-e2e-tests' }}
+        run: pnpm coverage:report
+      # - name: Enforce Coverage Threshold
+      #   if: ${{ inputs.run-code-coverage-checks && matrix.project != '@evervault/inputs-e2e-tests' }}
+      #   run: pnpm coverage:chec 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,73 @@
+name: Lint and Test
+on:
+  workflow_call:
+    inputs:
+      vite-evervault-js-url:
+        description: "URL where the JS SDK should be loaded from"
+        required: true
+        type: string
+      vite-keys-url:
+        description: "URL where keys will be fetched from"
+        required: true
+        type: string
+      vite-api-url:
+        description: "API endpoint"
+        required: true
+        type: string
+      run-code-coverage-checks:
+        description: "Whether to run code coverage checks or not"
+        required: true
+        type: boolean
+jobs:
+  lint:
+    name: "Lint and Test"
+    timeout-minutes: 25
+    runs-on: ubuntu-latest
+    env:
+      EV_API_KEY: ${{ secrets.TESTS_DECRYPT_FN_KEY }}
+      EV_APP_UUID: ${{ secrets.TESTS_APP_UUID }}
+      EV_TEAM_UUID: ${{ secrets.TESTS_TEAM_UUID }}
+      VITE_GOOGLE_PAY_MERCHANT_ID: ${{ vars.GOOGLE_PAY_MERCHANT_ID }}
+      VITE_EV_APP_UUID: ${{ secrets.TESTS_APP_UUID }}
+      VITE_EV_TEAM_UUID: ${{ secrets.TESTS_TEAM_UUID }}
+      VITE_API_URL: ${{ inputs.vite-api-url }}
+      VITE_EVERVAULT_JS_URL: ${{ inputs.vite-evervault-js-url}}
+      VITE_KEYS_URL: ${{ inputs.vite-keys-url }}
+      VITE_TEST_COVERAGE: "${{ inputs.run-code-coverage-checks }}"
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Cache turbo build setup
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+      - uses: pnpm/action-setup@v4
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
+      - name: Install deps
+        run: pnpm install --frozen-lockfile
+      # TODO: resolve issues with unit test coverage
+      # - name: Build in coverage tooling
+      #   if: ${{ inputs.run-code-coverage-checks }}
+      #   run: pnpm run -r --if-present build
+      - name: Formats check
+        run: pnpm run format:check
+      - name: Typescript check
+        run: pnpm run typecheck
+      - name: eslint check
+        run: pnpm run lint
+      - name: Run unit tests
+        run: pnpm test
+      # TODO: resolve issues with unit test coverage
+      # - name: Generate Coverage Report
+      #   if: ${{ inputs.run-code-coverage-checks }}
+      #   run: pnpm coverage:report
+      # - name: Enforce Coverage Threshold
+      #   if: ${{ inputs.run-code-coverage-checks }}
+      #   run: pnpm coverage:check

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -6,7 +6,7 @@ on:
       - "master"
       - "main"
 jobs:
-  build:
+  build-and-test:
     uses: ./.github/workflows/build-and-test.yml
     with:
       vite-evervault-js-url: "https://js.evervault.io/v2"
@@ -14,3 +14,38 @@ jobs:
       vite-api-url: "https://api.evervault.io"
       environment: "staging"
     secrets: inherit
+  lint-and-test:
+    uses: ./.github/workflows/lint.yml
+    with:
+      vite-evervault-js-url: "https://js.evervault.io/v2"
+      vite-keys-url: "https://keys.evervault.io"
+      vite-api-url: "https://api.evervault.io"
+      run-code-coverage-checks: true
+    secrets: inherit
+  e2e-test:
+    uses: ./.github/workflows/e2e-test.yml
+    with:
+      vite-evervault-js-url: "https://js.evervault.com/v2"
+      vite-keys-url: "https://keys.evervault.com"
+      vite-api-url: "https://api.evervault.com"
+      run-code-coverage-checks: true
+    secrets: inherit
+  build-all-packages:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
+      - name: Install deps
+        run: pnpm install --frozen-lockfile
+      - name: Build all packages
+        run: pnpm run -r --if-present build
+        env:
+          VITE_API_URL: "https://api.evervault.io"
+          VITE_EVERVAULT_JS_URL: "https://js.evervault.io/v2"
+          VITE_KEYS_URL: "https://keys.evervault.io"

--- a/e2e-tests/browser/package.json
+++ b/e2e-tests/browser/package.json
@@ -10,6 +10,9 @@
     "clean": "rm -rf .turbo node_modules dist",
     "preview": "vite --port 4006"
   },
+  "dependencies": {
+    "@evervault/browser": "workspace:*"
+  },
   "devDependencies": {
     "vite": "catalog:",
     "@repo/test-coverage": "workspace:*"

--- a/e2e-tests/ui-components/playwright.config.js
+++ b/e2e-tests/ui-components/playwright.config.js
@@ -20,8 +20,8 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  /* Use 3 of 4 cores in CI. */
+  workers: process.env.CI ? "75%" : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: "html",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */


### PR DESCRIPTION
# Why

Our CI for this repo is in a dire state, and needs some love.

# How

First PR of several — rework the PR action:
- Split out linting steps from build
- Run builds in parallel for all packages in this repo
- Make artifact upload conditional
- Make test coverage conditional
- Cache playwright binaries, and run e2e tests in parallel
