### PR TITLE
Grant write permissions for static bundle release

### DIFF
--- a/.github/workflows/publish-static-bundle.yml
+++ b/.github/workflows/publish-static-bundle.yml
@@ -53,7 +53,7 @@ on:
         required: true
         type: string
 permissions:
-  contents: read
+  contents: write
   id-token: write
 jobs:
   # Resolve the name of the artifact to be used in the deployment


### PR DESCRIPTION
# Why

Action needs write permissions to be able to create a github release

# How

Update permissions requested by action