### PR TITLE
fix: remove version from harness to avoid being included in changeset

### DIFF
--- a/e2e-tests/crypto-harness/package.json
+++ b/e2e-tests/crypto-harness/package.json
@@ -1,7 +1,6 @@
 {
   "private": true,
   "name": "@repo/crypto-harness-e2e-tests",
-  "version": "0.0.0",
   "decription": "Series of tests to ensure the crypto library matches the browser library",
   "scripts": {
     "dev:test": "playwright test",


### PR DESCRIPTION
# Why

Changesets is attempting to create a release for the crypto harness as it has a version value. This is unexpected based on their documentation, but is currently blocking CI on master so deleting version to unblock.

# How

Remove version for private package