### PR TITLE
Expose onpaymentmethodchange event for Apple Pay

### DIFF
--- a/.changeset/nine-candles-wave.md
+++ b/.changeset/nine-candles-wave.md
@@ -1,0 +1,6 @@
+---
+"@evervault/browser": minor
+"@evervault/js": minor
+---
+
+Expose onPaymentMethodChange hook for Apple Pay

--- a/packages/browser/lib/ui/ApplePay/index.ts
+++ b/packages/browser/lib/ui/ApplePay/index.ts
@@ -13,6 +13,7 @@ import {
   ApplePayButtonStyle,
   ApplePayButtonType,
   ApplePayCardNetwork,
+  PaymentMethodUpdate,
   ShippingAddress,
 } from "./types";
 import { tryCatch } from "../../utilities";
@@ -29,7 +30,7 @@ export type ApplePayButtonOptions = {
   borderRadius?: string | number;
   size?: { width: string | number; height: string | number };
   allowedCardNetworks?: ApplePayCardNetwork[];
-  requestPayerDetails?: ("name" | "email" | "phone")[];
+  requestPayerDetails?: ("name" | "email" | "phone" | "postalAddress")[];
   requestBillingAddress?: boolean;
   requestShipping?: boolean;
   paymentOverrides?: {
@@ -39,6 +40,9 @@ export type ApplePayButtonOptions = {
   disbursementOverrides?: {
     disbursementDetails?: PaymentDetailsInit;
   };
+  onPaymentMethodChange?: (
+    newPaymentMethod: PaymentMethodUpdate
+  ) => Promise<{ amount: number; lineItems?: TransactionLineItem[] }>;
   onShippingAddressChange?: (
     newAddress: ShippingAddress
   ) => Promise<{ amount: number; lineItems?: TransactionLineItem[] }>;
@@ -118,6 +122,7 @@ export default class ApplePayButton {
       disbursementOverrides: this.#options.disbursementOverrides,
       requestBillingAddress: this.#options.requestBillingAddress,
       requestShipping: this.#options.requestShipping,
+      onPaymentMethodChange: this.#options.onPaymentMethodChange,
       onShippingAddressChange: this.#options.onShippingAddressChange,
       prepareTransaction: this.#options.prepareTransaction,
     });

--- a/packages/browser/lib/ui/ApplePay/types.ts
+++ b/packages/browser/lib/ui/ApplePay/types.ts
@@ -102,6 +102,26 @@ export interface ShippingAddress {
   sortingCode: string;
 }
 
+export interface BillingContact {
+  addressLines?: string[];
+  administrativeArea?: string;
+  country?: string;
+  countryCode?: string;
+  familyName?: string;
+  givenName?: string;
+  locality?: string;
+  phoneticFamilyName?: string;
+  phoneticGivenName?: string;
+  postalCode?: string;
+  subAdministrativeArea?: string;
+  subLocality?: string;
+}
+
+export interface PaymentMethodUpdate {
+  type?: string;
+  billingContact?: BillingContact;
+}
+
 export interface ApplePayPaymentRequest extends PaymentRequest {
   onshippingaddresschange?: (event: PaymentRequestUpdateEvent) => void;
   onmerchantvalidation?: (event: OnMerchantValidationEvent) => void;
@@ -123,7 +143,7 @@ export interface ApplePayConfig {
   disbursementOverrides?: {
     disbursementDetails?: PaymentDetailsInit;
   };
-  requestPayerDetails?: ("name" | "email" | "phone")[];
+  requestPayerDetails?: ("name" | "email" | "phone" | "postalAddress")[];
 }
 
 export interface ValidateMerchantResponse {


### PR DESCRIPTION
# Why

We have at least one customer with a use case for responding to payment method changes

# How

Expose a hook for this event so that the consumer can e.g. update tax based on location
