### PR TITLE
Accept explicit environment names in static bundle publish workflow

### DIFF
--- a/.github/workflows/publish-static-bundle.yml
+++ b/.github/workflows/publish-static-bundle.yml
@@ -8,8 +8,12 @@ on:
         description: "Stage to deploy to (eg. staging, production)"
         required: true
         type: string
-      environment:
-        description: "Name of the github environment used to gate deployments. This will be used by the workflow to resolve the correct values for Github Secrets and Vars."
+      preview-environment:
+        description: "Name of the github environment used for deployment previews. This will be used by the workflow to resolve the correct values for Github Secrets and Vars."
+        required: false
+        type: string
+      live-environment:
+        description: "Name of the github environment used to live deployments. This will be used by the workflow to resolve the correct values for Github Secrets and Vars."
         required: true
         type: string
       run-preflight-checks:
@@ -59,7 +63,7 @@ jobs:
   # This is to ensure that the preview deployment is working as expected before we promote to production.
   deploy-preview:
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }}
+    environment: ${{ inputs.preview-environment }}
     if: ${{ inputs.perform-gated-preview-deployment }}
     name: "[PREVIEW] Deploy ${{ inputs.package-name }} to ${{ inputs.stage }}"
     needs: get-artifact-name
@@ -163,7 +167,7 @@ jobs:
     # We need to run this step even if the preview deployment is skipped. This is to account for the preview deployment being skipped.
     # If the preview deployment fails, we should not attempt a live deployment.
     if: ${{ always() && !failure() }}
-    environment: ${{ inputs.environment }}-deploy
+    environment: ${{ inputs.live-environment }}
     name: "Deploy ${{ inputs.package-name }} to ${{ inputs.stage }}"
     steps:
       - name: Configure AWS Credentials

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -62,7 +62,8 @@ jobs:
     with:
       stage: "staging"
       package-name: '@evervault/browser'
-      environment: 'browser-staging'
+      preview-environment: 'staging-deploy'
+      live-environment: 'browser-staging-deploy'
       run-preflight-checks: false
       perform-gated-preview-deployment: true
       cloudfront-preview-path-invalidation: "/v2/preview/index.js"
@@ -77,7 +78,7 @@ jobs:
     with:
       stage: "staging"
       package-name: '@evervault/inputs'
-      environment: 'staging'
+      live-environment: 'staging'
       run-preflight-checks: false
       perform-gated-preview-deployment: false
       cloudfront-live-path-invalidation: "/index.html,/bundle.js,/v2/*"
@@ -90,7 +91,8 @@ jobs:
     with:
       stage: "staging"
       package-name: '@evervault/ui-components'
-      environment: 'ui-components-staging'
+      preview-environment: 'staging'
+      live-environment: 'ui-components-staging-deploy'
       run-preflight-checks: false
       perform-gated-preview-deployment: true
       s3-bucket-var-name: 'UI_COMPONENTS_S3_BUCKET'
@@ -105,7 +107,7 @@ jobs:
     with:
       stage: "staging"
       package-name: '@evervault/3ds'
-      environment: 'staging'
+      live-environment: 'staging'
       run-preflight-checks: false
       perform-gated-preview-deployment: false
       s3-bucket-var-name: 'TDS_AWS_S3_BUCKET'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,8 @@ jobs:
     with:
       package-name: '@evervault/browser'
       stage: "production"
-      environment: 'browser-production'
+      preview-environment: 'browser-production'
+      live-environment: 'browser-production-deploy'
       run-preflight-checks: true
       perform-gated-preview-deployment: true
       cloudfront-preview-path-invalidation: "/v2/preview/index.js"
@@ -58,7 +59,7 @@ jobs:
     uses: ./.github/workflows/publish-static-bundle.yml
     with:
       package-name: '@evervault/inputs'
-      environment: 'production'
+      live-environment: 'production'
       run-preflight-checks: false
       perform-gated-preview-deployment: false
       cloudfront-live-path-invalidation: "/index.html,/bundle.js,/v2/*"
@@ -74,7 +75,8 @@ jobs:
     with:
       package-name: '@evervault/ui-components'
       stage: "production"
-      environment: 'ui-components-production'
+      preview-environment: 'ui-components-production'
+      live-environment: 'ui-components-production'
       run-preflight-checks: true
       perform-gated-preview-deployment: true
       s3-bucket-var-name: 'UI_COMPONENTS_S3_BUCKET'
@@ -91,7 +93,7 @@ jobs:
     with:
       package-name: '@evervault/3ds'
       stage: "production"
-      environment: 'production'
+      live-environment: 'production'
       run-preflight-checks: false
       perform-gated-preview-deployment: false
       s3-bucket-var-name: 'TDS_AWS_S3_BUCKET'


### PR DESCRIPTION
# Why

The environments are used to select the appropriate variable value within Actions. The environment names in this repo leave a lot to be desired, and don't follow any strong structure (gated deployments are prefixed by the package name, some are suffixed by `-deploy`, others are just the stage). This should be cleaned up, but we need to get the CI working before that can happen.

# How

Update static bundle workflow to accept explicit environment names for the package being released. This will be more reliable than the previous approach to try to build the environments based on other inputs.
