### PR TITLE
Validation option for cardholder name

### DIFF
--- a/.changeset/fair-mugs-notice.md
+++ b/.changeset/fair-mugs-notice.md
@@ -1,0 +1,8 @@
+---
+"@evervault/ui-components": minor
+"@evervault/browser": minor
+"@evervault/react": minor
+"types": minor
+---
+
+Add `validation` option to the Card Collection component to allow for customizing validation logic. Currently only supports adding regex validation for the card holder name.

--- a/e2e-tests/ui-components/tests/cardDetails.spec.js
+++ b/e2e-tests/ui-components/tests/cardDetails.spec.js
@@ -921,6 +921,26 @@ test.describe("card component", () => {
     await expect.poll(async () => values.isComplete).toBeTruthy();
     await expect.poll(async () => values.isValid).toBeTruthy();
   });
+
+  test("Can add custom validation for the name field", async ({ page }) => {
+    await page.evaluate(() => {
+      const card = window.evervault.ui.card({
+        fields: ["name", "number", "expiry", "cvc"],
+        validation: {
+          name: {
+            regex: /^[^0-9]+$/,
+          },
+        },
+      });
+
+      card.mount("#form");
+    });
+
+    const frame = page.frameLocator("iframe[data-evervault]");
+    await frame.getByLabel("Card Holder").fill("Test Person 123");
+    await frame.getByLabel("Card Holder").blur();
+    await expect(frame.getByText("Please enter a valid name")).toBeVisible();
+  });
 });
 
 async function decrypt(payload) {

--- a/packages/browser/lib/ui/card.ts
+++ b/packages/browser/lib/ui/card.ts
@@ -114,6 +114,7 @@ export default class Card {
         autoProgress: this.#options.autoProgress,
         redactCVC: this.#options.redactCVC,
         allow3DigitAmexCVC: this.#options.allow3DigitAmexCVC,
+        validation: this.#options.validation,
       },
     };
   }

--- a/packages/react/lib/ui/Card.tsx
+++ b/packages/react/lib/ui/Card.tsx
@@ -34,6 +34,7 @@ export interface CardProps {
   onKeyDown?: (event: FieldEvent) => void;
   redactCVC?: boolean;
   allow3DigitAmexCVC?: boolean;
+  validation?: CardOptions["validation"];
 }
 
 export function Card({
@@ -57,6 +58,7 @@ export function Card({
   defaultValues,
   redactCVC,
   allow3DigitAmexCVC,
+  validation,
 }: CardProps) {
   const ref = useRef<HTMLDivElement>(null);
 
@@ -73,6 +75,7 @@ export function Card({
       defaultValues,
       redactCVC,
       allow3DigitAmexCVC,
+      validation,
     }),
     [
       theme,
@@ -86,6 +89,7 @@ export function Card({
       defaultValues,
       redactCVC,
       allow3DigitAmexCVC,
+      validation,
     ]
   );
 

--- a/packages/types/uiComponents.ts
+++ b/packages/types/uiComponents.ts
@@ -114,6 +114,11 @@ export interface CardOptions {
     expiry?: boolean;
     cvc?: boolean;
   };
+  validation?: {
+    name?: {
+      regex?: RegExp;
+    };
+  };
 }
 
 export interface FormOptions {

--- a/packages/ui-components/src/Card/index.tsx
+++ b/packages/ui-components/src/Card/index.tsx
@@ -71,7 +71,7 @@ export function Card({ config }: { config: CardConfig }) {
         // Check custom regex validation if provided
         if (config.validation?.name?.regex) {
           if (!config.validation.name.regex.test(values.name)) {
-            return "invalid";
+            return "regex";
           }
         }
 

--- a/packages/ui-components/src/Card/index.tsx
+++ b/packages/ui-components/src/Card/index.tsx
@@ -68,6 +68,13 @@ export function Card({ config }: { config: CardConfig }) {
           return "invalid";
         }
 
+        // Check custom regex validation if provided
+        if (config.validation?.name?.regex) {
+          if (!config.validation.name.regex.test(values.name)) {
+            return "invalid";
+          }
+        }
+
         return undefined;
       },
       number: (values) => {

--- a/packages/ui-components/src/Card/translations.ts
+++ b/packages/ui-components/src/Card/translations.ts
@@ -6,6 +6,7 @@ export const DEFAULT_TRANSLATIONS: CardTranslations = {
     placeholder: "Name",
     errors: {
       invalid: "Please enter your full name",
+      regex: "Please enter a valid name",
     },
   },
   number: {

--- a/packages/ui-components/src/Card/types.ts
+++ b/packages/ui-components/src/Card/types.ts
@@ -26,6 +26,11 @@ export interface CardConfig {
     expiry?: boolean;
     cvc?: boolean;
   };
+  validation?: {
+    name?: {
+      regex?: RegExp;
+    };
+  };
 }
 
 export interface CardForm {


### PR DESCRIPTION
Adds a new `validation` option to Card Collection to allow users to customise validation logic.

For now this just introduces an option for adding regex validation to the card holder name, however, we can expand this object in the future to suport more options.

```
evervault.ui.card({
  validation: {
    name: {
      regex: /^[^0-9]+$/
    }
  }
})
```
