### PR TITLE
Upload playwright report on e2e-test failure

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -161,4 +161,19 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit == 'true'
         run: pnpm exec playwright install-deps
       - name: E2E test
+        id: run-e2e-test
         run: pnpm run --filter="${{ matrix.project }}" --if-present e2e:test --shard=${{ matrix.shard }}/${{ matrix.total-shards }}
+      - name: Get path to package
+        if: ${{ steps.run-e2e-test.outcome == 'failure' }}
+        id: get-path-to-package
+        run: |-
+          PACKAGE_PATH=$(pnpm m ls --depth=1 --json | jq -r '.[] | select(.name == "${{ matrix.project }}") | .path')
+          echo "package-path=$PACKAGE_PATH" >> $GITHUB_OUTPUT
+      - name: Upload report on failure
+        if: ${{ steps.run-e2e-test.outcome == 'failure' }}
+        uses: actions/upload-artifact@v4
+        with:
+          path: |
+            ${{ steps.get-path-to-package.outputs.package-path }}/playwright-report
+            ${{ steps.get-path-to-package.outputs.package-path }}/test-results
+          name: e2e-tests-${{ matrix.project }}-report-${{ matrix.shard }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -162,18 +162,25 @@ jobs:
         run: pnpm exec playwright install-deps
       - name: E2E test
         id: run-e2e-test
+        continue-on-error: true
         run: pnpm run --filter="${{ matrix.project }}" --if-present e2e:test --shard=${{ matrix.shard }}/${{ matrix.total-shards }}
       - name: Get path to package
-        if: ${{ failure() && steps.run-e2e-test.outcome == 'failure' }}
+        if: ${{ steps.run-e2e-test.outcome == 'failure' }}
         id: get-path-to-package
         run: |-
           PACKAGE_PATH=$(pnpm m ls --depth=1 --json | jq -r '.[] | select(.name == "${{ matrix.project }}") | .path')
           echo "package-path=$PACKAGE_PATH" >> $GITHUB_OUTPUT
+      - name: Normalize package name
+        if: ${{ steps.run-e2e-test.outcome == 'failure' }}
+        id: normalize-package-name
+        run: |-
+          NORMALIZED_NAME=$(echo "${{ matrix.project }}" | sed -e 's/@//g' -e 's/[/]/-/g')
+          echo "normalized-name=$NORMALIZED_NAME" >> $GITHUB_OUTPUT
       - name: Upload report on failure
-        if: ${{ failure() && steps.run-e2e-test.outcome == 'failure' }}
+        if: ${{ steps.run-e2e-test.outcome == 'failure' }}
         uses: actions/upload-artifact@v4
         with:
           path: |
             ${{ steps.get-path-to-package.outputs.package-path }}/playwright-report
             ${{ steps.get-path-to-package.outputs.package-path }}/test-results
-          name: e2e-tests-${{ matrix.project }}-report-${{ matrix.shard }}
+          name: ${{ steps.normalize-package-name.outputs.normalized-name }}-report-${{ matrix.shard }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -162,15 +162,16 @@ jobs:
         run: pnpm exec playwright install-deps
       - name: E2E test
         id: run-e2e-test
+        continue-on-error: true
         run: pnpm run --filter="${{ matrix.project }}" --if-present e2e:test --shard=${{ matrix.shard }}/${{ matrix.total-shards }}
       - name: Get path to package
-        if: ${{ steps.run-e2e-test.outcome == 'failure' }}
+        if: ${{ failure() && steps.run-e2e-test.outcome == 'failure' }}
         id: get-path-to-package
         run: |-
           PACKAGE_PATH=$(pnpm m ls --depth=1 --json | jq -r '.[] | select(.name == "${{ matrix.project }}") | .path')
           echo "package-path=$PACKAGE_PATH" >> $GITHUB_OUTPUT
       - name: Upload report on failure
-        if: ${{ steps.run-e2e-test.outcome == 'failure' }}
+        if: ${{ failure() && steps.run-e2e-test.outcome == 'failure' }}
         uses: actions/upload-artifact@v4
         with:
           path: |

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -162,7 +162,6 @@ jobs:
         run: pnpm exec playwright install-deps
       - name: E2E test
         id: run-e2e-test
-        continue-on-error: true
         run: pnpm run --filter="${{ matrix.project }}" --if-present e2e:test --shard=${{ matrix.shard }}/${{ matrix.total-shards }}
       - name: Get path to package
         if: ${{ failure() && steps.run-e2e-test.outcome == 'failure' }}


### PR DESCRIPTION
# Why

We currently have no ability to debug and identify flaky tests in CI

# How

Add steps to run on e2e failure which upload the test report and results
