### PR TITLE
fix: correct changelog script to support multiline output

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -94,7 +94,11 @@ jobs:
         id: release-content
         run: |
           CHANGELOG_CONTENT=$(git diff HEAD~1..HEAD -- ${{ github.workspace }}/packages/${{ steps.parse.outputs.name }}/CHANGELOG.md | grep '^+' | grep --invert-match '^+++'  | sed 's/^+//' | tail -n +3)
-          echo "content=${CHANGELOG_CONTENT}" >> $GITHUB_OUTPUT
+          {
+            echo 'content<<EOF'
+            echo "$CHANGELOG_CONTENT"
+            echo 'EOF'
+          } >> $GITHUB_OUTPUT
       - uses: softprops/action-gh-release@v2
         with:
           body: ${{ steps.release-content.outputs.content }}

--- a/.github/workflows/publish-static-bundle.yml
+++ b/.github/workflows/publish-static-bundle.yml
@@ -247,7 +247,11 @@ jobs:
         id: release-content
         run: |
           CHANGELOG_CONTENT=$(git diff HEAD~1..HEAD -- ${{ github.workspace }}/packages/${{ steps.parse.outputs.name }}/CHANGELOG.md | grep '^+' | grep --invert-match '^+++'  | sed 's/^+//' | tail -n +3)
-          echo "content=${CHANGELOG_CONTENT}" >> $GITHUB_OUTPUT
+          {
+            echo 'content<<EOF'
+            echo "$CHANGELOG_CONTENT"
+            echo 'EOF'
+          } >> $GITHUB_OUTPUT
       - uses: softprops/action-gh-release@v2
         with:
           body: ${{ steps.release-content.outputs.content }}


### PR DESCRIPTION
# Why

The changelog script errors due to its handling of multiline output

# How

Update script for deriving the changelog for a release to support multiline output
