### PR TITLE
fix: add fetch-tags: true to changelog gen step

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -77,6 +77,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
+          fetch-tags: true
       - name: Get package name
         env:
           TAG: ${{ inputs.tag_name }}

--- a/.github/workflows/publish-static-bundle.yml
+++ b/.github/workflows/publish-static-bundle.yml
@@ -252,6 +252,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
+          fetch-tags: true
       - name: Get package name
         env:
           TAG: ${{ inputs.tag_name }}


### PR DESCRIPTION
# Why

The step that creates the changelog requires the tags to be fetched in advance so we can distinguish between new and existing packages, and decide which commits to diff.

# How

Add fetch-tags: true to the checkout
