### PR TITLE
Add allow3DigitAmexCVC option to Card component

### DIFF
--- a/.changeset/big-planets-own.md
+++ b/.changeset/big-planets-own.md
@@ -1,0 +1,7 @@
+---
+"@evervault/ui-components": minor
+"@evervault/browser": minor
+"@evervault/react": minor
+---
+
+Adds a new `allow3DigitAmexCVC` option which allows you to configure whether or not 3 digit CVC should be treated as invalid or not. The default value is true.

--- a/e2e-tests/ui-components/tests/cardDetails.spec.js
+++ b/e2e-tests/ui-components/tests/cardDetails.spec.js
@@ -328,6 +328,41 @@ test.describe("card component", () => {
     await expect(frame.getByLabel("CVC")).toHaveValue("1234");
   });
 
+  test("allows 3 digit CVCs for Amex by default", async ({ page }) => {
+    await page.evaluate(() => {
+      const card = window.evervault.ui.card();
+      card.mount("#form");
+    });
+
+    const amex = "378282246310005";
+    const frame = page.frameLocator("iframe[data-evervault]");
+    await frame.getByLabel("Number").fill(amex);
+    await frame.getByLabel("CVC").fill("12");
+    await frame.getByLabel("CVC").blur();
+    // intentionally make invalid first to test it becomes valid with 3 digits
+    await expect(frame.getByText("Your CVC is invalid")).toBeVisible();
+    await frame.getByLabel("CVC").fill("123");
+    await expect(frame.getByText("Your CVC is invalid")).not.toBeVisible();
+  });
+
+  test("can disable 3 digit amex CVCs", async ({ page }) => {
+    await page.evaluate(() => {
+      const card = window.evervault.ui.card({
+        allow3DigitAmexCVC: false,
+      });
+      card.mount("#form");
+    });
+
+    const amex = "378282246310005";
+    const frame = page.frameLocator("iframe[data-evervault]");
+    await frame.getByLabel("Number").fill(amex);
+    await frame.getByLabel("CVC").fill("123");
+    await frame.getByLabel("CVC").blur();
+    await expect(frame.getByText("Your CVC is invalid")).toBeVisible();
+    await frame.getByLabel("CVC").fill("1233");
+    await expect(frame.getByText("Your CVC is invalid")).not.toBeVisible();
+  });
+
   test("only permits 16 digits for visa", async ({ page }) => {
     await page.evaluate(() => {
       const card = window.evervault.ui.card();

--- a/packages/browser/lib/ui/card.ts
+++ b/packages/browser/lib/ui/card.ts
@@ -113,6 +113,7 @@ export default class Card {
         autoComplete: this.#options.autoComplete,
         autoProgress: this.#options.autoProgress,
         redactCVC: this.#options.redactCVC,
+        allow3DigitAmexCVC: this.#options.allow3DigitAmexCVC,
       },
     };
   }

--- a/packages/react/lib/ui/Card.tsx
+++ b/packages/react/lib/ui/Card.tsx
@@ -34,6 +34,7 @@ export interface CardProps {
   onKeyUp?: (event: FieldEvent) => void;
   onKeyDown?: (event: FieldEvent) => void;
   redactCVC?: boolean;
+  allow3DigitAmexCVC?: boolean;
 }
 
 type CardClass = ReturnType<Evervault["ui"]["card"]>;
@@ -58,6 +59,7 @@ export function Card({
   acceptedBrands,
   defaultValues,
   redactCVC,
+  allow3DigitAmexCVC,
 }: CardProps) {
   const ev = useEvervault();
   const initialized = useRef(false);
@@ -130,6 +132,7 @@ export function Card({
       acceptedBrands,
       defaultValues,
       redactCVC,
+      allow3DigitAmexCVC,
     }),
     [
       theme,
@@ -142,6 +145,7 @@ export function Card({
       acceptedBrands,
       defaultValues,
       redactCVC,
+      allow3DigitAmexCVC,
     ]
   );
 

--- a/packages/types/uiComponents.ts
+++ b/packages/types/uiComponents.ts
@@ -103,6 +103,7 @@ export interface CardOptions {
   translations?: Partial<CardTranslations>;
   autoProgress?: boolean;
   redactCVC?: boolean;
+  allow3DigitAmexCVC?: boolean;
   defaultValues?: {
     name?: string;
   };

--- a/packages/ui-components/src/Card/index.tsx
+++ b/packages/ui-components/src/Card/index.tsx
@@ -98,7 +98,13 @@ export function Card({ config }: { config: CardConfig }) {
         if (!fields.includes("cvc")) return undefined;
 
         const cvcValidation = validateCVC(values.cvc, values.number);
+
         if (!cvcValidation.isValid) {
+          return "invalid";
+        }
+
+        const allow3DigitAmex = config.allow3DigitAmexCVC ?? true;
+        if (values.cvc?.length === 3 && !allow3DigitAmex) {
           return "invalid";
         }
 

--- a/packages/ui-components/src/Card/types.ts
+++ b/packages/ui-components/src/Card/types.ts
@@ -16,6 +16,7 @@ export interface CardConfig {
   translations?: Partial<CardTranslations>;
   autoProgress?: boolean;
   redactCVC?: boolean;
+  allow3DigitAmexCVC?: boolean;
   defaultValues?: {
     name?: string;
   };


### PR DESCRIPTION
# Why

Some Amex cards can have 3 digit CVC codes, however, not all payment gateways support 3 digit Amex CVCs.

# How

Introduce a new `allow3DigitAmexCVC` option to the card component to allow users to disable support for 3 digit Amex CVCs.

```js
evervault.ui.card({
  allow3DigitAmexCVC: false
})
```
