### PR TITLE
Correctly set isComplete in validate response for 3 digit amex CVCs

### DIFF
--- a/.changeset/spicy-peas-rhyme.md
+++ b/.changeset/spicy-peas-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@evervault/ui-components": patch
+---
+
+Fixes bug where isComplete could be incorrectly set to true in the validate method response for 3 digit amex CVCs when allow3DigitAmexCVC is false

--- a/packages/ui-components/src/Card/index.tsx
+++ b/packages/ui-components/src/Card/index.tsx
@@ -160,12 +160,14 @@ export function Card({ config }: { config: CardConfig }) {
 
         form.validate((formState) => {
           void (async () => {
-            const data = await changePayload(ev, formState, fields);
+            const data = await changePayload(ev, formState, fields, {
+              allow3DigitAmexCVC: config.allow3DigitAmexCVC,
+            });
             send("EV_VALIDATED", data);
           })();
         });
       }),
-    [ev, on, send, form, fields]
+    [ev, on, send, form, fields, config.allow3DigitAmexCVC]
   );
 
   useEffect(


### PR DESCRIPTION
Missed this in the previous PR because the `validate` method has its own use of the `changePayload` method.

