### PR TITLE
Improve the types for onShippingAddressChange

### DIFF
--- a/.changeset/plenty-dogs-shop.md
+++ b/.changeset/plenty-dogs-shop.md
@@ -1,0 +1,6 @@
+---
+"@evervault/browser": minor
+"@evervault/js": minor
+---
+
+Better types for ApplePay onShippingAddressChange

--- a/examples/react-google-wallet/src/App.tsx
+++ b/examples/react-google-wallet/src/App.tsx
@@ -127,8 +127,7 @@ function App() {
         borderRadius: 10,
         allowedCardNetworks: ["visa", "masterCard"],
         requestShipping: true,
-        onShippingAddressChange: async (event: PaymentRequestUpdateEvent) => {
-          const newAddress = (event.target as any | null)?.shippingAddress;
+        onShippingAddressChange: async (newAddress) => {
           if (!newAddress) return { amount: transaction.details.amount, lineItems: getLineItems() };
 
           const shipping = await calculateShipping(newAddress.region);

--- a/packages/browser/lib/ui/ApplePay/index.ts
+++ b/packages/browser/lib/ui/ApplePay/index.ts
@@ -13,6 +13,7 @@ import {
   ApplePayButtonStyle,
   ApplePayButtonType,
   ApplePayCardNetwork,
+  ShippingAddress,
 } from "./types";
 import { tryCatch } from "../../utilities";
 import { Transaction } from "../../resources/transaction";
@@ -39,7 +40,7 @@ export type ApplePayButtonOptions = {
     disbursementDetails?: PaymentDetailsInit;
   };
   onShippingAddressChange?: (
-    event: PaymentRequestUpdateEvent
+    newAddress: ShippingAddress
   ) => Promise<{ amount: number; lineItems?: TransactionLineItem[] }>;
   prepareTransaction?: () => Promise<{
     amount?: number;

--- a/packages/browser/lib/ui/ApplePay/types.ts
+++ b/packages/browser/lib/ui/ApplePay/types.ts
@@ -90,16 +90,16 @@ interface OnMerchantValidationEvent extends Event {
 }
 
 export interface ShippingAddress {
-    addressLine: string[];
-    city: string;
-    country: string;
-    dependentLocality: string;
-    organization: string;
-    phone: string;
-    postalCode: string;
-    recipient: string;
-    region: string;
-    sortingCode: string;
+  addressLine: string[];
+  city: string;
+  country: string;
+  dependentLocality: string;
+  organization: string;
+  phone: string;
+  postalCode: string;
+  recipient: string;
+  region: string;
+  sortingCode: string;
 }
 
 export interface ApplePayPaymentRequest extends PaymentRequest {

--- a/packages/browser/lib/ui/ApplePay/types.ts
+++ b/packages/browser/lib/ui/ApplePay/types.ts
@@ -89,6 +89,19 @@ interface OnMerchantValidationEvent extends Event {
   validationURL: string;
 }
 
+export interface ShippingAddress {
+    addressLine: string[];
+    city: string;
+    country: string;
+    dependentLocality: string;
+    organization: string;
+    phone: string;
+    postalCode: string;
+    recipient: string;
+    region: string;
+    sortingCode: string;
+}
+
 export interface ApplePayPaymentRequest extends PaymentRequest {
   onshippingaddresschange?: (event: PaymentRequestUpdateEvent) => void;
   onmerchantvalidation?: (event: OnMerchantValidationEvent) => void;

--- a/packages/browser/lib/ui/ApplePay/utilities.ts
+++ b/packages/browser/lib/ui/ApplePay/utilities.ts
@@ -70,13 +70,20 @@ export async function buildSession(
   // Apple pay requires subscribing to onshippingaddresschange and calling updateWith
   // in order to receive shipping data.
   baseRequest.onshippingaddresschange = (event: PaymentRequestUpdateEvent) => {
-    const target = event.target as unknown as { shippingAddress?: ShippingAddress };
+    const target = event.target as unknown as {
+      shippingAddress?: ShippingAddress;
+    };
     if (!target.shippingAddress) {
       return;
     }
 
     if (config.onShippingAddressChange) {
-      const updates = updatePaymentRequest(target.shippingAddress, config, tx, merchant); // Do not await this promise
+      const updates = updatePaymentRequest(
+        target.shippingAddress,
+        config,
+        tx,
+        merchant
+      ); // Do not await this promise
       event.updateWith(updates);
     } else {
       // If no handler is provided, just update with empty shipping options
@@ -94,7 +101,9 @@ async function updatePaymentRequest(
   tx: TransactionDetailsWithDomain,
   merchant: MerchantDetail
 ): Promise<PaymentDetailsUpdate> {
-  const updatedTransactionConfig = await config.onShippingAddressChange!(newAddress);
+  const updatedTransactionConfig = await config.onShippingAddressChange!(
+    newAddress
+  );
   const displayItems = (updatedTransactionConfig.lineItems ?? []).map(
     (item) => ({
       label: item.label,


### PR DESCRIPTION
# Why

The typing of the parameter to the onShippingChange callback was pretty poor.

# How

Parse the shipping address out of the event target and pass that to the callback.