### PR TITLE
Add mask obfuscation

### DIFF
--- a/.changeset/shiny-dodos-hunt.md
+++ b/.changeset/shiny-dodos-hunt.md
@@ -1,0 +1,5 @@
+---
+"@evervault/react-native": minor
+---
+
+- Adds new `obfuscateValue` prop to Card.Number and Card.Cvc to enable value obfuscation

--- a/examples/expo/src/screens/Card.tsx
+++ b/examples/expo/src/screens/Card.tsx
@@ -1,6 +1,6 @@
 import { Card, CardPayload } from "@evervault/react-native";
 import { StyleSheet, View, ScrollView, Keyboard, Text } from "react-native";
-import React, { useRef, useState } from "react";
+import React, { useCallback, useRef, useState } from "react";
 import { Button } from "@/src/ui/Button";
 import { Code } from "@/src/ui/Code";
 import { Field } from "@/src/ui/Field";
@@ -30,6 +30,15 @@ export function CardExample() {
   const [payload, setPayload] = useState<CardPayload | null>(null);
   const [error, setError] = useState<Error | null>(null);
 
+  const [focusedFields, setFocusedFields] = useState<string[]>([]);
+  const shouldObfuscate = focusedFields.length === 0;
+  const onFocus = useCallback((field: string) => {
+    setFocusedFields((prev) => Array.from(new Set([...prev, field])));
+  }, []);
+  const onBlur = useCallback((field: string) => {
+    setFocusedFields((prev) => prev.filter((f) => f !== field));
+  }, []);
+
   return (
     <ScrollView
       style={[styles.scroll, { paddingTop: insets.top }]}
@@ -48,20 +57,34 @@ export function CardExample() {
             onError={setError}
           >
             <Field label="Cardholder Name" error={payload?.errors?.name}>
-              <Card.Holder />
+              <Card.Holder
+                onFocus={() => onFocus("name")}
+                onBlur={() => onBlur("name")}
+              />
             </Field>
 
             <Field label="Card Number" error={payload?.errors?.number}>
-              <Card.Number />
+              <Card.Number
+                obfuscateValue={shouldObfuscate}
+                onFocus={() => onFocus("number")}
+                onBlur={() => onBlur("number")}
+              />
             </Field>
 
             <View style={styles.row}>
               <Field label="Expiration Date" error={payload?.errors?.expiry}>
-                <Card.Expiry />
+                <Card.Expiry
+                  onFocus={() => onFocus("expiry")}
+                  onBlur={() => onBlur("expiry")}
+                />
               </Field>
 
               <Field label="CVC" error={payload?.errors?.cvc}>
-                <Card.Cvc />
+                <Card.Cvc
+                  obfuscateValue={shouldObfuscate}
+                  onFocus={() => onFocus("cvc")}
+                  onBlur={() => onBlur("cvc")}
+                />
               </Field>
             </View>
           </Card>

--- a/packages/react-native-v2/src/Card/Cvc.tsx
+++ b/packages/react-native-v2/src/Card/Cvc.tsx
@@ -6,13 +6,16 @@ import { validateNumber } from "@evervault/card-validator";
 import { useFormContext } from "react-hook-form";
 import { CardBrandName } from "./types";
 
-const DEFAULT_CARD_CVC_MASK = mask("999");
+const DEFAULT_CARD_CVC_MASK = mask("[999]");
 
 const CARD_CVC_MASKS: Partial<Record<CardBrandName, Mask>> = {
-  "american-express": mask("9999"),
+  "american-express": mask("[9999]"),
 };
 
-export type CardCvcProps = BaseEvervaultInputProps;
+export interface CardCvcProps extends BaseEvervaultInputProps {
+  /** Whether to obfuscate the entire CVC value. */
+  obfuscateValue?: boolean;
+}
 
 export type CardCvc = EvervaultInput;
 

--- a/packages/react-native-v2/src/Card/Cvc.tsx
+++ b/packages/react-native-v2/src/Card/Cvc.tsx
@@ -13,8 +13,12 @@ const CARD_CVC_MASKS: Partial<Record<CardBrandName, Mask>> = {
 };
 
 export interface CardCvcProps extends BaseEvervaultInputProps {
-  /** Whether to obfuscate the entire CVC value. */
-  obfuscateValue?: boolean;
+  /**
+   * Whether to obfuscate the entire CVC value.
+   *
+   * If a string is provided, it will be used to obfuscate the value.
+   */
+  obfuscateValue?: boolean | string;
 }
 
 export type CardCvc = EvervaultInput;

--- a/packages/react-native-v2/src/Card/Number.test.tsx
+++ b/packages/react-native-v2/src/Card/Number.test.tsx
@@ -13,7 +13,7 @@ function wrapper({ children }: PropsWithChildren) {
 }
 
 it("uses 16 digits for mask by default", async () => {
-  const { getByTestId } = render(
+  const { rerender, getByTestId } = render(
     <Card>
       <CardNumber testID="number" />
     </Card>,
@@ -24,10 +24,17 @@ it("uses 16 digits for mask by default", async () => {
   const user = userEvent.setup();
   await user.type(number, "4242424242424242");
   expect(number).toHaveProp("value", "4242 4242 4242 4242");
+
+  rerender(
+    <Card>
+      <CardNumber testID="number" obfuscateValue />
+    </Card>
+  );
+  expect(number).toHaveProp("value", "4242 42•• •••• ••••");
 });
 
 it("uses 19 digits for mask for unionpay", async () => {
-  const { getByTestId } = render(
+  const { rerender, getByTestId } = render(
     <Card>
       <CardNumber testID="number" />
     </Card>,
@@ -38,10 +45,17 @@ it("uses 19 digits for mask for unionpay", async () => {
   const user = userEvent.setup();
   await user.type(number, "6205500000000000004");
   expect(number).toHaveProp("value", "6205 5000 0000 0000 004");
+
+  rerender(
+    <Card>
+      <CardNumber testID="number" obfuscateValue />
+    </Card>
+  );
+  expect(number).toHaveProp("value", "6205 50•• •••• •••• •••");
 });
 
 it("uses 15 digits for mask for american express", async () => {
-  const { getByTestId } = render(
+  const { rerender, getByTestId } = render(
     <Card>
       <CardNumber testID="number" />
     </Card>,
@@ -52,4 +66,11 @@ it("uses 15 digits for mask for american express", async () => {
   const user = userEvent.setup();
   await user.type(number, "371449635398431");
   expect(number).toHaveProp("value", "3714 496353 98431");
+
+  rerender(
+    <Card>
+      <CardNumber testID="number" obfuscateValue />
+    </Card>
+  );
+  expect(number).toHaveProp("value", "3714 49•••• •••••");
 });

--- a/packages/react-native-v2/src/Card/Number.tsx
+++ b/packages/react-native-v2/src/Card/Number.tsx
@@ -5,11 +5,11 @@ import { MaskArray } from "react-native-mask-input";
 import { validateNumber } from "@evervault/card-validator";
 import { CardBrandName } from "./types";
 
-const DEFAULT_CARD_NUMBER_MASK = mask("[9999 9999 9999] 9999");
+const DEFAULT_CARD_NUMBER_MASK = mask("9999 99[99 9999 9999]");
 
 const CARD_NUMBER_MASKS: Partial<Record<CardBrandName, MaskArray>> = {
-  unionpay: mask("[9999 9999 9999 999]9 999"),
-  "american-express": mask("[9999 999999 9]9999"),
+  unionpay: mask("9999 99[99 9999 9999 999]"),
+  "american-express": mask("9999 99[9999 99999]"),
 };
 
 export interface CardNumberProps extends BaseEvervaultInputProps {

--- a/packages/react-native-v2/src/Card/Number.tsx
+++ b/packages/react-native-v2/src/Card/Number.tsx
@@ -13,8 +13,12 @@ const CARD_NUMBER_MASKS: Partial<Record<CardBrandName, MaskArray>> = {
 };
 
 export interface CardNumberProps extends BaseEvervaultInputProps {
-  /** Whether to obfuscate the card number value (excluding the last 4 digits). */
-  obfuscateValue?: boolean;
+  /**
+   * Whether to obfuscate the card number value (excluding the last 4 digits).
+   *
+   * If a string is provided, it will be used to obfuscate the value.
+   */
+  obfuscateValue?: boolean | string;
 }
 
 export type CardNumber = EvervaultInput;

--- a/packages/react-native-v2/src/Card/Number.tsx
+++ b/packages/react-native-v2/src/Card/Number.tsx
@@ -5,14 +5,17 @@ import { MaskArray } from "react-native-mask-input";
 import { validateNumber } from "@evervault/card-validator";
 import { CardBrandName } from "./types";
 
-const DEFAULT_CARD_NUMBER_MASK = mask("9999 9999 9999 9999");
+const DEFAULT_CARD_NUMBER_MASK = mask("[9999 9999 9999] 9999");
 
 const CARD_NUMBER_MASKS: Partial<Record<CardBrandName, MaskArray>> = {
-  unionpay: mask("9999 9999 9999 9999 999"),
-  "american-express": mask("9999 999999 99999"),
+  unionpay: mask("[9999 9999 9999 999]9 999"),
+  "american-express": mask("[9999 999999 9]9999"),
 };
 
-export type CardNumberProps = BaseEvervaultInputProps;
+export interface CardNumberProps extends BaseEvervaultInputProps {
+  /** Whether to obfuscate the card number value (excluding the last 4 digits). */
+  obfuscateValue?: boolean;
+}
 
 export type CardNumber = EvervaultInput;
 

--- a/packages/react-native-v2/src/Input.test.tsx
+++ b/packages/react-native-v2/src/Input.test.tsx
@@ -392,6 +392,18 @@ describe("EvervaultInput", () => {
     await user.type(input, "1234567890");
     expect(input).toHaveProp("value", "(###) ###-7890");
 
+    rerender(
+      <EvervaultInput
+        testID="phone"
+        mask={phoneMask}
+        name="phone"
+        obfuscateValue="🤔"
+      />
+    );
+
+    await user.type(input, "1234567890");
+    expect(input).toHaveProp("value", "(🤔🤔🤔) 🤔🤔🤔-7890");
+
     const unobfuscatedMask = mask("(999) 999-9999");
     rerender(
       <EvervaultInput

--- a/packages/react-native-v2/src/Input.test.tsx
+++ b/packages/react-native-v2/src/Input.test.tsx
@@ -380,6 +380,18 @@ describe("EvervaultInput", () => {
     await user.type(input, "1234567890");
     expect(input).toHaveProp("value", "(•••) •••-7890");
 
+    rerender(
+      <EvervaultInput
+        testID="phone"
+        mask={phoneMask}
+        name="phone"
+        obfuscateValue="#"
+      />
+    );
+
+    await user.type(input, "1234567890");
+    expect(input).toHaveProp("value", "(###) ###-7890");
+
     const unobfuscatedMask = mask("(999) 999-9999");
     rerender(
       <EvervaultInput

--- a/packages/react-native-v2/src/Input.test.tsx
+++ b/packages/react-native-v2/src/Input.test.tsx
@@ -27,6 +27,25 @@ describe("mask", () => {
       /\d/,
     ]);
   });
+
+  it("should account for obfuscation", () => {
+    expect(mask("[9999 9999] 9999")).toEqual([
+      [/\d/],
+      [/\d/],
+      [/\d/],
+      [/\d/],
+      " ",
+      [/\d/],
+      [/\d/],
+      [/\d/],
+      [/\d/],
+      " ",
+      /\d/,
+      /\d/,
+      /\d/,
+      /\d/,
+    ]);
+  });
 });
 
 describe("EvervaultInput", () => {
@@ -332,5 +351,46 @@ describe("EvervaultInput", () => {
       "1234567890",
       { shouldDirty: true, shouldValidate: true }
     );
+  });
+
+  it("should obfuscate the value when obfuscateValue=true", async () => {
+    const phoneMask = mask("[(999) 999]-9999");
+    const { rerender } = render(
+      <EvervaultInput testID="phone" mask={phoneMask} name="phone" />,
+      {
+        wrapper: Form,
+      }
+    );
+
+    const input = screen.getByTestId("phone");
+    const user = userEvent.setup();
+
+    await user.type(input, "1234567890");
+    expect(input).toHaveProp("value", "(123) 456-7890");
+
+    rerender(
+      <EvervaultInput
+        testID="phone"
+        mask={phoneMask}
+        name="phone"
+        obfuscateValue
+      />
+    );
+
+    await user.type(input, "1234567890");
+    expect(input).toHaveProp("value", "(•••) •••-7890");
+
+    const unobfuscatedMask = mask("(999) 999-9999");
+    rerender(
+      <EvervaultInput
+        testID="phone"
+        mask={unobfuscatedMask}
+        name="phone"
+        obfuscateValue
+      />
+    );
+
+    await user.type(input, "1234567890");
+    expect(input).toHaveProp("value", "(123) 456-7890");
   });
 });

--- a/packages/react-native-v2/src/Input.tsx
+++ b/packages/react-native-v2/src/Input.tsx
@@ -131,7 +131,7 @@ export const EvervaultInput = forwardRef<
 
   const obfuscationCharacter = useMemo(() => {
     if (typeof obfuscateValue === "string") {
-      return obfuscateValue.slice(0, 1);
+      return obfuscateValue;
     } else {
       return "•";
     }

--- a/packages/react-native-v2/src/Input.tsx
+++ b/packages/react-native-v2/src/Input.tsx
@@ -8,6 +8,7 @@ import {
   useCallback,
   useContext,
   useImperativeHandle,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -109,7 +110,7 @@ export interface EvervaultInputProps<Values extends Record<string, unknown>>
   extends BaseEvervaultInputProps {
   name: keyof Values;
   mask?: Mask;
-  obfuscateValue?: boolean;
+  obfuscateValue?: boolean | string;
 }
 
 export const EvervaultInput = forwardRef<
@@ -127,6 +128,14 @@ export const EvervaultInput = forwardRef<
     name,
     shouldUnregister: true,
   });
+
+  const obfuscationCharacter = useMemo(() => {
+    if (typeof obfuscateValue === "string") {
+      return obfuscateValue.slice(0, 1);
+    } else {
+      return "•";
+    }
+  }, [obfuscateValue]);
 
   return (
     <MaskInput
@@ -150,8 +159,8 @@ export const EvervaultInput = forwardRef<
       }}
       mask={mask}
       maskAutoComplete={!!mask}
-      obfuscationCharacter="•"
-      showObfuscatedValue={obfuscateValue}
+      obfuscationCharacter={obfuscationCharacter}
+      showObfuscatedValue={!!obfuscateValue}
       value={field.value}
       onChangeText={(masked, unmasked) => {
         const shouldValidate =

--- a/packages/react-native-v2/src/Input.tsx
+++ b/packages/react-native-v2/src/Input.tsx
@@ -9,10 +9,11 @@ import {
   useContext,
   useImperativeHandle,
   useRef,
+  useState,
 } from "react";
 import { TextInput, TextInputProps } from "react-native";
 import { mergeRefs } from "./utils";
-import { Controller, useFormContext } from "react-hook-form";
+import { Controller, useController, useFormContext } from "react-hook-form";
 import MaskInput, { Mask, MaskArray } from "react-native-mask-input";
 
 export interface EvervaultInputContextValue {
@@ -82,73 +83,89 @@ export type BaseEvervaultInputProps = Omit<
 >;
 
 export function mask(format: string): MaskArray {
-  return format.split("").map((char) => {
-    if (char === "9") {
-      return /\d/;
+  const maskArray: MaskArray = [];
+
+  let isObfuscated = false;
+  format.split("").forEach((char) => {
+    if (char === "[") {
+      isObfuscated = true;
+      return;
+    } else if (char === "]") {
+      isObfuscated = false;
+      return;
     }
-    return char;
+
+    let value: string | RegExp | [RegExp] = char;
+    if (char === "9") {
+      value = isObfuscated ? [/\d/] : /\d/;
+    }
+    maskArray.push(value);
   });
+
+  return maskArray;
 }
 
 export interface EvervaultInputProps<Values extends Record<string, unknown>>
   extends BaseEvervaultInputProps {
   name: keyof Values;
   mask?: Mask;
+  obfuscateValue?: boolean;
 }
 
 export const EvervaultInput = forwardRef<
   EvervaultInput,
   EvervaultInputProps<Record<string, unknown>>
->(function EvervaultInput({ name, mask, ...props }, ref) {
+>(function EvervaultInput({ name, mask, obfuscateValue, ...props }, ref) {
   const { validationMode } = useContext(EvervaultInputContext);
 
   const inputRef = useForwardedInputRef(ref);
 
   const methods = useFormContext();
 
+  const { field, fieldState } = useController({
+    control: methods.control,
+    name,
+    shouldUnregister: true,
+  });
+
   return (
-    <Controller
-      control={methods.control}
-      name={name}
-      shouldUnregister
-      render={({ field, fieldState }) => (
-        <MaskInput
-          // Overridable props
-          id={field.name}
-          {...props}
-          // Strict props
-          ref={mergeRefs(inputRef, field.ref)}
-          editable={!field.disabled && (props.editable ?? true)}
-          onBlur={(evt) => {
-            const shouldValidate =
-              validationMode === "onBlur" ||
-              validationMode === "onTouched" ||
-              validationMode === "all";
-            methods.setValue(field.name, field.value, {
-              shouldDirty: true,
-              shouldTouch: true,
-              shouldValidate,
-            });
-            props.onBlur?.(evt);
-          }}
-          mask={mask}
-          maskAutoComplete={!!mask}
-          value={field.value}
-          onChangeText={(masked, unmasked) => {
-            const shouldValidate =
-              (validationMode === "onTouched" && fieldState.isTouched) ||
-              ((validationMode === "onChange" || validationMode === "all") &&
-                (!!fieldState.error || fieldState.isTouched));
-            methods.setValue(field.name, unmasked, {
-              shouldDirty: true,
-              shouldValidate,
-            });
-          }}
-          // Remove unwanted props
-          defaultValue={undefined}
-          onChange={undefined}
-        />
-      )}
+    <MaskInput
+      // Overridable props
+      id={field.name}
+      {...props}
+      // Strict props
+      ref={mergeRefs(inputRef, field.ref)}
+      editable={!field.disabled && (props.editable ?? true)}
+      onBlur={(evt) => {
+        const shouldValidate =
+          validationMode === "onBlur" ||
+          validationMode === "onTouched" ||
+          validationMode === "all";
+        methods.setValue(field.name, field.value, {
+          shouldDirty: true,
+          shouldTouch: true,
+          shouldValidate,
+        });
+        props.onBlur?.(evt);
+      }}
+      mask={mask}
+      maskAutoComplete={!!mask}
+      obfuscationCharacter="•"
+      showObfuscatedValue={obfuscateValue}
+      value={field.value}
+      onChangeText={(masked, unmasked) => {
+        const shouldValidate =
+          (validationMode === "onTouched" && fieldState.isTouched) ||
+          ((validationMode === "onChange" || validationMode === "all") &&
+            (!!fieldState.error || fieldState.isTouched));
+        methods.setValue(field.name, unmasked, {
+          shouldDirty: true,
+          shouldValidate,
+        });
+      }}
+      // Remove unwanted props
+      defaultValue={undefined}
+      onChange={undefined}
     />
   );
 }) as <Values extends Record<string, unknown>>(


### PR DESCRIPTION
# Why

This PR enables mask obfuscation for the `Card.Number` and `Card.Cvc` components

# How

- Adds new `obfuscateValue` prop to `EvervaultInput`, which accepts a boolean or obfuscation character
- Adds "obfuscate on blur" example to Expo app
- Convert `<Controller>` usage to `useController`
