### PR TITLE
Dave/apple pay/transaction hooks

### DIFF
--- a/.changeset/fair-students-fail.md
+++ b/.changeset/fair-students-fail.md
@@ -1,0 +1,7 @@
+---
+"example-react-google-wallet": minor
+"@evervault/browser": minor
+"types": minor
+---
+
+Add support for onShippingAddressChange hook for Apple Pay

--- a/examples/react-google-wallet/src/App.tsx
+++ b/examples/react-google-wallet/src/App.tsx
@@ -1,6 +1,24 @@
 import React, { useLayoutEffect, useRef, useState } from "react";
-import { useEvervault } from "@evervault/react";
+import { TransactionLineItem, useEvervault } from "@evervault/react";
 import "./App.css";
+
+function getLineItems(): TransactionLineItem[] {
+  return [
+    {
+      label: "First Edition \"The Great Gatsby\" (1925)",
+      amount: 245000,
+    },
+    {
+      label: "Signed \"One Hundred Years of Solitude\" (1967)",
+      amount: 185000,
+    }
+  ];
+}
+
+async function calculateShipping(region: string) {
+  const newShipping = region === "Dublin" ? 1000 : 0;
+  return Promise.resolve(newShipping);
+}
 
 function App() {
   const [name, setName] = useState("");
@@ -16,10 +34,11 @@ function App() {
       const evervault = await ev;
       if (!evervault) return;
       const transaction = evervault.transactions.create({
-        amount: 4300,
+        amount: 430000,
         currency: "USD",
         country: "US",
         merchantId: import.meta.env.VITE_MERCHANT_ID,
+        lineItems: getLineItems(),
       });
 
       const inst = evervault.ui.googlePay(transaction, {
@@ -71,13 +90,32 @@ function App() {
         type: "disbursement",
       });
 
-      const apple = evervault.ui.applePay(disbursementTransaction, {
+      const apple = evervault.ui.applePay(transaction, {
         type: "contribute",
         style: "white-outline",
         locale: "en-US",
         size: { width: "100%", height: "80px" },
         borderRadius: 10,
         allowedCardNetworks: ["visa", "masterCard"],
+        requestShipping: true,
+        onShippingAddressChange: async (event: PaymentRequestUpdateEvent) => {
+          const newAddress = (event.target as any | null)?.shippingAddress;
+          if (!newAddress) return;
+
+          const shipping = await calculateShipping(newAddress.region);
+          const newAmount = transaction.details.amount + shipping;
+
+          return {
+            amount: newAmount,
+            lineItems: [
+              ...getLineItems(),
+              {
+                label: "Shipping",
+                amount: shipping,
+              },
+            ],
+          };
+        },
         process: async (data, {}) => {
           console.log("Sending encrypted data to merchant", data);
 
@@ -205,3 +243,4 @@ function App() {
 }
 
 export default App;
+

--- a/packages/browser/lib/ui/ApplePay/index.ts
+++ b/packages/browser/lib/ui/ApplePay/index.ts
@@ -38,7 +38,9 @@ export type ApplePayButtonOptions = {
   disbursementOverrides?: {
     disbursementDetails?: PaymentDetailsInit;
   };
-  onShippingAddressChange?: (event: PaymentRequestUpdateEvent) => Promise<{ amount: number, lineItems?: TransactionLineItem[] }>;
+  onShippingAddressChange?: (
+    event: PaymentRequestUpdateEvent
+  ) => Promise<{ amount: number; lineItems?: TransactionLineItem[] }>;
   process: (
     data: EncryptedApplePayData,
     helpers: {

--- a/packages/browser/lib/ui/ApplePay/index.ts
+++ b/packages/browser/lib/ui/ApplePay/index.ts
@@ -3,6 +3,7 @@ import type {
   ApplePayErrorMessage,
   EncryptedApplePayData,
   SelectorType,
+  TransactionLineItem,
 } from "types";
 import { resolveSelector } from "../utils";
 import { buildSession, resolveUnit } from "./utilities";
@@ -37,6 +38,7 @@ export type ApplePayButtonOptions = {
   disbursementOverrides?: {
     disbursementDetails?: PaymentDetailsInit;
   };
+  onShippingAddressChange?: (event: PaymentRequestUpdateEvent) => Promise<{ amount: number, lineItems?: TransactionLineItem[] }>;
   process: (
     data: EncryptedApplePayData,
     helpers: {
@@ -98,6 +100,7 @@ export default class ApplePayButton {
       disbursementOverrides: this.#options.disbursementOverrides,
       requestBillingAddress: this.#options.requestBillingAddress,
       requestShipping: this.#options.requestShipping,
+      onShippingAddressChange: this.#options.onShippingAddressChange,
     });
 
     const [response, responseError] = await tryCatch(session.show());

--- a/packages/browser/lib/ui/ApplePay/utilities.ts
+++ b/packages/browser/lib/ui/ApplePay/utilities.ts
@@ -83,7 +83,7 @@ async function updatePaymentRequest(
   event: PaymentRequestUpdateEvent,
   config: BuildSessionOptions,
   tx: TransactionDetailsWithDomain,
-  merchant: any
+  merchant: MerchantDetail
 ): Promise<PaymentDetailsUpdate> {
   const updatedTransactionConfig = await config.onShippingAddressChange!(event);
   const displayItems = (updatedTransactionConfig.lineItems ?? []).map(

--- a/packages/browser/lib/ui/ApplePay/utilities.ts
+++ b/packages/browser/lib/ui/ApplePay/utilities.ts
@@ -3,6 +3,7 @@ import {
   MerchantDetail,
   PaymentTransactionDetails,
   TransactionDetailsWithDomain,
+  TransactionLineItem,
 } from "types";
 import {
   DisbursementContactAddress,
@@ -26,6 +27,7 @@ type BuildSessionOptions = {
   disbursementOverrides?: {
     disbursementDetails?: PaymentDetailsInit;
   };
+  onShippingAddressChange?: (event: PaymentRequestUpdateEvent) => Promise<{ amount: number, lineItems?: TransactionLineItem[] }>;
 };
 
 export async function buildSession(
@@ -53,14 +55,41 @@ export async function buildSession(
   };
 
   // Apple pay requires subscribing to onshippingaddresschange and calling updateWith
-  // in order to receive shipping data. In future we should allow users to hook into
-  // this event to modify the payment request based on the shipping address.
+  // in order to receive shipping data.
   baseRequest.onshippingaddresschange = (event: PaymentRequestUpdateEvent) => {
-    const update: PaymentDetailsUpdate = {};
-    event.updateWith(update);
+    console.log("onshippingaddresschange", event);
+    if (config.onShippingAddressChange) {
+      const updates = updatePaymentRequest(event, config, tx, merchant); // Do not await this promise
+      event.updateWith(updates);
+    } else {
+      console.log("onShippingAddressChange not provided, updating with empty shipping options");
+      // If no handler is provided, just update with empty shipping options
+      const update: PaymentDetailsUpdate = {};
+      event.updateWith(update);  
+    }
   };
 
   return baseRequest;
+}
+
+async function updatePaymentRequest(event: PaymentRequestUpdateEvent, config: BuildSessionOptions, tx: TransactionDetailsWithDomain, merchant: any): Promise<PaymentDetailsUpdate> {
+  const updatedTransactionConfig = await config.onShippingAddressChange!(event);
+  const displayItems = (updatedTransactionConfig.lineItems ?? []).map((item) => ({
+    label: item.label,
+    amount: {
+      value: (item.amount / 100).toFixed(2).toString(),
+      currency: tx.currency,
+    },
+  }));
+  const total = {
+    label: merchant.name,
+    amount: { currency: tx.currency, value: (updatedTransactionConfig.amount / 100).toFixed(2) },
+  };
+  const updates = {
+    displayItems,
+    total,
+  };
+  return updates;
 }
 
 function buildPaymentSession(
@@ -107,6 +136,7 @@ function buildPaymentSession(
     requestPayerPhone: config.requestPayerDetails?.includes("phone") ?? false,
     requestShipping: config.requestShipping ?? false,
     shippingType: "shipping",
+    onShippingAddressChange: config.onShippingAddressChange,
   };
 
   const paymentOverrides = config.paymentOverrides || {};
@@ -265,7 +295,7 @@ async function validateMerchant(
   return response.json();
 }
 
-async function getMerchant(applePay: ApplePayButton, id: string) {
+async function getMerchant(applePay: ApplePayButton, id: string): Promise<MerchantDetail | undefined> {
   const app = applePay.client.config.appId;
   const apiURL = applePay.client.config.http.apiUrl;
   const response = await fetch(`${apiURL}/frontend/merchants/${id}`, {

--- a/packages/browser/lib/ui/ApplePay/utilities.ts
+++ b/packages/browser/lib/ui/ApplePay/utilities.ts
@@ -27,7 +27,9 @@ type BuildSessionOptions = {
   disbursementOverrides?: {
     disbursementDetails?: PaymentDetailsInit;
   };
-  onShippingAddressChange?: (event: PaymentRequestUpdateEvent) => Promise<{ amount: number, lineItems?: TransactionLineItem[] }>;
+  onShippingAddressChange?: (
+    event: PaymentRequestUpdateEvent
+  ) => Promise<{ amount: number; lineItems?: TransactionLineItem[] }>;
 };
 
 export async function buildSession(
@@ -37,6 +39,9 @@ export async function buildSession(
   const { transaction: tx } = config;
 
   const merchant = await getMerchant(applePay, tx.merchantId);
+  if (!merchant) {
+    throw new Error("Merchant not found");
+  }
 
   let baseRequest: ApplePayPaymentRequest;
   if (tx.type === "payment") {
@@ -62,28 +67,40 @@ export async function buildSession(
       const updates = updatePaymentRequest(event, config, tx, merchant); // Do not await this promise
       event.updateWith(updates);
     } else {
-      console.log("onShippingAddressChange not provided, updating with empty shipping options");
+      console.log(
+        "onShippingAddressChange not provided, updating with empty shipping options"
+      );
       // If no handler is provided, just update with empty shipping options
       const update: PaymentDetailsUpdate = {};
-      event.updateWith(update);  
+      event.updateWith(update);
     }
   };
 
   return baseRequest;
 }
 
-async function updatePaymentRequest(event: PaymentRequestUpdateEvent, config: BuildSessionOptions, tx: TransactionDetailsWithDomain, merchant: any): Promise<PaymentDetailsUpdate> {
+async function updatePaymentRequest(
+  event: PaymentRequestUpdateEvent,
+  config: BuildSessionOptions,
+  tx: TransactionDetailsWithDomain,
+  merchant: any
+): Promise<PaymentDetailsUpdate> {
   const updatedTransactionConfig = await config.onShippingAddressChange!(event);
-  const displayItems = (updatedTransactionConfig.lineItems ?? []).map((item) => ({
-    label: item.label,
-    amount: {
-      value: (item.amount / 100).toFixed(2).toString(),
-      currency: tx.currency,
-    },
-  }));
+  const displayItems = (updatedTransactionConfig.lineItems ?? []).map(
+    (item) => ({
+      label: item.label,
+      amount: {
+        value: (item.amount / 100).toFixed(2).toString(),
+        currency: tx.currency,
+      },
+    })
+  );
   const total = {
     label: merchant.name,
-    amount: { currency: tx.currency, value: (updatedTransactionConfig.amount / 100).toFixed(2) },
+    amount: {
+      currency: tx.currency,
+      value: (updatedTransactionConfig.amount / 100).toFixed(2),
+    },
   };
   const updates = {
     displayItems,
@@ -295,7 +312,10 @@ async function validateMerchant(
   return response.json();
 }
 
-async function getMerchant(applePay: ApplePayButton, id: string): Promise<MerchantDetail | undefined> {
+async function getMerchant(
+  applePay: ApplePayButton,
+  id: string
+): Promise<MerchantDetail | undefined> {
   const app = applePay.client.config.appId;
   const apiURL = applePay.client.config.http.apiUrl;
   const response = await fetch(`${apiURL}/frontend/merchants/${id}`, {


### PR DESCRIPTION
# Why

The `PaymentRequest` API provides a hook for reacting when a user changes their shipping address after the Apple Pay modal has rendered. We should allow users to hook into this event in order to update e.g. shipping price.

# How

Add an optional `onShippingAddressChange` callback to our transaction abstraction, which accepts a `PaymentRequestUpdateEvent` and returns a `Promise<{ amount: number; lineItems?: TransactionLineItem[] }>`. We will use the updated information to update the `PaymentRequest` details.

See video below.

https://github.com/user-attachments/assets/94f07d1b-9fe3-4f76-a860-5a971e876022

