### PR TITLE
Move prepareTransaction call above session creation in Apple Pay

### DIFF
--- a/.changeset/eight-poets-shake.md
+++ b/.changeset/eight-poets-shake.md
@@ -1,0 +1,5 @@
+---
+"@evervault/browser": patch
+---
+
+Fix prepareTransaction function for ApplePay

--- a/packages/browser/lib/ui/ApplePay/index.ts
+++ b/packages/browser/lib/ui/ApplePay/index.ts
@@ -99,6 +99,17 @@ export default class ApplePayButton {
   }
 
   async #handleClick() {
+    if (this.#options.prepareTransaction) {
+      const { amount, lineItems } = await this.#options.prepareTransaction();
+      if (amount) {
+        this.transaction.details.amount = amount;
+      }
+
+      if (lineItems) {
+        this.transaction.details.lineItems = lineItems;
+      }
+    }
+
     const session = await buildSession(this, {
       transaction: this.transaction.details,
       allowedCardNetworks: this.#options.allowedCardNetworks,
@@ -110,17 +121,6 @@ export default class ApplePayButton {
       onShippingAddressChange: this.#options.onShippingAddressChange,
       prepareTransaction: this.#options.prepareTransaction,
     });
-
-    if (this.#options.prepareTransaction) {
-      const { amount, lineItems } = await this.#options.prepareTransaction();
-      if (amount) {
-        this.transaction.details.amount = amount;
-      }
-
-      if (lineItems) {
-        this.transaction.details.lineItems = lineItems;
-      }
-    }
 
     const [response, responseError] = await tryCatch(session.show());
 


### PR DESCRIPTION
The `prepareTransaction` function needs to be called before the session creation in order for the transaction to be mutated before it is passed to the session builder.
