### PR TITLE
Use correct input for keys url in e2e tests on push

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -162,22 +162,21 @@ jobs:
         run: pnpm exec playwright install-deps
       - name: E2E test
         id: run-e2e-test
-        continue-on-error: true
         run: pnpm run --filter="${{ matrix.project }}" --if-present e2e:test --shard=${{ matrix.shard }}/${{ matrix.total-shards }}
       - name: Get path to package
-        if: ${{ steps.run-e2e-test.outcome == 'failure' }}
+        if: ${{ failure() && steps.run-e2e-test.outcome == 'failure' }}
         id: get-path-to-package
         run: |-
           PACKAGE_PATH=$(pnpm m ls --depth=1 --json | jq -r '.[] | select(.name == "${{ matrix.project }}") | .path')
           echo "package-path=$PACKAGE_PATH" >> $GITHUB_OUTPUT
       - name: Normalize package name
-        if: ${{ steps.run-e2e-test.outcome == 'failure' }}
+        if: ${{ failure() && steps.run-e2e-test.outcome == 'failure' }}
         id: normalize-package-name
         run: |-
           NORMALIZED_NAME=$(echo "${{ matrix.project }}" | sed -e 's/@//g' -e 's/[/]/-/g')
           echo "normalized-name=$NORMALIZED_NAME" >> $GITHUB_OUTPUT
       - name: Upload report on failure
-        if: ${{ steps.run-e2e-test.outcome == 'failure' }}
+        if: ${{ failure() && steps.run-e2e-test.outcome == 'failure' }}
         uses: actions/upload-artifact@v4
         with:
           path: |

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,7 +18,7 @@ jobs:
     uses: ./.github/workflows/e2e-test.yml
     with:
       vite-evervault-js-url: "https://js.evervault.com/v2"
-      vite-keys-url: "https://api.evervault.com/teams"
+      vite-keys-url: "https://keys.evervault.com"
       vite-api-url: "https://api.evervault.com"
       run-code-coverage-checks: false
     secrets: inherit


### PR DESCRIPTION
# Why
e2e tests are misconfigured in workflow on push

# How
Use correct url: keys.evervault.com
