### PR TITLE
expose card.paymentMethodType for Apple Pay and Google Pay (CARD-627)

### DIFF
--- a/.changeset/expose-payment-method-type.md
+++ b/.changeset/expose-payment-method-type.md
@@ -4,4 +4,4 @@
 "@evervault/react": minor
 ---
 
-Expose `card.paymentMethodType` on the Apple Pay payload, sourced from `ApplePayPaymentMethod.type`. The value is one of `"credit"`, `"debit"`, `"prepaid"`, or `"store"` and reflects the funding type of the card the user selected in their wallet. This is useful for distinguishing the selected funding type more reliably than BIN-derived fields, which can return `credit` for cards that support both credit and debit. The field is also typed on the Google Pay payload for forward-compatibility; populating it for Google Pay requires a change to the credentials exchange endpoint and is tracked separately.
+Expose `card.paymentMethodType` on the Apple Pay and Google Pay payloads. The value is one of `"credit"`, `"debit"`, `"prepaid"`, or `"store"` and reflects the funding type of the card the user selected in their wallet. For Apple Pay it is sourced from `ApplePayPaymentMethod.type`; for Google Pay from `CardInfo.cardFundingSource`. This helps distinguish the selected funding type more reliably than BIN-derived fields, which can return `credit` for dual-network cards even when the user selected their debit card.

--- a/.changeset/expose-payment-method-type.md
+++ b/.changeset/expose-payment-method-type.md
@@ -1,0 +1,7 @@
+---
+"@evervault/browser": minor
+"@evervault/js": minor
+"@evervault/react": minor
+---
+
+Expose `card.paymentMethodType` on the Apple Pay payload, sourced from `ApplePayPaymentMethod.type`. The value is one of `"credit"`, `"debit"`, `"prepaid"`, or `"store"` and reflects the funding type of the card the user selected in their wallet. This is useful for distinguishing the selected funding type more reliably than BIN-derived fields, which can return `credit` for cards that support both credit and debit. The field is also typed on the Google Pay payload for forward-compatibility; populating it for Google Pay requires a change to the credentials exchange endpoint and is tracked separately.

