### PR TITLE
Add billing address support to Google Pay

### DIFF
--- a/.changeset/strong-kangaroos-reflect.md
+++ b/.changeset/strong-kangaroos-reflect.md
@@ -1,0 +1,32 @@
+---
+"@evervault/ui-components": minor
+"@evervault/browser": minor
+"types": minor
+---
+
+Adds support for requesting billing address information with Google Pay.
+
+You can now collect billing address information using the `billingAddress` option.
+
+```js
+const googlePay = evervault.ui.googlePay(transaction, {
+    billingAddress: true,
+    process: async () => {
+        ...
+    }
+});
+```
+
+You can also specific the address format and request a phone number by using an object instead of a boolean.
+
+```js
+const googlePay = evervault.ui.googlePay(transaction, {
+    billingAddress: {
+        format: 'MIn',
+        phoneNumber: true
+    },
+    process: async () => {
+        ...
+    }
+});
+```

--- a/packages/browser/lib/ui/googlePay.ts
+++ b/packages/browser/lib/ui/googlePay.ts
@@ -87,6 +87,7 @@ export default class GooglePay {
         borderRadius: this.#options.borderRadius,
         allowedAuthMethods: this.#options.allowedAuthMethods,
         allowedCardNetworks: this.#options.allowedCardNetworks,
+        billingAddress: this.#options.billingAddress,
       },
     };
   }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -5,7 +5,8 @@
   "main": "index.ts",
   "types": "index.ts",
   "dependencies": {
-    "jss": "catalog:"
+    "jss": "catalog:",
+    "@types/googlepay": "catalog:"
   },
   "scripts": {
     "clean": "rm -rf node_modules",

--- a/packages/types/uiComponents.ts
+++ b/packages/types/uiComponents.ts
@@ -352,7 +352,10 @@ export interface EncryptedFPAN {
   };
 }
 
