### PR TITLE
PAY-28 Add prepareTransaction callback for Apple Pay

### DIFF
--- a/.changeset/curly-walls-protect.md
+++ b/.changeset/curly-walls-protect.md
@@ -1,0 +1,7 @@
+---
+"@evervault/browser": minor
+"types": minor
+"@evervault/js": minor
+---
+
+Add prepareTransaction method to Apple Pay button config

--- a/packages/browser/lib/ui/ApplePay/index.ts
+++ b/packages/browser/lib/ui/ApplePay/index.ts
@@ -41,6 +41,10 @@ export type ApplePayButtonOptions = {
   onShippingAddressChange?: (
     event: PaymentRequestUpdateEvent
   ) => Promise<{ amount: number; lineItems?: TransactionLineItem[] }>;
+  prepareTransaction?: () => Promise<{
+    amount?: number;
+    lineItems?: TransactionLineItem[];
+  }>;
   process: (
     data: EncryptedApplePayData,
     helpers: {
@@ -103,7 +107,24 @@ export default class ApplePayButton {
       requestBillingAddress: this.#options.requestBillingAddress,
       requestShipping: this.#options.requestShipping,
       onShippingAddressChange: this.#options.onShippingAddressChange,
+      prepareTransaction: this.#options.prepareTransaction,
     });
+
+    if (this.#options.prepareTransaction) {
+      const { amount, lineItems } = await this.#options.prepareTransaction();
+      if (amount) {
+        this.transaction.details.amount = amount;
+      }
+      const existingLabels = new Set(
+        (this.transaction.details.lineItems ?? []).map((item) => item.label)
+      );
+
+      const lineItemsToAdd = (lineItems ?? []).filter(
+        (item) => !existingLabels.has(item.label)
+      );
+
+      this.transaction.details.lineItems?.push(...lineItemsToAdd);
+    }
 
     const [response, responseError] = await tryCatch(session.show());
 

--- a/packages/browser/lib/ui/ApplePay/index.ts
+++ b/packages/browser/lib/ui/ApplePay/index.ts
@@ -115,15 +115,10 @@ export default class ApplePayButton {
       if (amount) {
         this.transaction.details.amount = amount;
       }
-      const existingLabels = new Set(
-        (this.transaction.details.lineItems ?? []).map((item) => item.label)
-      );
 
-      const lineItemsToAdd = (lineItems ?? []).filter(
-        (item) => !existingLabels.has(item.label)
-      );
-
-      this.transaction.details.lineItems?.push(...lineItemsToAdd);
+      if (lineItems) {
+        this.transaction.details.lineItems = lineItems;
+      }
     }
 
     const [response, responseError] = await tryCatch(session.show());

--- a/packages/browser/lib/ui/ApplePay/utilities.ts
+++ b/packages/browser/lib/ui/ApplePay/utilities.ts
@@ -31,6 +31,10 @@ type BuildSessionOptions = {
   onShippingAddressChange?: (
     event: PaymentRequestUpdateEvent
   ) => Promise<{ amount: number; lineItems?: TransactionLineItem[] }>;
+  prepareTransaction?: () => Promise<{
+    amount?: number;
+    lineItems?: TransactionLineItem[];
+  }>;
 };
 
 export async function buildSession(


### PR DESCRIPTION
# Why

We should allow a user to implement logic to update the transaction before showing the Apple Pay modal, for example to offer a sign-up discount or other promotion.

# How

Add an `onClick` callback to the Apple Pay config, which returns a Promise of `{ amount?: number; lineItems?: TransactionLineItem[]; }` which are used to update the transaction.

See video below for an example implementation:

https://github.com/user-attachments/assets/0e208e57-6e2b-44e1-b566-c66fec510fa4


