### PR TITLE
fix: get canonical artifact name in publish flow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -25,8 +25,15 @@ on:
         required: true
 
 jobs:
+  get-artifact-name:
+    uses: ./.github/workflows/get-artifact-name.yml
+    with:
+      package-name: ${{ inputs.package }}
+      environment: 'production'
+
   publish:
     name: Publish to NPM
+    needs: [get-artifact-name]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -41,7 +48,7 @@ jobs:
       - name: Download Build Artifacts
         uses: actions/download-artifact@v4.1.8
         with:
-          name: production-${{ inputs.artifact }}
+          name: ${{ needs.get-artifact-name.outputs.artifact-name }}
           path: ${{ inputs.repo_path }}
 
       - uses: pnpm/action-setup@v4


### PR DESCRIPTION
# Why

Release of the react native SDK failed because the artifact path was not updated in our CI overhaul. It should be using the composable workflow to get a canonical artifact name.

# How

Add call to `get-artifact-name` in npm publish workflow. It might be useful to update this workflow to perform a dry run publish and have the artifact available for inspection in future.