### PR TITLE
Allow for browser SDK load retries in `@evervault/react`

### DIFF
--- a/.changeset/mean-masks-burn.md
+++ b/.changeset/mean-masks-burn.md
@@ -1,0 +1,5 @@
+---
+"@evervault/react": minor
+---
+
+Allow retry when Evervault browser SDK fails to load

--- a/examples/react/src/App.tsx
+++ b/examples/react/src/App.tsx
@@ -1,4 +1,5 @@
 import { Card, CardPayload, EvervaultProvider, themes } from "@evervault/react";
+import React from "react";
 
 const theme = themes.clean({
   styles: {
@@ -22,13 +23,20 @@ function App() {
     console.log(payload);
   };
 
+  const [retry, setRetry] = React.useState(0);
+
   return (
     <EvervaultProvider
+      key={retry}
       teamId={import.meta.env.VITE_EV_TEAM_UUID}
       appId={import.meta.env.VITE_EV_APP_UUID}
       customConfig={customConfig}
+      onLoadError={() => {
+        console.error("Custom onLoadError");
+      }}
     >
       <h1>Example React app</h1>
+      <button onClick={() => setRetry((prev) => prev + 1)}>Retry</button>
       <Card icons onChange={handleChange} theme={theme} />
     </EvervaultProvider>
   );

--- a/packages/react/lib/load.ts
+++ b/packages/react/lib/load.ts
@@ -136,7 +136,7 @@ export function useEvervaultClient({
     );
   }, [id, customConfig?.jsSdkUrl, onLoadError]);
 
-  const client = React.useMemo<PromisifiedEvervaultClient | null>(() => {
+  const client = React.useMemo<PromisifiedEvervaultClient>(() => {
     return new PromisifiedEvervaultClient((resolve, reject) => {
       if (!loadPromise) return;
 

--- a/packages/react/lib/load.ts
+++ b/packages/react/lib/load.ts
@@ -1,0 +1,150 @@
+import EvervaultClient, {
+  CustomConfig as BrowserConfig,
+} from "@evervault/browser";
+import React from "react";
+import { useId } from "react";
+
+export class PromisifiedEvervaultClient extends Promise<EvervaultClient> {
+  public async encrypt(data: unknown) {
+    const ev = await this;
+    return ev.encrypt(data);
+  }
+
+  public async decrypt(token: string, data: unknown) {
+    const ev = await this;
+    return ev.decrypt(token, data);
+  }
+}
+
+const EVERVAULT_URL = "https://js.evervault.com/v2";
+
+function injectScript(overrideUrl?: string) {
+  return new Promise<typeof EvervaultClient>((resolve, reject) => {
+    const script = document.createElement("script");
+
+    script.addEventListener("load", () => {
+      if (window.Evervault) {
+        resolve(window.Evervault);
+      } else {
+        reject(new Error("Evervault.js not available"));
+      }
+    });
+
+    script.addEventListener("error", () => {
+      reject(new Error("Failed to load Evervault.js"));
+    });
+
+    if (overrideUrl && overrideUrl !== "") {
+      script.src = overrideUrl;
+    } else {
+      script.src = EVERVAULT_URL;
+    }
+
+    const headOrBody = document.head || document.body;
+
+    if (!headOrBody) {
+      throw new Error(
+        "Expected document.body not to be null. Evervault.js requires a <body> element."
+      );
+    }
+
+    headOrBody.appendChild(script);
+  });
+}
+
+type EvervaultClientPromise = Promise<typeof EvervaultClient>;
+const evervaultPromiseMap: Record<string, EvervaultClientPromise> = {};
+
+interface LoadScriptOptions {
+  overrideUrl?: string;
+  onLoadError?: () => void;
+}
+
+function loadScript(
+  loadKey: string,
+  options?: LoadScriptOptions
+): EvervaultClientPromise {
+  // Ensure that we only attempt to load Evervault.js at most once
+  if (!evervaultPromiseMap[loadKey]) {
+    evervaultPromiseMap[loadKey] = new Promise((resolve, reject) => {
+      if (typeof window === "undefined") {
+        reject(new Error("Evervault.js not available"));
+        return;
+      }
+
+      if (window.Evervault) {
+        console.warn("Evervault has already been loaded");
+        resolve(window.Evervault);
+        return;
+      }
+
+      injectScript(options?.overrideUrl).then(resolve).catch(reject);
+    });
+  }
+
+  return evervaultPromiseMap[loadKey];
+}
+
+function loadEvervault(
+  loadKey: string,
+  options?: LoadScriptOptions
+): EvervaultClientPromise {
+  const evPromise = loadScript(loadKey, options);
+
+  let loadCalled = false;
+
+  evPromise.catch((err) => {
+    if (!loadCalled) {
+      console.warn(err);
+    }
+  });
+
+  loadCalled = true;
+
+  return evPromise;
+}
+
+export interface CustomConfig extends BrowserConfig {
+  jsSdkUrl: string;
+}
+
+export interface UseEvervaultClientOptions {
+  teamId: string;
+  appId: string;
+  customConfig?: CustomConfig;
+  onLoadError?: () => void;
+}
+
+export function useEvervaultClient({
+  teamId,
+  appId,
+  customConfig,
+  onLoadError,
+}: UseEvervaultClientOptions) {
+  const id = useId();
+
+  const [loadPromise, setLoadPromise] =
+    React.useState<EvervaultClientPromise | null>(null);
+
+  React.useEffect(() => {
+    const loadKey = `${id}-${customConfig?.jsSdkUrl}`;
+    setLoadPromise(
+      loadEvervault(loadKey, {
+        overrideUrl: customConfig?.jsSdkUrl,
+        onLoadError,
+      })
+    );
+  }, [id, customConfig?.jsSdkUrl, onLoadError]);
+
+  const client = React.useMemo<PromisifiedEvervaultClient | null>(() => {
+    return new PromisifiedEvervaultClient((resolve, reject) => {
+      if (!loadPromise) return;
+
+      loadPromise
+        .then((Evervault) => new Evervault(teamId, appId, customConfig))
+        .then(resolve, reject);
+    });
+  }, [loadPromise, teamId, appId, customConfig]);
+
+  return client;
+}

--- a/packages/react/lib/main.tsx
+++ b/packages/react/lib/main.tsx
@@ -19,6 +19,11 @@ export { useEvervault, themes };
 
 export type { PromisifiedEvervaultClient } from "./load";
 
+export interface EvervaultProvider {
+  /** Attempts to reload the Evervault script. */
+  reload(): void;
+}
+
 export interface EvervaultProviderProps {
   teamId: string;
   appId: string;
@@ -30,40 +35,32 @@ export interface EvervaultProviderProps {
   onLoadError?: () => void;
 }
 
-export const EvervaultProvider = ({
-  teamId,
-  appId,
-  customConfig,
-  children,
-  onLoadError,
-  ...props
-}: EvervaultProviderProps) => {
-  const client = useEvervaultClient({
+export const EvervaultProvider = React.forwardRef<
+  EvervaultProvider,
+  EvervaultProviderProps
+>(({ teamId, appId, customConfig, children, onLoadError, ...props }, ref) => {
+  const { client, reload } = useEvervaultClient({
     teamId,
     appId,
     customConfig,
     onLoadError,
   });
 
+  React.useImperativeHandle(ref, () => ({
+    reload,
+  }));
+
   return (
     <EvervaultContext.Provider {...props} value={client}>
       {children}
     </EvervaultContext.Provider>
   );
-};
+});
 
 export interface EvervaultInputProps {
   onChange?: (cardData: unknown) => void;
   config?: InputSettings;
   onInputsLoad?: () => void;
-}
-
-export interface EvervaultRevealProps {
-  request: Request | EvervaultRequestProps;
-  config?: RevealSettings;
-  onCopy?: () => void;
-  onRevealLoad?: () => void;
-  onRevealError?: (e: unknown) => void;
 }
 
 export function EvervaultInput({
@@ -104,6 +101,14 @@ export function EvervaultInput({
   }, [evervault]);
 
   return <div id={id} />;
+}
+
+export interface EvervaultRevealProps {
+  request: Request | EvervaultRequestProps;
+  config?: RevealSettings;
+  onCopy?: () => void;
+  onRevealLoad?: () => void;
+  onRevealError?: (e: unknown) => void;
 }
 
 export function EvervaultReveal({

--- a/packages/react/lib/main.tsx
+++ b/packages/react/lib/main.tsx
@@ -1,6 +1,4 @@
-import type EvervaultClient from "@evervault/browser";
 import type {
-  CustomConfig as BrowserConfig,
   EvervaultRequestProps,
   InputSettings,
   RevealSettings,
@@ -9,6 +7,7 @@ import * as React from "react";
 import * as themes from "themes";
 import { EvervaultContext } from "./context";
 import { useEvervault } from "./useEvervault";
+import { CustomConfig, useEvervaultClient } from "./load";
 
 export type * from "types";
 export { Reveal } from "./ui/Reveal";
@@ -18,9 +17,7 @@ export { ThreeDSecure } from "./ui/ThreeDSecure";
 export { useThreeDSecure } from "./ui/useThreeDSecure";
 export { useEvervault, themes };
 
-export interface CustomConfig extends BrowserConfig {
-  jsSdkUrl: string;
-}
+export type { PromisifiedEvervaultClient } from "./load";
 
 export interface EvervaultProviderProps {
   teamId: string;
@@ -32,6 +29,28 @@ export interface EvervaultProviderProps {
    */
   onLoadError?: () => void;
 }
+
+export const EvervaultProvider = ({
+  teamId,
+  appId,
+  customConfig,
+  children,
+  onLoadError,
+  ...props
+}: EvervaultProviderProps) => {
+  const client = useEvervaultClient({
+    teamId,
+    appId,
+    customConfig,
+    onLoadError,
+  });
+
+  return (
+    <EvervaultContext.Provider {...props} value={client}>
+      {children}
+    </EvervaultContext.Provider>
+  );
+};
 
 export interface EvervaultInputProps {
   onChange?: (cardData: unknown) => void;
@@ -46,153 +65,6 @@ export interface EvervaultRevealProps {
   onRevealLoad?: () => void;
   onRevealError?: (e: unknown) => void;
 }
-
-export class PromisifiedEvervaultClient extends Promise<EvervaultClient> {
-  public async encrypt(data: unknown) {
-    const ev = await this;
-    return ev.encrypt(data);
-  }
-
-  public async decrypt(token: string, data: unknown) {
-    const ev = await this;
-    return ev.decrypt(token, data);
-  }
-}
-
-const EVERVAULT_URL = "https://js.evervault.com/v2";
-function injectScript(overrideUrl?: string) {
-  const script = document.createElement("script");
-
-  if (overrideUrl && overrideUrl !== "") {
-    script.src = overrideUrl;
-  } else {
-    script.src = EVERVAULT_URL;
-  }
-
-  const headOrBody = document.head || document.body;
-
-  if (!headOrBody) {
-    throw new Error(
-      "Expected document.body not to be null. Evervault.js requires a <body> element."
-    );
-  }
-
-  headOrBody.appendChild(script);
-
-  return script;
-}
-
-type EvervaultClientPromise = Promise<typeof EvervaultClient | undefined>;
-let evervaultPromise: EvervaultClientPromise | null = null;
-
-function loadScript(
-  overrideUrl?: string,
-  onLoadError?: () => void
-): EvervaultClientPromise | null {
-  // Ensure that we only attempt to load Evervault.js at most once
-  if (evervaultPromise !== null) {
-    return evervaultPromise;
-  }
-
-  evervaultPromise = new Promise((resolve, reject) => {
-    if (typeof window === "undefined") {
-      resolve(undefined);
-      return;
-    }
-
-    if (window.Evervault) {
-      console.warn("Evervault has already been loaded");
-      resolve(window.Evervault);
-      return;
-    }
-
-    try {
-      const script = injectScript(overrideUrl);
-
-      script.addEventListener("load", () => {
-        if (window.Evervault) {
-          resolve(window.Evervault);
-        } else {
-          onLoadError?.();
-          reject(new Error("Evervault.js not available"));
-        }
-      });
-
-      script.addEventListener("error", () => {
-        onLoadError?.();
-        reject(new Error("Failed to load Evervault.js"));
-      });
-    } catch (error) {
-      reject(error);
-    }
-  });
-
-  return evervaultPromise;
-}
-
-function loadEvervault(
-  overrideUrl?: string,
-  onLoadError?: () => void
-): EvervaultClientPromise {
-  const evPromise = Promise.resolve().then(() =>
-    loadScript(overrideUrl, onLoadError)
-  );
-
-  let loadCalled = false;
-
-  evPromise.catch((err) => {
-    if (!loadCalled) {
-      console.warn(err);
-    }
-  });
-
-  loadCalled = true;
-  return evPromise.then((ev) => {
-    if (typeof window !== "undefined") return window.Evervault;
-    return ev ?? undefined;
-  });
-}
-
-export const EvervaultProvider = ({
-  teamId,
-  appId,
-  customConfig,
-  children,
-  onLoadError,
-  ...props
-}: EvervaultProviderProps) => {
-  if (typeof window === "undefined") {
-    return (
-      <EvervaultContext.Provider value={null}>
-        {children}
-      </EvervaultContext.Provider>
-    );
-  }
-
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const ev = React.useMemo<PromisifiedEvervaultClient>(
-    () =>
-      new PromisifiedEvervaultClient((resolve, reject) => {
-        loadEvervault(customConfig?.jsSdkUrl, onLoadError)
-          .then((Evervault) => {
-            if (Evervault !== undefined) {
-              resolve(new Evervault(teamId, appId, customConfig));
-            } else {
-              console.error("Evervault.js not available");
-              reject("Evervault.js not available");
-            }
-          })
-          .catch((e) => reject(e));
-      }),
-    []
-  );
-
-  return (
-    <EvervaultContext.Provider {...props} value={ev}>
-      {children}
-    </EvervaultContext.Provider>
-  );
-};
 
 export function EvervaultInput({
   onChange,

--- a/packages/react/lib/ui/Card.tsx
+++ b/packages/react/lib/ui/Card.tsx
@@ -1,7 +1,5 @@
-import type Evervault from "@evervault/browser";
 import * as React from "react";
-import { useEffect, useLayoutEffect, useMemo, useRef } from "react";
-import { useEvervault } from "../useEvervault";
+import { useEffect, useMemo, useRef } from "react";
 import type {
   CardBrandName,
   CardField,
@@ -13,6 +11,7 @@ import type {
   SwipedCard,
   ThemeDefinition,
 } from "types";
+import { useEvInstance } from "../useEvInstance";
 
 export interface CardProps {
   autoFocus?: boolean;
@@ -37,8 +36,6 @@ export interface CardProps {
   allow3DigitAmexCVC?: boolean;
 }
 
-type CardClass = ReturnType<Evervault["ui"]["card"]>;
-
 export function Card({
   theme,
   icons,
@@ -61,15 +58,49 @@ export function Card({
   redactCVC,
   allow3DigitAmexCVC,
 }: CardProps) {
-  const ev = useEvervault();
-  const initialized = useRef(false);
   const ref = useRef<HTMLDivElement>(null);
-  const [instance, setInstance] = React.useState<CardClass | null>(null);
 
-  const onErrorRef = useRef(onError);
-  useEffect(() => {
-    onErrorRef.current = onError;
-  }, [onError]);
+  const config = useMemo(
+    () => ({
+      theme,
+      icons,
+      fields,
+      autoFocus,
+      translations,
+      autoComplete,
+      autoProgress,
+      acceptedBrands,
+      defaultValues,
+      redactCVC,
+      allow3DigitAmexCVC,
+    }),
+    [
+      theme,
+      icons,
+      translations,
+      fields,
+      autoFocus,
+      autoComplete,
+      autoProgress,
+      acceptedBrands,
+      defaultValues,
+      redactCVC,
+      allow3DigitAmexCVC,
+    ]
+  );
+
+  const instance = useEvInstance({
+    onMount(evervault) {
+      if (!ref.current) return;
+      const inst = evervault.ui.card(config);
+      inst.mount(ref.current);
+      return inst;
+    },
+    onUpdate(instance) {
+      instance.update(config);
+    },
+    onMountError: onError,
+  });
 
   // setup ready event listener
   useEffect(() => {
@@ -124,60 +155,6 @@ export function Card({
     if (!instance || !onKeyDown) return undefined;
     return instance?.on("keydown", onKeyDown);
   }, [instance, onKeyDown]);
-
-  const config = useMemo(
-    () => ({
-      theme,
-      icons,
-      fields,
-      autoFocus,
-      translations,
-      autoComplete,
-      autoProgress,
-      acceptedBrands,
-      defaultValues,
-      redactCVC,
-      allow3DigitAmexCVC,
-    }),
-    [
-      theme,
-      icons,
-      translations,
-      fields,
-      autoFocus,
-      autoComplete,
-      autoProgress,
-      acceptedBrands,
-      defaultValues,
-      redactCVC,
-      allow3DigitAmexCVC,
-    ]
-  );
-
-  useLayoutEffect(() => {
-    if (!ref.current) return;
-
-    async function init() {
-      try {
-        if (initialized.current || !ref.current) return;
-        initialized.current = true;
-        const evervault = await ev;
-        if (!evervault) return;
-        const inst = evervault.ui.card(config);
-        inst.mount(ref.current);
-        setInstance(inst);
-      } catch (err) {
-        onErrorRef.current?.();
-        console.error(err);
-      }
-    }
-
-    if (instance) {
-      instance.update(config);
-    } else {
-      init();
-    }
-  }, [ev, config, instance]);
 
   return <div ref={ref} />;
 }

--- a/packages/react/lib/ui/Pin.tsx
+++ b/packages/react/lib/ui/Pin.tsx
@@ -42,6 +42,7 @@ export function Pin({
     onUpdate(instance) {
       instance.update(config);
     },
+    onMountError: onError,
   });
 
   // setup ready event listener

--- a/packages/react/lib/ui/Pin.tsx
+++ b/packages/react/lib/ui/Pin.tsx
@@ -1,16 +1,13 @@
-import type Evervault from "@evervault/browser";
 import * as React from "react";
-import { useLayoutEffect, useMemo, useRef } from "react";
-import { useEvervault } from "../useEvervault";
+import { useMemo, useRef } from "react";
 import type { PinOptions, PinPayload } from "types";
+import { useEvInstance } from "../useEvInstance";
 
 export type PinProps = PinOptions & {
   onReady?: () => void;
   onError?: () => void;
   onChange?: (data: PinPayload) => void;
 };
-
-type PinClass = ReturnType<Evervault["ui"]["pin"]>;
 
 export function Pin({
   theme,
@@ -22,10 +19,30 @@ export function Pin({
   onChange,
   onError,
 }: PinProps) {
-  const ev = useEvervault();
-  const initialized = useRef(false);
-  const [instance, setInstance] = React.useState<PinClass | null>(null);
   const ref = useRef<HTMLDivElement>(null);
+
+  const config = useMemo(
+    () => ({
+      theme,
+      length,
+      autoFocus,
+      mode,
+      inputType,
+    }),
+    [theme, length, autoFocus, mode, inputType]
+  );
+
+  const instance = useEvInstance({
+    onMount(evervault) {
+      if (!ref.current) return;
+      const inst = evervault.ui.pin(config);
+      inst.mount(ref.current);
+      return inst;
+    },
+    onUpdate(instance) {
+      instance.update(config);
+    },
+  });
 
   // setup ready event listener
   React.useEffect(() => {
@@ -44,36 +61,6 @@ export function Pin({
     if (!instance || !onChange) return undefined;
     return instance?.on("change", onChange);
   }, [instance, onChange]);
-
-  const config = useMemo(
-    () => ({
-      theme,
-      length,
-      autoFocus,
-      mode,
-      inputType,
-    }),
-    [theme, length, autoFocus, mode, inputType]
-  );
-
-  useLayoutEffect(() => {
-    if (!ref.current) return;
-    async function init() {
-      if (initialized.current || !ref.current) return;
-      initialized.current = true;
-      const evervault = await ev;
-      if (!evervault) return;
-      const inst = evervault.ui.pin(config);
-      inst.mount(ref.current);
-      setInstance(inst);
-    }
-
-    if (instance) {
-      instance.update(config);
-    } else {
-      init().catch(console.error);
-    }
-  }, [instance, config]);
 
   return <div ref={ref} />;
 }

--- a/packages/react/lib/ui/Reveal.tsx
+++ b/packages/react/lib/ui/Reveal.tsx
@@ -17,6 +17,7 @@ function Reveal({ request, children, onReady, onError }: RevealProps) {
     onMount(evervault) {
       return evervault.ui.reveal(request);
     },
+    onMountError: onError,
   });
   const context = React.useMemo(() => ({ reveal: instance }), [instance]);
 

--- a/packages/react/lib/ui/RevealCopyButton.tsx
+++ b/packages/react/lib/ui/RevealCopyButton.tsx
@@ -22,13 +22,16 @@ export function RevealCopyButton({
 
   // setup ready event listener
   React.useEffect(() => {
-    if (!instance || !onCopy) return undefined;
+    if (!reveal) return undefined;
+    if (!onCopy) return undefined;
     return instance?.on("copy", onCopy);
-  }, [instance, onCopy]);
+  }, [instance, reveal, onCopy]);
 
   useLayoutEffect(() => {
-    if ((!ref.current || instance) ?? !reveal) return;
-    const inst = reveal?.copyButton(path, options);
+    if (!ref.current) return;
+    if (instance) return;
+    if (!reveal) return;
+    const inst = reveal.copyButton(path, options);
     inst.mount(ref.current);
     setInstance(inst);
   }, [reveal, path, options, instance]);

--- a/packages/react/lib/ui/RevealText.tsx
+++ b/packages/react/lib/ui/RevealText.tsx
@@ -19,12 +19,11 @@ export function RevealText({ path, theme, format }: RevealTextProps) {
   const { reveal } = useRevealContext();
 
   useLayoutEffect(() => {
-    if ((!ref.current || instance) ?? !reveal) return;
+    if (!ref.current) return;
+    if (instance) return;
+    if (!reveal) return;
 
-    const inst = reveal.text(path, {
-      theme,
-      format,
-    });
+    const inst = reveal.text(path, { theme, format });
     inst.mount(ref.current);
     setInstance(inst);
   }, [reveal, path, theme, format, instance]);

--- a/packages/react/lib/ui/ThreeDSecure.tsx
+++ b/packages/react/lib/ui/ThreeDSecure.tsx
@@ -1,7 +1,6 @@
-import type Evervault from "@evervault/browser";
 import * as React from "react";
-import { useEvervault } from "../useEvervault";
 import type { ComponentError, ThemeDefinition } from "types";
+import { useEvInstance } from "../useEvInstance";
 
 export interface ThreeDSecureProps {
   session: string;
@@ -14,8 +13,6 @@ export interface ThreeDSecureProps {
   failOnChallenge?: boolean | (() => boolean) | (() => Promise<boolean>);
 }
 
-type ThreeDSecureInstance = ReturnType<Evervault["ui"]["threeDSecure"]>;
-
 export function ThreeDSecure({
   session,
   theme,
@@ -26,12 +23,28 @@ export function ThreeDSecure({
   onFailure,
   failOnChallenge,
 }: ThreeDSecureProps) {
-  const ev = useEvervault();
-  const initialized = React.useRef(false);
   const ref = React.useRef<HTMLDivElement>(null);
-  const [instance, setInstance] = React.useState<ThreeDSecureInstance | null>(
-    null
+
+  const config = React.useMemo(
+    () => ({
+      theme,
+      size,
+      failOnChallenge,
+    }),
+    [theme, size, failOnChallenge]
   );
+
+  const instance = useEvInstance({
+    onMount(evervault) {
+      if (!ref.current) return;
+      const inst = evervault.ui.threeDSecure(session, config);
+      inst.mount(ref.current as HTMLElement);
+      return inst;
+    },
+    onUpdate(instance) {
+      instance.update(config);
+    },
+  });
 
   React.useEffect(() => {
     if (!instance || !onReady) return undefined;
@@ -52,33 +65,6 @@ export function ThreeDSecure({
     if (!instance || !onError) return undefined;
     return instance?.on("error", onError);
   }, [instance, onError]);
-
-  const config = React.useMemo(
-    () => ({
-      theme,
-      size,
-      failOnChallenge,
-    }),
-    [theme, size, failOnChallenge]
-  );
-
-  React.useLayoutEffect(() => {
-    async function init() {
-      if (initialized.current) return;
-      initialized.current = true;
-      const evervault = await ev;
-      if (!evervault) return;
-      const inst = evervault.ui.threeDSecure(session, config);
-      inst.mount(ref.current as HTMLElement);
-      setInstance(inst);
-    }
-
-    if (instance) {
-      instance.update(config);
-    } else {
-      init().catch(console.error);
-    }
-  }, [instance, session, config]);
 
   return <div ref={ref} />;
 }

--- a/packages/react/lib/ui/ThreeDSecure.tsx
+++ b/packages/react/lib/ui/ThreeDSecure.tsx
@@ -38,12 +38,13 @@ export function ThreeDSecure({
     onMount(evervault) {
       if (!ref.current) return;
       const inst = evervault.ui.threeDSecure(session, config);
-      inst.mount(ref.current as HTMLElement);
+      inst.mount(ref.current);
       return inst;
     },
     onUpdate(instance) {
       instance.update(config);
     },
+    onMountError: onError,
   });
 
   React.useEffect(() => {

--- a/packages/react/lib/useEvInstance.ts
+++ b/packages/react/lib/useEvInstance.ts
@@ -1,0 +1,49 @@
+import { useEvervault } from "./useEvervault";
+import React from "react";
+import EvervaultClient from "@evervault/browser";
+
+export interface UseEvInstanceOptions<TInstance> {
+  onMount(instance: EvervaultClient): TInstance | null | undefined;
+  onMountError?(err: unknown): void;
+  onUpdate?(instance: TInstance): void;
+}
+
+export function useEvInstance<TInstance>({
+  onMount,
+  onUpdate,
+  onMountError,
+}: UseEvInstanceOptions<TInstance>) {
+  const ev = useEvervault();
+  const [instance, setInstance] = React.useState<TInstance | null>(null);
+
+  const onMountErrorRef = React.useRef(onMountError);
+  onMountErrorRef.current = onMountError;
+
+  React.useLayoutEffect(() => {
+    const abortController = new AbortController();
+    async function init() {
+      try {
+        const evervault = await ev;
+        if (!evervault) return;
+        if (abortController.signal.aborted) return;
+
+        const instance = onMount(evervault);
+        if (!instance) return;
+
+        setInstance(instance);
+      } catch (error) {
+        onMountErrorRef.current?.(error);
+        console.error(error);
+      }
+    }
+
+    if (instance) {
+      onUpdate?.(instance);
+    } else {
+      init();
+      return () => abortController.abort();
+    }
+  }, [ev, onMount, onUpdate, instance]);
+
+  return instance;
+}

--- a/packages/react/lib/useEvervault.ts
+++ b/packages/react/lib/useEvervault.ts
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { EvervaultContext } from "./context";
-import type { PromisifiedEvervaultClient } from "./main";
+import type { PromisifiedEvervaultClient } from "./load";
 
 export function useEvervault(): PromisifiedEvervaultClient | null {
   if (typeof window === "undefined") {


### PR DESCRIPTION
# Why

Previously, our browser SDK loading logic would never retry if it failed to load once. This is an issue if the script fails to load initially but is then made available later

~While this PR does not add explicit functionality to force a retry, it does allow for retries when the `EvervaultProvider` component is remounted (e.g. a `key` is changed)~

**Edit:** in addition to automatic retries on mount, we've also added a `reload` function to the `EvervaultProvider` ref so the script can retry a load without needing to remount the tree

# How

- Move browser script loading to separate file, add handy hook `useEveraultClient`
- Move to a promise map to allow for multiple load promises to happen concurrently
- Adds new `reload` function via an `EvervaultProvider` ref for manual reloads
- Add new `useEvInstance` hook to consolidate instance initialization in components
- Update `Card`, `Pin`, `Reveal`, and `ThreeDSecure` to use new `useEvInstance` hook
- Update our React example with retry mechanism
