### PR TITLE
Add multiline commit support to autoformat action

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -37,8 +37,12 @@ jobs:
       - name: Get current commit message
         id: commit-msg
         run: |
-          COMMIT_MSG=$(git log -1 --pretty=%B)
-          echo "commit-message=$COMMIT_MSG" >> $GITHUB_OUTPUT
+          COMMIT_MSG="$(git log -1 --pretty=%B)"
+          {
+            echo 'commit-message<<EOF'
+            echo "$COMMIT_MSG"
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
 
       - name: Apply formatting
         run: |


### PR DESCRIPTION
# Why
Action fails if a commit is more than 1 line
 
# How
Uses `<<EOF ... EOF` syntax to write multiline output