### PR TITLE
PAY-93 Expose last 4 of underlying card for Apple Pay

### DIFF
--- a/.changeset/happy-brooms-flash.md
+++ b/.changeset/happy-brooms-flash.md
@@ -1,0 +1,7 @@
+---
+"example-react-google-wallet": minor
+"@evervault/browser": minor
+"types": minor
+---
+
+Expose underlying payment card display name for Apple Pay

--- a/examples/react-google-wallet/src/App.tsx
+++ b/examples/react-google-wallet/src/App.tsx
@@ -19,7 +19,7 @@ function App() {
         amount: 4300,
         currency: "USD",
         country: "US",
-        merchantId: "merchant_e930d3f7bf37",
+        merchantId: import.meta.env.VITE_MERCHANT_ID,
       });
 
       const inst = evervault.ui.googlePay(transaction, {
@@ -66,7 +66,7 @@ function App() {
         amount: 4300,
         currency: "USD",
         country: "US",
-        merchantId: "merchant_e930d3f7bf37",
+        merchantId: import.meta.env.VITE_MERCHANT_ID,
         requiredRecipientDetails: ["email", "phone", "name", "address"],
         type: "disbursement",
       });

--- a/packages/browser/lib/ui/ApplePay/index.ts
+++ b/packages/browser/lib/ui/ApplePay/index.ts
@@ -112,6 +112,9 @@ export default class ApplePayButton {
       return;
     }
 
+    let paymentMethodDisplayName =
+      response.details?.token?.paymentMethod?.displayName;
+
     const [encrypted, encryptedError] = await tryCatch(
       this.#exchangeApplePaymentData(response)
     );
@@ -127,6 +130,10 @@ export default class ApplePayButton {
 
     if (response.details.shippingContact) {
       encrypted.shippingContact = response.details.shippingContact;
+    }
+
+    if (paymentMethodDisplayName && encrypted.card) {
+      encrypted.card.displayName = paymentMethodDisplayName;
     }
 
     let failed = false;

--- a/packages/browser/lib/ui/ApplePay/index.ts
+++ b/packages/browser/lib/ui/ApplePay/index.ts
@@ -112,7 +112,7 @@ export default class ApplePayButton {
       return;
     }
 
-    let paymentMethodDisplayName =
+    const paymentMethodDisplayName =
       response.details?.token?.paymentMethod?.displayName;
 
     const [encrypted, encryptedError] = await tryCatch(

--- a/packages/browser/lib/ui/ApplePay/index.ts
+++ b/packages/browser/lib/ui/ApplePay/index.ts
@@ -132,8 +132,13 @@ export default class ApplePayButton {
       encrypted.shippingContact = response.details.shippingContact;
     }
 
-    if (paymentMethodDisplayName && encrypted.card) {
-      encrypted.card.displayName = paymentMethodDisplayName;
+    if (paymentMethodDisplayName) {
+      const fourDigitMatch = paymentMethodDisplayName.match(/\b\d{4}\b/);
+      if (fourDigitMatch) {
+        encrypted.card.lastFour = fourDigitMatch[0];
+      } else {
+        encrypted.card.displayName = paymentMethodDisplayName;
+      }
     }
 
     let failed = false;

--- a/packages/types/uiComponents.ts
+++ b/packages/types/uiComponents.ts
@@ -336,6 +336,7 @@ export interface EncryptedDPAN<P> {
   token: PaymentToken<P>;
   card: {
     brand: string;
+    lastFour?: string;
     displayName?: string;
   };
   cryptogram: string;

--- a/packages/types/uiComponents.ts
+++ b/packages/types/uiComponents.ts
@@ -336,6 +336,7 @@ export interface EncryptedDPAN<P> {
   token: PaymentToken<P>;
   card: {
     brand: string;
+    displayName?: string;
   };
   cryptogram: string;
   eci: string;


### PR DESCRIPTION
# Why

Some users care about the details of the underlying card. Since we have access to it under the `response.details.token.paymentMethod.displayName` field, we can expose it.

# How

Add the above detail to the card object of the Apple Pay object. The field typically contains data in the format below:

```
"Visa 9675"
```

We will try to parse the lastFour and set the card.lastFour accordingly. If the data is in an unexpected shape, we will just set the card.displayName field to the raw displayName value.