### PR TITLE
PAY-94 Expose last 4 of underlying card for Google Pay

### DIFF
--- a/.changeset/hip-actors-explode.md
+++ b/.changeset/hip-actors-explode.md
@@ -1,5 +1,5 @@
 ---
-"example-react-google-wallet": minor
+"@evervault/js": minor
 "@evervault/ui-components": minor
 "types": minor
 ---

--- a/.changeset/hip-actors-explode.md
+++ b/.changeset/hip-actors-explode.md
@@ -1,0 +1,7 @@
+---
+"example-react-google-wallet": minor
+"@evervault/ui-components": minor
+"types": minor
+---
+
+Expose last four digits of underlying card number for Google Pay

--- a/examples/react-google-wallet/src/App.tsx
+++ b/examples/react-google-wallet/src/App.tsx
@@ -20,7 +20,7 @@ function App() {
         amount: 4300,
         currency: "USD",
         country: "US",
-        merchantId: "merchant_e930d3f7bf37",
+        merchantId: import.meta.env.VITE_MERCHANT_ID,
       });
 
       const inst = evervault.ui.googlePay(transaction, {
@@ -74,7 +74,6 @@ function App() {
           requiredRecipientDetails: ["email", "phone", "name", "address"],
           type: "disbursement",
         });
-
        */
 
       const recurringTransaction = evervault.transactions.create({

--- a/packages/types/uiComponents.ts
+++ b/packages/types/uiComponents.ts
@@ -336,6 +336,8 @@ export interface EncryptedDPAN<P> {
   token: PaymentToken<P>;
   card: {
     brand: string;
+    lastFour?: string;
+    displayName?: string;
   };
   cryptogram: string;
   eci: string;
@@ -345,6 +347,8 @@ export interface EncryptedFPAN {
   card: {
     brand: string;
     number: string;
+    lastFour?: string;
+    displayName?: string;
     expiry: {
       month: string;
       year: string;
@@ -356,7 +360,7 @@ export type EncryptedGooglePayData = (
   | EncryptedDPAN<"google">
   | EncryptedFPAN
 ) & {
-  billingAddress: google.payments.api.Address | null;
+  billingAddress?: google.payments.api.Address | null;
 };
 
 export interface GooglePayErrorMessage {

--- a/packages/ui-components/src/GooglePay/index.tsx
+++ b/packages/ui-components/src/GooglePay/index.tsx
@@ -53,8 +53,7 @@ export function GooglePay({ config }: GooglePayProps) {
 
             const paymentMethodInfo = paymentMethodData?.info;
 
-            const billingAddress =
-              paymentMethodInfo?.billingAddress || null;
+            const billingAddress = paymentMethodInfo?.billingAddress || null;
             if (billingAddress) {
               payload.billingAddress = billingAddress;
             }
@@ -67,7 +66,8 @@ export function GooglePay({ config }: GooglePayProps) {
                 payload.card.lastFour = lastFour[0];
               } else {
                 // If the last four digits are not found, try to get them from the description
-                const descriptionLastFour = paymentMethodData?.description?.match(fourDigitRegex);
+                const descriptionLastFour =
+                  paymentMethodData?.description?.match(fourDigitRegex);
                 if (descriptionLastFour) {
                   payload.card.lastFour = descriptionLastFour[0];
                 }

--- a/packages/ui-components/src/GooglePay/index.tsx
+++ b/packages/ui-components/src/GooglePay/index.tsx
@@ -48,10 +48,30 @@ export function GooglePay({ config }: GooglePayProps) {
               config.transaction.merchantId
             );
 
+            const paymentMethodData = data.paymentMethodData;
+            payload.card.displayName = paymentMethodData?.description;
+
+            const paymentMethodInfo = paymentMethodData?.info;
+
             const billingAddress =
-              data.paymentMethodData.info?.billingAddress || null;
+              paymentMethodInfo?.billingAddress || null;
             if (billingAddress) {
               payload.billingAddress = billingAddress;
+            }
+
+            const cardDetails = data.paymentMethodData.info?.cardDetails;
+            if (cardDetails) {
+              const fourDigitRegex = /(\d{4})$/;
+              const lastFour = cardDetails.match(fourDigitRegex);
+              if (lastFour) {
+                payload.card.lastFour = lastFour[0];
+              } else {
+                // If the last four digits are not found, try to get them from the description
+                const descriptionLastFour = paymentMethodData?.description?.match(fourDigitRegex);
+                if (descriptionLastFour) {
+                  payload.card.lastFour = descriptionLastFour[0];
+                }
+              }
             }
 
             return new Promise((resolve) => {


### PR DESCRIPTION
# Why

We have access to it, at least one customer wants it, so lets expose it.

# How

Set the card.lastFour field of the Google Pay object from `data.paymentMethodData.cardDetails`. This should be the lastFour. If anything other than 4 digits, we try to parse 4 digits from this string. If that fails fallback to attempting to parse if from `paymentMethodData?.description` which also usually contains the last four.