### PR TITLE
Quote the invalidation paths in action script

### DIFF
--- a/.github/workflows/publish-static-bundle.yml
+++ b/.github/workflows/publish-static-bundle.yml
@@ -117,7 +117,7 @@ jobs:
         id: prepare-cloudfront-payload
         with:
           script: |
-            const paths = ${{ inputs.cloudfront-preview-path-invalidation }}.split(',').map(path => path.trim()).filter(path => path !== '');
+            const paths = "${{ inputs.cloudfront-preview-path-invalidation }}".split(",").map(path => path.trim()).filter(path => path !== "");
             return {
               Paths: {
                 Quantity: paths.length,
@@ -208,7 +208,7 @@ jobs:
         id: prepare-cloudfront-payload
         with:
           script: |
-            const paths = ${{ inputs.cloudfront-live-path-invalidation }}.split(',').map(path => path.trim()).filter(path => path !== '');
+            const paths = "${{ inputs.cloudfront-live-path-invalidation }}".split(",").map(path => path.trim()).filter(path => path !== "");
             return {
               Paths: {
                 Quantity: paths.length,


### PR DESCRIPTION
# Why

The input value is being inserted into the script verbatim, so cannot be handled as a string without quoting. This is causing a syntax error.

E.g. 
```js
  const paths = /v2/preview/index.js.split(',').map(path => path.trim()).filter(path => path !== '');
  return {
    Paths: {
      Quantity: paths.length,
      Items: paths
    }
  };
```

# How

Quote the invalidation paths in the script when preparing the cloudfront payload

