### PR TITLE
dave/3ds method timeout

### DIFF
--- a/.changeset/lazy-meals-sing.md
+++ b/.changeset/lazy-meals-sing.md
@@ -1,0 +1,5 @@
+---
+"@evervault/ui-components": minor
+---
+
+Extend 3ds method timeout

--- a/packages/ui-components/src/ThreeDSecure/BrowserFingerprint.tsx
+++ b/packages/ui-components/src/ThreeDSecure/BrowserFingerprint.tsx
@@ -8,6 +8,8 @@ interface BrowserFingerprintProps {
   onTimeout: () => void;
 }
 
+const THREE_DS_METHOD_TIMEOUT = 7500;
+
 export function BrowserFingerprint({
   action,
   onComplete,
@@ -26,7 +28,10 @@ export function BrowserFingerprint({
       });
     }
 
-    const timeout = setTimeout(onTimeout, 5000);
+    const timeout = setTimeout(() => {
+      window.removeEventListener("message", handleMessage);
+      onTimeout();
+    }, THREE_DS_METHOD_TIMEOUT);
 
     const handleMessage = (e: MessageEvent) => {
       if (isTrampolineMessage(e)) {


### PR DESCRIPTION
# Why

We timeout the 3DS method profiling script after 5 seconds. The protocol declares the following:
```
The 3DS Server shall:
[Req 315] Set the 3DS Method Completion Indicator = Y upon notification from
the 3DS Requestor. If the 3DS Method does not complete within 10 seconds,
set the 3DS Method Completion Indicator to = N.
```

I'm proposing we extend the timeout to 7.5 seconds. Waiting the full 10 seconds before timing out the ACS's profiling script feels like a poor UX. This middle ground should help us capture many cases where profiling completes shortly after we have marked the profiling as having timed out.

# How

Update the timeout value. Additionally cleanup the message listener when we invoke a timeout patch to help prevent conflicting timeout/complete patch events.
