### PR TITLE
Set isComplete to false for 3 digit Amex CVCs when disabled.

### DIFF
--- a/.changeset/witty-years-watch.md
+++ b/.changeset/witty-years-watch.md
@@ -1,0 +1,5 @@
+---
+"@evervault/ui-components": patch
+---
+
+Set isComplete to false for 3 digit Amex CVCs when disabled

--- a/e2e-tests/ui-components/tests/cardDetails.spec.js
+++ b/e2e-tests/ui-components/tests/cardDetails.spec.js
@@ -329,38 +329,68 @@ test.describe("card component", () => {
   });
 
   test("allows 3 digit CVCs for Amex by default", async ({ page }) => {
+    let values = {};
+
+    await page.exposeFunction("handleChange", (newValues) => {
+      values = newValues;
+    });
+
     await page.evaluate(() => {
       const card = window.evervault.ui.card();
+      card.on("change", window.handleChange);
       card.mount("#form");
     });
 
     const amex = "378282246310005";
     const frame = page.frameLocator("iframe[data-evervault]");
     await frame.getByLabel("Number").fill(amex);
+    await frame.getByLabel("Expiration").fill(getFutureExpiration());
+    // intentionally make invalid first to test it becomes valid with 3 digits
     await frame.getByLabel("CVC").fill("12");
     await frame.getByLabel("CVC").blur();
-    // intentionally make invalid first to test it becomes valid with 3 digits
     await expect(frame.getByText("Your CVC is invalid")).toBeVisible();
+    await expect.poll(async () => values.isComplete).toBeFalsy();
+    // check it becomes valid with 3 digit CVC
     await frame.getByLabel("CVC").fill("123");
+    await frame.getByLabel("CVC").blur();
     await expect(frame.getByText("Your CVC is invalid")).not.toBeVisible();
+    await expect.poll(async () => values.isComplete).toBeTruthy();
   });
 
   test("can disable 3 digit amex CVCs", async ({ page }) => {
+    let values = {};
+
+    await page.exposeFunction("handleChange", (newValues) => {
+      values = newValues;
+    });
+
     await page.evaluate(() => {
       const card = window.evervault.ui.card({
         allow3DigitAmexCVC: false,
       });
+      card.on("change", window.handleChange);
       card.mount("#form");
     });
 
     const amex = "378282246310005";
     const frame = page.frameLocator("iframe[data-evervault]");
     await frame.getByLabel("Number").fill(amex);
+    await frame.getByLabel("Expiration").fill(getFutureExpiration());
+    // check is invalid with 3 digits
     await frame.getByLabel("CVC").fill("123");
     await frame.getByLabel("CVC").blur();
+    await expect.poll(async () => values.isComplete).toBeFalsy();
     await expect(frame.getByText("Your CVC is invalid")).toBeVisible();
+    // check it becomes valid with 4
     await frame.getByLabel("CVC").fill("1233");
+    await frame.getByLabel("CVC").blur();
+    await expect.poll(async () => values.isComplete).toBeTruthy();
     await expect(frame.getByText("Your CVC is invalid")).not.toBeVisible();
+    // check it becomes invalid again when 3
+    await frame.getByLabel("CVC").fill("123");
+    await frame.getByLabel("CVC").blur();
+    await expect.poll(async () => values.isComplete).toBeFalsy();
+    await expect(frame.getByText("Your CVC is invalid")).toBeVisible();
   });
 
   test("allow3DigitAmexCVC: false only applies to Amex cards", async ({
@@ -848,4 +878,12 @@ async function decrypt(payload) {
     console.log("decrypt error");
     console.error(e);
   }
+}
+
+function getFutureExpiration() {
+  const date = new Date();
+  date.setFullYear(date.getFullYear() + 1);
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const year = String(date.getFullYear()).slice(-2);
+  return `${month}/${year}`;
 }

--- a/e2e-tests/ui-components/tests/cardDetails.spec.js
+++ b/e2e-tests/ui-components/tests/cardDetails.spec.js
@@ -665,7 +665,9 @@ test.describe("card component", () => {
     });
 
     await page.evaluate(() => {
-      const card = window.evervault.ui.card();
+      const card = window.evervault.ui.card({
+        allow3DigitAmexCVC: false,
+      });
       card.on("change", window.handleChange);
       card.mount("#form");
     });

--- a/packages/ui-components/src/Card/index.tsx
+++ b/packages/ui-components/src/Card/index.tsx
@@ -116,7 +116,9 @@ export function Card({ config }: { config: CardConfig }) {
     onChange: (formState) => {
       const triggerChange = async () => {
         if (!ev) return;
-        const cardData = await changePayload(ev, formState, fields);
+        const cardData = await changePayload(ev, formState, fields, {
+          allow3DigitAmexCVC: config.allow3DigitAmexCVC,
+        });
 
         if (cardData.isComplete) {
           send("EV_COMPLETE", cardData);


### PR DESCRIPTION
# Why

We need to pass the `allow3DigitAmexCVC` option through to the payload formatting so that it can correctly set the isComplete field. 