--- a/packages/browser/lib/ui/ApplePay/index.ts
+++ b/packages/browser/lib/ui/ApplePay/index.ts
@@ -142,6 +142,7 @@ export default class ApplePayButton {
 
     const paymentMethodDisplayName =
       response.details?.token?.paymentMethod?.displayName;
+    const paymentMethodType = response.details?.token?.paymentMethod?.type;
 
     const [encrypted, encryptedError] = await tryCatch(
       this.#exchangeApplePaymentData(response)
@@ -161,6 +162,9 @@ export default class ApplePayButton {
     }
 
     encrypted.card.displayName = paymentMethodDisplayName;
+    if (paymentMethodType) {
+      encrypted.card.paymentMethodType = paymentMethodType;
+    }
     if (paymentMethodDisplayName) {
       const fourDigitRegex = /(\d{4})$/;
       const lastFour = paymentMethodDisplayName.match(fourDigitRegex);

--- a/packages/types/uiComponents.ts
+++ b/packages/types/uiComponents.ts
@@ -354,12 +354,15 @@ interface PaymentToken<P> {
   };
 }
 
+export type PaymentMethodType = "credit" | "debit" | "prepaid" | "store";
+
 export interface EncryptedDPAN<P> {
   token: PaymentToken<P>;
   card: {
     brand: string;
     lastFour?: string;
     displayName?: string;
+    paymentMethodType?: PaymentMethodType;
   };
   cryptogram: string;
   eci: string;
@@ -373,6 +376,7 @@ export interface EncryptedFPAN {
     number: string;
     lastFour?: string;
     displayName?: string;
+    paymentMethodType?: PaymentMethodType;
     expiry: {
       month: string;
       year: string;

--- a/packages/types/uiComponents.ts
+++ b/packages/types/uiComponents.ts
@@ -354,7 +354,12 @@ interface PaymentToken<P> {
   };
 }
 
-export type PaymentMethodType = "credit" | "debit" | "prepaid" | "store";
+export type PaymentMethodType =
+  | "credit"
+  | "debit"
+  | "prepaid"
+  | "store"
+  | "unknown";
 
 export interface EncryptedDPAN<P> {
   token: PaymentToken<P>;

--- a/packages/types/uiComponents.ts
+++ b/packages/types/uiComponents.ts
@@ -354,12 +354,7 @@ interface PaymentToken<P> {
   };
 }
 
-export type PaymentMethodType =
-  | "credit"
-  | "debit"
-  | "prepaid"
-  | "store"
-  | "unknown";
+export type PaymentMethodType = "credit" | "debit" | "prepaid" | "store";
 
 export interface EncryptedDPAN<P> {
   token: PaymentToken<P>;

--- a/packages/ui-components/src/GooglePay/index.tsx
+++ b/packages/ui-components/src/GooglePay/index.tsx
@@ -20,7 +20,6 @@ const FUNDING_SOURCE_MAP: Partial<
   CREDIT: "credit",
   DEBIT: "debit",
   PREPAID: "prepaid",
-  UNKNOWN: "unknown",
 };
 
 interface GooglePayProps {
@@ -78,10 +77,9 @@ export function GooglePay({ config }: GooglePayProps) {
 
             const paymentMethodInfo = paymentMethodData?.info;
 
-            const paymentMethodType =
-              FUNDING_SOURCE_MAP[
-                paymentMethodInfo?.cardFundingSource ?? "UNKNOWN"
-              ];
+            const paymentMethodType = paymentMethodInfo?.cardFundingSource
+              ? FUNDING_SOURCE_MAP[paymentMethodInfo.cardFundingSource]
+              : undefined;
             if (paymentMethodType) {
               payload.card.paymentMethodType = paymentMethodType;
             }

--- a/packages/ui-components/src/GooglePay/index.tsx
+++ b/packages/ui-components/src/GooglePay/index.tsx
@@ -14,10 +14,8 @@ import { getMerchant } from "../utilities/useMerchant";
 import { getAppSDKConfig } from "../utilities/getAppSDKConfig";
 import { apiConfig } from "../utilities/config";
 
-type GooglePayCardFundingSource = "CREDIT" | "DEBIT" | "PREPAID" | "UNKNOWN";
-
 const FUNDING_SOURCE_MAP: Partial<
-  Record<GooglePayCardFundingSource, PaymentMethodType>
+  Record<google.payments.api.CardFundingSource, PaymentMethodType>
 > = {
   CREDIT: "credit",
   DEBIT: "debit",
@@ -77,11 +75,7 @@ export function GooglePay({ config }: GooglePayProps) {
             const paymentMethodData = data.paymentMethodData;
             payload.card.displayName = paymentMethodData?.description;
 
-            const paymentMethodInfo = paymentMethodData?.info as
-              | (google.payments.api.CardInfo & {
-                  cardFundingSource?: GooglePayCardFundingSource;
-                })
-              | undefined;
+            const paymentMethodInfo = paymentMethodData?.info;
 
             const fundingSource = paymentMethodInfo?.cardFundingSource;
             const paymentMethodType = fundingSource

--- a/packages/ui-components/src/GooglePay/index.tsx
+++ b/packages/ui-components/src/GooglePay/index.tsx
@@ -4,11 +4,25 @@ import { buildPaymentRequest, exchangePaymentData } from "./utilities";
 import { setSize } from "../utilities/resize";
 import { GooglePayConfig } from "./types";
 import { useMessaging } from "../utilities/useMessaging";
-import { GooglePayClientMessages, GooglePayHostMessages } from "types";
+import {
+  GooglePayClientMessages,
+  GooglePayHostMessages,
+  PaymentMethodType,
+} from "types";
 import { useSearchParams } from "../utilities/useSearchParams";
 import { getMerchant } from "../utilities/useMerchant";
 import { getAppSDKConfig } from "../utilities/getAppSDKConfig";
 import { apiConfig } from "../utilities/config";
+
+type GooglePayCardFundingSource = "CREDIT" | "DEBIT" | "PREPAID" | "UNKNOWN";
+
+const FUNDING_SOURCE_MAP: Partial<
+  Record<GooglePayCardFundingSource, PaymentMethodType>
+> = {
+  CREDIT: "credit",
+  DEBIT: "debit",
+  PREPAID: "prepaid",
+};
 
 interface GooglePayProps {
   config: GooglePayConfig;
@@ -63,7 +77,19 @@ export function GooglePay({ config }: GooglePayProps) {
             const paymentMethodData = data.paymentMethodData;
             payload.card.displayName = paymentMethodData?.description;
 
-            const paymentMethodInfo = paymentMethodData?.info;
+            const paymentMethodInfo = paymentMethodData?.info as
+              | (google.payments.api.CardInfo & {
+                  cardFundingSource?: GooglePayCardFundingSource;
+                })
+              | undefined;
+
+            const fundingSource = paymentMethodInfo?.cardFundingSource;
+            const paymentMethodType = fundingSource
+              ? FUNDING_SOURCE_MAP[fundingSource]
+              : undefined;
+            if (paymentMethodType) {
+              payload.card.paymentMethodType = paymentMethodType;
+            }
 
             const billingAddress = paymentMethodInfo?.billingAddress || null;
             if (billingAddress) {

--- a/packages/ui-components/src/GooglePay/index.tsx
+++ b/packages/ui-components/src/GooglePay/index.tsx
@@ -20,6 +20,7 @@ const FUNDING_SOURCE_MAP: Partial<
   CREDIT: "credit",
   DEBIT: "debit",
   PREPAID: "prepaid",
+  UNKNOWN: "unknown",
 };
 
 interface GooglePayProps {
@@ -77,10 +78,10 @@ export function GooglePay({ config }: GooglePayProps) {
 
             const paymentMethodInfo = paymentMethodData?.info;
 
-            const fundingSource = paymentMethodInfo?.cardFundingSource;
-            const paymentMethodType = fundingSource
-              ? FUNDING_SOURCE_MAP[fundingSource]
-              : undefined;
+            const paymentMethodType =
+              FUNDING_SOURCE_MAP[
+                paymentMethodInfo?.cardFundingSource ?? "UNKNOWN"
+              ];
             if (paymentMethodType) {
               payload.card.paymentMethodType = paymentMethodType;
             }
@@ -90,7 +91,7 @@ export function GooglePay({ config }: GooglePayProps) {
               payload.billingAddress = billingAddress;
             }
 
-            const cardDetails = data.paymentMethodData.info?.cardDetails;
+            const cardDetails = paymentMethodInfo?.cardDetails;
             if (cardDetails) {
               const fourDigitRegex = /(\d{4})$/;
               const lastFour = cardDetails.match(fourDigitRegex);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ catalogs:
       specifier: ^14.0.9
       version: 14.0.9
     '@types/googlepay':
-      specifier: ^0.7.6
-      version: 0.7.6
+      specifier: ^0.7.10
+      version: 0.7.10
     '@types/jest':
       specifier: ^28.1.2
       version: 28.1.8
@@ -1090,7 +1090,7 @@ importers:
     dependencies:
       '@types/googlepay':
         specifier: 'catalog:'
-        version: 0.7.6
+        version: 0.7.10
       jss:
         specifier: 'catalog:'
         version: 10.10.0
@@ -1115,7 +1115,7 @@ importers:
         version: 14.0.9
       '@types/googlepay':
         specifier: 'catalog:'
-        version: 0.7.6
+        version: 0.7.10
       imask:
         specifier: 'catalog:'
         version: 7.6.1
@@ -4541,8 +4541,8 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
-  '@types/googlepay@0.7.6':
-    resolution: {integrity: sha512-5003wG+qvf4Ktf1hC9IJuRakNzQov00+Xf09pAWGJLpdOjUrq0SSLCpXX7pwSeTG9r5hrdzq1iFyZcW7WVyr4g==}
+  '@types/googlepay@0.7.10':
+    resolution: {integrity: sha512-ByXjDfxEp87zsjw5cVsNKEeA+AIJYcWwJvRqPu85jO0Lp/FeG67csnf4mqbPaIxmdI6+Khp3v5I0yyjq9MrGhw==}
 
   '@types/graceful-fs@4.1.9':
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
@@ -4768,11 +4768,12 @@ packages:
   '@xmldom/xmldom@0.7.13':
     resolution: {integrity: sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==}
     engines: {node: '>=10.0.0'}
-    deprecated: this version is no longer supported, please update to at least 0.8.*
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xmldom/xmldom@0.8.10':
     resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@zxing/text-encoding@0.9.0':
     resolution: {integrity: sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==}
@@ -9211,7 +9212,7 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
 
   temp-dir@2.0.0:
     resolution: {integrity: sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==}
@@ -14424,7 +14425,7 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
-  '@types/googlepay@0.7.6': {}
+  '@types/googlepay@0.7.10': {}
 
   '@types/graceful-fs@4.1.9':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,7 +15,7 @@ catalog:
   "@playwright/test": ^1.56.1
   "@swc/core": ^1.4.11
   "@types/applepayjs": ^14.0.9
-  "@types/googlepay": ^0.7.6
+  "@types/googlepay": ^0.7.10
   "@types/jest": ^28.1.2
   "@types/jsdom": ^21.1.6
   "@types/node": ^24


### PR DESCRIPTION
## Summary

Adds `card.paymentMethodType?: "credit" | "debit" | "prepaid" | "store"` to the `EncryptedApplePayData` and `EncryptedGooglePayData` payloads. The value reflects the funding type of the specific card the user selected in their wallet — more reliable than BIN-derived funding fields, which can return `credit` for dual-network cards even when the user selected their debit card.

**Apple Pay** — sourced from `ApplePayPaymentMethod.type` in the Payment Request response.

**Google Pay** — sourced from `CardInfo.cardFundingSource` (typed in `@types/googlepay@0.7.10`, also bumped in this PR). Mapped from uppercase Google Pay constants (`CREDIT`/`DEBIT`/`PREPAID`) to lowercase. `UNKNOWN` and absent values leave the field `undefined` rather than surfacing a sentinel.

The field is optional on both `EncryptedDPAN` and `EncryptedFPAN`, so existing consumers are unaffected.

Linear: [CARD-627](https://linear.app/evervault/issue/CARD-627/expose-payment-method-type-in-card-object)

## Changes

| File | What changed |
|------|-------------|
| `packages/types/uiComponents.ts` | Add `PaymentMethodType` type and optional `card.paymentMethodType` to `EncryptedDPAN` and `EncryptedFPAN` |
| `packages/browser/lib/ui/ApplePay/index.ts` | Populate from `paymentMethod.type` after credential exchange |
| `packages/ui-components/src/GooglePay/index.tsx` | Populate from `cardFundingSource` via `FUNDING_SOURCE_MAP` |
| `pnpm-workspace.yaml` + `pnpm-lock.yaml` | Bump `@types/googlepay` `0.7.6` → `0.7.10` (adds `CardFundingSource` type) |

## Test plan
- [ ] Apple Pay — select a debit card in Wallet → `data.card.paymentMethodType === "debit"`.
- [ ] Apple Pay — select a credit card → `"credit"`.
- [ ] Google Pay — transaction where `cardFundingSource` is present → correct lowercase value on payload.
- [ ] Google Pay — `cardFundingSource` absent or `UNKNOWN` → `paymentMethodType` is `undefined`, no error.
- [ ] Existing Apple Pay and Google Pay integrations that don't read `paymentMethodType` are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)