### PR TITLE
Update create release to use ls-remote

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -68,7 +68,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.PUBLIC_REPO_NPM_PUBLISH }}
           NPM_CONFIG_PROVENANCE: true
   create_release:
-    name: Create Github Release and Changelog
+    name: Create Github Release
     runs-on: ubuntu-latest
     needs: publish
     continue-on-error: true
@@ -76,7 +76,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 1
       - name: Get package name
         env:
           TAG: ${{ inputs.tag_name }}
@@ -97,15 +97,17 @@ jobs:
         run: |
           name_part=${TAG##*/}
           tag_prefix=${name_part%@*}
-          git fetch --tags
 
-          num_existing_tags=$(git tag --sort="version:refname" -l @evervault/$tag_prefix@\* | wc -l)
+          num_existing_tags=$(git ls-remote --sort="version:refname" --tags origin @evervault/$tag_prefix@\* | wc -l)
           if [[ "$num_existing_tags" -lt 2 ]]; then
             echo "No previous tags found for @evervault/$tag_prefix, taking entire changelog content"
             CHANGELOG_CONTENT=$(cat ./packages/${{ steps.parse.outputs.name }}/CHANGELOG.md | tail -n +3)
           else
+            echo "Previous tags found for @evervault/$tag_prefix, taking diff between two most recent tags"
+            git fetch --tags origin
             CHANGELOG_CONTENT=$(git tag --sort="version:refname" -l @evervault/$tag_prefix@\* | tail -n2 | xargs -n2 sh -c 'git diff $0..$1 -- ${{ github.workspace }}/packages/${{ steps.parse.outputs.name }}/CHANGELOG.md' | grep '^+' | grep --invert-match '^+++'  | sed 's/^+//' | tail -n +3)  
           fi
+
           {
             echo 'content<<EOF'
             echo "$CHANGELOG_CONTENT"

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -97,6 +97,7 @@ jobs:
         run: |
           name_part=${TAG##*/}
           tag_prefix=${name_part%@*}
+          git fetch --tags
 
           num_existing_tags=$(git tag --sort="version:refname" -l @evervault/$tag_prefix@\* | wc -l)
           if [[ "$num_existing_tags" -lt 2 ]]; then

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -77,7 +77,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
-          fetch-tags: true
       - name: Get package name
         env:
           TAG: ${{ inputs.tag_name }}

--- a/.github/workflows/publish-static-bundle.yml
+++ b/.github/workflows/publish-static-bundle.yml
@@ -266,6 +266,7 @@ jobs:
         run: |
           name_part=${TAG##*/}
           tag_prefix=${name_part%@*}
+          git fetch --tags
 
           num_existing_tags=$(git tag --sort="version:refname" -l @evervault/$tag_prefix@\* | wc -l)
           if [[ "$num_existing_tags" -lt 2 ]]; then

--- a/.github/workflows/publish-static-bundle.yml
+++ b/.github/workflows/publish-static-bundle.yml
@@ -252,7 +252,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
-          fetch-tags: true
       - name: Get package name
         env:
           TAG: ${{ inputs.tag_name }}

--- a/.github/workflows/publish-static-bundle.yml
+++ b/.github/workflows/publish-static-bundle.yml
@@ -243,15 +243,15 @@ jobs:
   # If we just created a production release, take the changelog contents for the provided package and put it into the Github Release body.
   create_release:
     name: Create Github Release and Changelog
-    runs-on: ubuntu-latest
     needs: deploy
     if: ${{ inputs.stage == 'production' }}
+    runs-on: ubuntu-latest
     continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 1
       - name: Get package name
         env:
           TAG: ${{ inputs.tag_name }}
@@ -266,13 +266,14 @@ jobs:
         run: |
           name_part=${TAG##*/}
           tag_prefix=${name_part%@*}
-          git fetch --tags
 
-          num_existing_tags=$(git tag --sort="version:refname" -l @evervault/$tag_prefix@\* | wc -l)
+          num_existing_tags=$(git ls-remote --sort="version:refname" --tags origin @evervault/$tag_prefix@\* | wc -l)
           if [[ "$num_existing_tags" -lt 2 ]]; then
             echo "No previous tags found for @evervault/$tag_prefix, taking entire changelog content"
             CHANGELOG_CONTENT=$(cat ./packages/${{ steps.parse.outputs.name }}/CHANGELOG.md | tail -n +3)
           else
+            echo "Previous tags found for @evervault/$tag_prefix, taking diff between two most recent tags"
+            git fetch --tags origin
             CHANGELOG_CONTENT=$(git tag --sort="version:refname" -l @evervault/$tag_prefix@\* | tail -n2 | xargs -n2 sh -c 'git diff $0..$1 -- ${{ github.workspace }}/packages/${{ steps.parse.outputs.name }}/CHANGELOG.md' | grep '^+' | grep --invert-match '^+++'  | sed 's/^+//' | tail -n +3)  
           fi
 


### PR DESCRIPTION
# Why

Using `git tag -l` will only see locally fetched tags. We want to be able to check if there are existing tags before running an expensive fetch.

# How

- Update to use `ls-remote` to locate tags for the current package
- Fetch all tags before diffing if needed.
