### PR TITLE
Apply pnpm security settings

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -87,3 +87,7 @@ catalog:
   vite-plugin-istanbul: ^7.2.1
   vitest: ^4.0.18
   wait-on: ^9.0.4
+settings:
+  minimumReleaseAge: 10080
+  blockExoticSubdeps: true
+  trustPolicy: no-downgrade


### PR DESCRIPTION
# Why

We should be leveraging every bit of supply chain defence we can get from pnpm. Their latest approach for this is:
- minimumReleaseAge — block installing package versions younger than 7 days
- blockExoticSubdeps — block package installs if they have any dependencies which are not from a trusted registry
- trustPolicy — no-downgrade, enforce that the security posture of any published package cannot go backwards (i.e. if the package has used a trusted publisher in the past, reject any newer version which does not)

# How

Apply the most conservative pnpm settings for reducing the risk of supply chain attacks.