### PR TITLE
Fix GooglePay locale

### DIFF
--- a/.changeset/silly-pants-relate.md
+++ b/.changeset/silly-pants-relate.md
@@ -1,0 +1,6 @@
+---
+"@evervault/ui-components": minor
+"@evervault/js": minor
+---
+
+Bugfix: GooglePay locale is not passed to the PaymentsClient

--- a/packages/ui-components/src/GooglePay/index.tsx
+++ b/packages/ui-components/src/GooglePay/index.tsx
@@ -115,6 +115,7 @@ export function GooglePay({ config }: GooglePayProps) {
         const paymentRequest = buildPaymentRequest(config, merchant);
         await paymentsClient.isReadyToPay(paymentRequest);
         const btn = paymentsClient.createButton({
+          buttonLocale: config.locale || "en",
           buttonType: config.type || "plain",
           buttonColor: config.color || "black",
           buttonRadius: config.borderRadius || 4,


### PR DESCRIPTION
# Why

The locale field on the GooglePay button config is not passed to the PaymentsClient

# How

Fix it.

<img width="933" height="491" alt="image" src="https://github.com/user-attachments/assets/780da991-8222-40f5-bfec-7ab215605962" />