-export type EncryptedGooglePayData = (EncryptedDPAN<"google"> | EncryptedFPAN) & {
+export type EncryptedGooglePayData = (
+  | EncryptedDPAN<"google">
+  | EncryptedFPAN
+) & {
   billingAddress: google.payments.api.Address | null;
 };
 
@@ -362,10 +365,12 @@ export interface GooglePayErrorMessage {
   intent?: google.payments.api.CallbackIntent;
 }
 
-export type GooglePayBillingAddressConfig = boolean | {
-  format?: google.payments.api.BillingAddressFormat;
-  phoneNumber?: boolean;
-}
+export type GooglePayBillingAddressConfig =
+  | boolean
+  | {
+      format?: google.payments.api.BillingAddressFormat;
+      phoneNumber?: boolean;
+    };
 
 export interface GooglePayOptions {
   process: (

--- a/packages/types/uiComponents.ts
+++ b/packages/types/uiComponents.ts
@@ -352,12 +352,19 @@ export interface EncryptedFPAN {
   };
 }
 
-export type EncryptedGooglePayData = EncryptedDPAN<"google"> | EncryptedFPAN;
+export type EncryptedGooglePayData = (EncryptedDPAN<"google"> | EncryptedFPAN) & {
+  billingAddress: google.payments.api.Address | null;
+};
 
 export interface GooglePayErrorMessage {
   message: string;
   reason?: google.payments.api.ErrorReason;
   intent?: google.payments.api.CallbackIntent;
+}
+
+export type GooglePayBillingAddressConfig = boolean | {
+  format?: google.payments.api.BillingAddressFormat;
+  phoneNumber?: boolean;
 }
 
 export interface GooglePayOptions {
@@ -374,6 +381,7 @@ export interface GooglePayOptions {
   size?: { width: WalletDimension; height: WalletDimension };
   allowedAuthMethods?: google.payments.api.CardAuthMethod[];
   allowedCardNetworks?: google.payments.api.CardNetwork[];
+  billingAddress?: GooglePayBillingAddressConfig;
 }
 
 export type ApplePayButtonType =

--- a/packages/ui-components/src/GooglePay/index.tsx
+++ b/packages/ui-components/src/GooglePay/index.tsx
@@ -42,11 +42,17 @@ export function GooglePay({ config }: GooglePayProps) {
         environment: apiConfig.googlePayEnvironment,
         paymentDataCallbacks: {
           onPaymentAuthorized: async (data) => {
-            const encrypted = await exchangePaymentData(
+            const payload = await exchangePaymentData(
               app,
               data,
               config.transaction.merchantId
             );
+
+            const billingAddress = data.paymentMethodData.info?.billingAddress || null;
+            if (billingAddress) {
+              payload.billingAddress = billingAddress
+            }
+
             return new Promise((resolve) => {
               on("EV_GOOGLE_PAY_AUTH_COMPLETE", () => {
                 send("EV_GOOGLE_PAY_SUCCESS");
@@ -64,7 +70,8 @@ export function GooglePay({ config }: GooglePayProps) {
                   error: googleError,
                 });
               });
-              send("EV_GOOGLE_PAY_AUTH", encrypted);
+
+              send("EV_GOOGLE_PAY_AUTH", payload);
             });
           },
         },

--- a/packages/ui-components/src/GooglePay/index.tsx
+++ b/packages/ui-components/src/GooglePay/index.tsx
@@ -48,9 +48,10 @@ export function GooglePay({ config }: GooglePayProps) {
               config.transaction.merchantId
             );
 
-            const billingAddress = data.paymentMethodData.info?.billingAddress || null;
+            const billingAddress =
+              data.paymentMethodData.info?.billingAddress || null;
             if (billingAddress) {
-              payload.billingAddress = billingAddress
+              payload.billingAddress = billingAddress;
             }
 
             return new Promise((resolve) => {

--- a/packages/ui-components/src/GooglePay/types.ts
+++ b/packages/ui-components/src/GooglePay/types.ts
@@ -1,4 +1,5 @@
 import {
+  GooglePayBillingAddressConfig,
   GooglePayButtonColor,
   GooglePayButtonType,
   TransactionDetailsWithDomain,
@@ -12,4 +13,5 @@ export interface GooglePayConfig {
   borderRadius: number;
   allowedAuthMethods?: string[];
   allowedCardNetworks?: string[];
+  billingAddress?: GooglePayBillingAddressConfig
 }

--- a/packages/ui-components/src/GooglePay/types.ts
+++ b/packages/ui-components/src/GooglePay/types.ts
@@ -13,5 +13,5 @@ export interface GooglePayConfig {
   borderRadius: number;
   allowedAuthMethods?: string[];
   allowedCardNetworks?: string[];
-  billingAddress?: GooglePayBillingAddressConfig
+  billingAddress?: GooglePayBillingAddressConfig;
 }

--- a/packages/ui-components/src/GooglePay/utilities.ts
+++ b/packages/ui-components/src/GooglePay/utilities.ts
@@ -32,7 +32,7 @@ export function buildPaymentRequest(
           billingAddressParameters: {
             format: billingAddressFormat(config),
             phoneNumberRequired: phoneNumberRequired(config),
-          }
+          },
         },
         tokenizationSpecification: {
           type: "PAYMENT_GATEWAY",
@@ -91,14 +91,15 @@ export async function exchangePaymentData(
   return response.json();
 }
 
-
 function isBillingRequired(config: GooglePayConfig): boolean {
   const billingConfig = config.billingAddress;
   if (typeof billingConfig === "boolean") return billingConfig;
-  return !!billingConfig
+  return !!billingConfig;
 }
 
-function billingAddressFormat(config: GooglePayConfig): google.payments.api.BillingAddressFormat {
+function billingAddressFormat(
+  config: GooglePayConfig
+): google.payments.api.BillingAddressFormat {
   const billingConfig = config.billingAddress;
   if (typeof billingConfig === "boolean") return "FULL";
   return billingConfig?.format || "FULL";

--- a/packages/ui-components/src/GooglePay/utilities.ts
+++ b/packages/ui-components/src/GooglePay/utilities.ts
@@ -28,6 +28,11 @@ export function buildPaymentRequest(
               "MASTERCARD",
               "VISA",
             ],
+          billingAddressRequired: isBillingRequired(config),
+          billingAddressParameters: {
+            format: billingAddressFormat(config),
+            phoneNumberRequired: phoneNumberRequired(config),
+          }
         },
         tokenizationSpecification: {
           type: "PAYMENT_GATEWAY",
@@ -84,4 +89,23 @@ export async function exchangePaymentData(
   });
 
   return response.json();
+}
+
+
+function isBillingRequired(config: GooglePayConfig): boolean {
+  const billingConfig = config.billingAddress;
+  if (typeof billingConfig === "boolean") return billingConfig;
+  return !!billingConfig
+}
+
+function billingAddressFormat(config: GooglePayConfig): google.payments.api.BillingAddressFormat {
+  const billingConfig = config.billingAddress;
+  if (typeof billingConfig === "boolean") return "FULL";
+  return billingConfig?.format || "FULL";
+}
+
+function phoneNumberRequired(config: GooglePayConfig): boolean {
+  const billingConfig = config.billingAddress;
+  if (typeof billingConfig === "boolean") return false;
+  return billingConfig?.phoneNumber || false;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,7 +53,7 @@ catalogs:
       version: 0.2.4
     '@types/node':
       specifier: ^22
-      version: 22.10.2
+      version: 22.10.7
     '@types/react':
       specifier: ^18.2.37
       version: 18.2.79
@@ -89,7 +89,7 @@ catalogs:
       version: 5.1.0
     dotenv:
       specifier: ^16.4.5
-      version: 16.4.5
+      version: 16.4.7
     dotenv-cli:
       specifier: ^7.4.1
       version: 7.4.1
@@ -1024,6 +1024,9 @@ importers:
 
   packages/types:
     dependencies:
+      '@types/googlepay':
+        specifier: 'catalog:'
+        version: 0.7.6
       jss:
         specifier: 'catalog:'
         version: 10.10.0
@@ -4327,7 +4330,7 @@ packages:
     resolution: {integrity: sha512-SCCPBJtYLdE8PX/7ZQAs1QAZ8Jqwih+0VBLum1EGqmCCQal+MIUqLCzj3ZUy8ufbC0cAM4LRlSTm7IQJwWT4ug==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
-      vite: ^4.2.0 || ^5.0.0 || ^6.0.0
+      vite: ^4.5.6
 
   '@vitest/expect@2.1.8':
     resolution: {integrity: sha512-8ytZ/fFHq2g4PJVAtDX57mayemKgDR6X3Oa2Foro+EygiOJHUXhCqBAAKQYYajZpFoIfvBCF1j6R6IYRSIUFuw==}


### PR DESCRIPTION

Adds support for requesting billing address information with Google Pay.

You can now collect billing address information using the `billingAddress` option.

```js
const googlePay = evervault.ui.googlePay(transaction, {
    billingAddress: true,
    process: async (payload) => {
        console.log(payload.billingAddress)
    }
});
```

You can also specific the address format and request a phone number by using an object instead of a boolean.

```js
const googlePay = evervault.ui.googlePay(transaction, {
    billingAddress: {
        format: 'MIN',
        phoneNumber: true
    },
    process: async (payload) => {
        console.log(payload.billingAddress)
    }
});
```