### PR TITLE
Upload entire package folder as artifact for react native packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,9 +70,16 @@ jobs:
           PATH_TO_PACKAGE=$(pnpm list --filter ${{ inputs.package-name }} --json | jq -r '.[0].path')
           echo "path-to-package=$PATH_TO_PACKAGE" >> $GITHUB_OUTPUT
       - name: Upload Build Artifacts
-        if: ${{ inputs.upload-artifact }}
+        if: ${{ inputs.upload-artifact && !endsWith(inputs.package-name, 'react-native') }}
         uses: actions/upload-artifact@v4
         with:
           overwrite: false
           name: ${{ needs.get-artifact-name.outputs.artifact-name }}
           path: ${{ steps.get-path-to-package.outputs.path-to-package }}/dist
+      - name: Upload Build Artifacts
+        if: ${{ inputs.upload-artifact && endsWith(inputs.package-name, 'react-native') }}
+        uses: actions/upload-artifact@v4
+        with:
+          overwrite: false
+          name: ${{ needs.get-artifact-name.outputs.artifact-name }}
+          path: ${{ steps.get-path-to-package.outputs.path-to-package }}


### PR DESCRIPTION
# Why
React native packages upload a different artifact to the rest of the packages. They expect the entire folder to go into the artifact, not the dist.

# How
Check if the package given to build is react-native using a suffix check. If it is, upload the entire directory.