### PR TITLE
Update SDK versions for React Native Android side

### DIFF
--- a/.changeset/gentle-elephants-study.md
+++ b/.changeset/gentle-elephants-study.md
@@ -1,0 +1,6 @@
+---
+"@evervault/react-native": minor
+---
+
+- Updates Android compile and target SDK version to 35
+- Updates Android minimum SDK version to 24

--- a/packages/react-native-v2/android/build.gradle
+++ b/packages/react-native-v2/android/build.gradle
@@ -17,8 +17,13 @@ apply plugin: 'com.facebook.react'
 apply plugin: 'org.jetbrains.kotlin.android'
 
 android {
-  compileSdkVersion safeExtGet('compileSdkVersion', 33)
+  compileSdkVersion safeExtGet('compileSdkVersion', 35)
   namespace "com.nativeevervault"
+
+  defaultConfig {
+    minSdkVersion safeExtGet('minSdkVersion', 24)
+    targetSdkVersion safeExtGet('targetSdkVersion', 35)
+  }
 }
 
 repositories {


### PR DESCRIPTION
# Why

Sets the minimum SDK versions, as advised by React Native:
https://reactnative.dev/blog/2024/10/23/release-0.76-new-architecture#updates-to-minimum-ios-and-android-sdk-requirements

# How

- Updates the SDK versions in `build.gradle`
