### PR TITLE
Fix autofill on chrome on iOS

### DIFF
--- a/.changeset/seven-elephants-poke.md
+++ b/.changeset/seven-elephants-poke.md
@@ -1,0 +1,5 @@
+---
+"@evervault/ui-components": patch
+---
+
+Fixes bug where card validation would initially fail when using payment autofill on Chrome on iOS

--- a/packages/ui-components/src/utilities/useMask.ts
+++ b/packages/ui-components/src/utilities/useMask.ts
@@ -1,5 +1,6 @@
 import IMask, { FactoryOpts } from "imask";
 import { RefObject, useCallback, useEffect, useRef } from "react";
+import { isChromeiOS } from "./userAgent";
 
 interface UseMaskReturn {
   setValue: (newValue: string) => void;
@@ -29,6 +30,32 @@ export function useMask(
       mask.current?.off("accept", handleAccept);
     };
   }, [config]);
+
+  // Fallbacks for platforms (e.g., iOS Chrome/WebKit) where autofill does not
+  // emit React onChange. Listen to native events directly to ensure we capture
+  // autofill value updates.
+  useEffect(() => {
+    if (!ref.current) return;
+    if (!isChromeiOS()) return;
+
+    const inputEl = ref.current;
+    const handleNativeEvent = () => {
+      if (!mask.current) return;
+      onAccept(mask.current.unmaskedValue);
+    };
+
+    inputEl.addEventListener("input", handleNativeEvent);
+    inputEl.addEventListener("change", handleNativeEvent);
+    inputEl.addEventListener("blur", handleNativeEvent);
+    inputEl.addEventListener("focus", handleNativeEvent);
+
+    return () => {
+      inputEl.removeEventListener("input", handleNativeEvent);
+      inputEl.removeEventListener("change", handleNativeEvent);
+      inputEl.removeEventListener("blur", handleNativeEvent);
+      inputEl.removeEventListener("focus", handleNativeEvent);
+    };
+  }, [ref, onAccept]);
 
   const setValue = useCallback((newValue: string) => {
     if (!mask.current) return;

--- a/packages/ui-components/src/utilities/userAgent.ts
+++ b/packages/ui-components/src/utilities/userAgent.ts
@@ -1,0 +1,7 @@
+/**
+ * Check if the user is using Chrome on iOS
+ * @returns {boolean}
+ */
+export function isChromeiOS() {
+  return window.navigator.userAgent.includes("CriOS");
+}


### PR DESCRIPTION
# Why

There seems to be a known bug where autofilling elements on chrome on iOS does not correctly emit onChange events inside of React.

https://issues.chromium.org/issues/41371116

# How

Setup native listeners for the required events only when on chrome on iOS.
