### PR TITLE
Fix: publish OIDC token permissions

### DIFF
--- a/.changeset/expose-payment-method-type.md
+++ b/.changeset/expose-payment-method-type.md
@@ -1,0 +1,7 @@
+---
+"@evervault/browser": minor
+"@evervault/js": minor
+"@evervault/react": minor
+---
+
+Expose `card.paymentMethodType` on the Apple Pay and Google Pay payloads. The value is one of `"credit"`, `"debit"`, `"prepaid"`, or `"store"` and reflects the funding type of the card the user selected in their wallet. For Apple Pay it is sourced from `ApplePayPaymentMethod.type`; for Google Pay from `CardInfo.cardFundingSource`. This helps distinguish the selected funding type more reliably than BIN-derived fields, which can return `credit` for dual-network cards even when the user selected their debit card.

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -65,9 +65,7 @@ jobs:
 
       # https://github.com/actions/setup-node/issues/1440#issuecomment-3571890875
       - name: Publish to npm
-        run: NODE_AUTH_TOKEN="" pnpm --filter ${{ inputs.package }} publish --access public --no-git-checks
-        env:
-          NPM_CONFIG_PROVENANCE: true
+        run: NODE_AUTH_TOKEN="" pnpm --filter ${{ inputs.package }} publish --access public --no-git-checks --verbose
   create_release:
     name: Create Github Release
     runs-on: ubuntu-latest

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -171,6 +171,9 @@ jobs:
     strategy:
       matrix:
         tag: ${{ fromJson(needs.create-tags.outputs.tags-to-publish) }}
+    permissions:
+      id-token: write
+      contents: read
     with:
       release-tag: ${{ matrix.tag }}
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,11 @@ on:
         description: "The tag name of the release"
         required: true
         type: string
+
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   get-package-name-from-tag:
     runs-on: ubuntu-latest
@@ -104,9 +109,6 @@ jobs:
   publish-react:
     if: startsWith(inputs.release-tag, '@evervault/react') && !contains(inputs.release-tag, '@evervault/react-native')
     needs: build
-    permissions:
-      id-token: write
-      contents: read
     uses: ./.github/workflows/npm-publish.yml
     with:
       package: "@evervault/react"
@@ -117,9 +119,6 @@ jobs:
   publish-card-validator:
     if: startsWith(inputs.release-tag, '@evervault/card-validator')
     needs: build
-    permissions:
-      id-token: write
-      contents: read
     uses: ./.github/workflows/npm-publish.yml
     with:
       package: "@evervault/card-validator"
@@ -130,9 +129,6 @@ jobs:
   publish-react-native-v2:
     if: startsWith(inputs.release-tag, '@evervault/react-native')
     needs: build
-    permissions:
-      id-token: write
-      contents: read
     uses: ./.github/workflows/npm-publish.yml
     with:
       package: "@evervault/react-native"
@@ -143,9 +139,6 @@ jobs:
   publish-react-native-v1:
     if: startsWith(inputs.release-tag, '@evervault/evervault-react-native')
     needs: build
-    permissions:
-      id-token: write
-      contents: read
     uses: ./.github/workflows/npm-publish.yml
     with:
       package: "@evervault/evervault-react-native"
@@ -156,9 +149,6 @@ jobs:
   publish-eql:
     if: startsWith(inputs.release-tag, '@evervault/eql')
     needs: build
-    permissions:
-      id-token: write
-      contents: read
     uses: ./.github/workflows/npm-publish.yml
     with:
       package: "@evervault/eql"
@@ -169,9 +159,6 @@ jobs:
   publish-js:
     if: startsWith(inputs.release-tag, '@evervault/js')
     needs: build
-    permissions:
-      id-token: write
-      contents: read
     uses: ./.github/workflows/npm-publish.yml
     with:
       package: "@evervault/js"

--- a/e2e-tests/browser/CHANGELOG.md
+++ b/e2e-tests/browser/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @evervault/browser-e2e-tests
 
-## 1.0.23
-
-### Patch Changes
-
-- Updated dependencies [417b58c]
-  - @evervault/browser@2.54.0
-
 ## 1.0.22
 
 ### Patch Changes

--- a/e2e-tests/browser/package.json
+++ b/e2e-tests/browser/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@evervault/browser-e2e-tests",
-  "version": "1.0.23",
+  "version": "1.0.22",
   "scripts": {
     "dev:test": "playwright test",
     "e2e:test": "playwright test",

--- a/e2e-tests/inputs/CHANGELOG.md
+++ b/e2e-tests/inputs/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @evervault/inputs-e2e-tests
 
-## 1.0.27
-
-### Patch Changes
-
-- @evervault/inputs@2.18.29
-
 ## 1.0.26
 
 ### Patch Changes

--- a/e2e-tests/inputs/package.json
+++ b/e2e-tests/inputs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@evervault/inputs-e2e-tests",
-  "version": "1.0.27",
+  "version": "1.0.26",
   "scripts": {
     "dev:test": "playwright test",
     "e2e:test": "playwright test",

--- a/e2e-tests/ui-components/CHANGELOG.md
+++ b/e2e-tests/ui-components/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @evervault/ui-components-e2e-tests
 
-## 1.2.19
-
-### Patch Changes
-
-- @evervault/ui-components@1.39.2
-
 ## 1.2.18
 
 ### Patch Changes

--- a/e2e-tests/ui-components/package.json
+++ b/e2e-tests/ui-components/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@evervault/ui-components-e2e-tests",
-  "version": "1.2.19",
+  "version": "1.2.18",
   "scripts": {
     "e2e:test": "playwright test",
     "clean": "rm -rf node_modules dist"

--- a/e2e-tests/ui-components/vanilla-test-server/CHANGELOG.md
+++ b/e2e-tests/ui-components/vanilla-test-server/CHANGELOG.md
@@ -1,12 +1,5 @@
 # e2e-tests-ui-components-vanilla-server
 
-## 0.0.57
-
-### Patch Changes
-
-- Updated dependencies [417b58c]
-  - @evervault/browser@2.54.0
-
 ## 0.0.56
 
 ### Patch Changes

--- a/e2e-tests/ui-components/vanilla-test-server/package.json
+++ b/e2e-tests/ui-components/vanilla-test-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "e2e-tests-ui-components-vanilla-server",
   "private": true,
-  "version": "0.0.57",
+  "version": "0.0.56",
   "type": "module",
   "scripts": {
     "dev": "vite --port 4005"

--- a/examples/apple-pay/CHANGELOG.md
+++ b/examples/apple-pay/CHANGELOG.md
@@ -1,12 +1,5 @@
 # example-apple-pay
 
-## 0.0.15
-
-### Patch Changes
-
-- Updated dependencies [417b58c]
-  - @evervault/js@2.11.0
-
 ## 0.0.14
 
 ### Patch Changes

--- a/examples/apple-pay/package.json
+++ b/examples/apple-pay/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-apple-pay",
   "private": true,
-  "version": "0.0.15",
+  "version": "0.0.14",
   "type": "module",
   "scripts": {
     "dev": "vite --port 4000",

--- a/examples/collect-card-details/CHANGELOG.md
+++ b/examples/collect-card-details/CHANGELOG.md
@@ -1,12 +1,5 @@
 # example-ui-components
 
-## 0.3.9
-
-### Patch Changes
-
-- Updated dependencies [417b58c]
-  - @evervault/js@2.11.0
-
 ## 0.3.8
 
 ### Patch Changes

--- a/examples/collect-card-details/package.json
+++ b/examples/collect-card-details/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-ui-components",
   "private": true,
-  "version": "0.3.9",
+  "version": "0.3.8",
   "type": "module",
   "scripts": {
     "dev": "vite --port 4000",

--- a/examples/custom-theme/CHANGELOG.md
+++ b/examples/custom-theme/CHANGELOG.md
@@ -1,12 +1,5 @@
 # example-custom-theme
 
-## 0.0.46
-
-### Patch Changes
-
-- Updated dependencies [417b58c]
-  - @evervault/js@2.11.0
-
 ## 0.0.45
 
 ### Patch Changes

--- a/examples/custom-theme/package.json
+++ b/examples/custom-theme/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-custom-theme",
   "private": true,
-  "version": "0.0.46",
+  "version": "0.0.45",
   "type": "module",
   "scripts": {
     "dev": "vite --port 4000",

--- a/examples/google-pay/CHANGELOG.md
+++ b/examples/google-pay/CHANGELOG.md
@@ -1,12 +1,5 @@
 # google-pay
 
-## 0.3.3
-
-### Patch Changes
-
-- Updated dependencies [417b58c]
-  - @evervault/js@2.11.0
-
 ## 0.3.2
 
 ### Patch Changes

--- a/examples/google-pay/package.json
+++ b/examples/google-pay/package.json
@@ -1,7 +1,7 @@
 {
   "name": "google-pay",
   "private": true,
-  "version": "0.3.3",
+  "version": "0.3.2",
   "type": "module",
   "scripts": {
     "dev": "vite --port 4000",

--- a/examples/next-3ds/CHANGELOG.md
+++ b/examples/next-3ds/CHANGELOG.md
@@ -1,12 +1,5 @@
 # example-next-3ds
 
-## 0.1.22
-
-### Patch Changes
-
-- Updated dependencies [417b58c]
-  - @evervault/react@2.24.0
-
 ## 0.1.21
 
 ### Patch Changes

--- a/examples/next-3ds/package.json
+++ b/examples/next-3ds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example-next-3ds",
-  "version": "0.1.22",
+  "version": "0.1.21",
   "private": true,
   "scripts": {
     "dev": "next dev --port 4000",

--- a/examples/react-google-wallet/CHANGELOG.md
+++ b/examples/react-google-wallet/CHANGELOG.md
@@ -1,13 +1,5 @@
 # example-react-google-wallet
 
-## 0.3.30
-
-### Patch Changes
-
-- Updated dependencies [417b58c]
-  - @evervault/browser@2.54.0
-  - @evervault/react@2.24.0
-
 ## 0.3.29
 
 ### Patch Changes

--- a/examples/react-google-wallet/package.json
+++ b/examples/react-google-wallet/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-react-google-wallet",
   "private": true,
-  "version": "0.3.30",
+  "version": "0.3.29",
   "type": "module",
   "scripts": {
     "dev": "vite --port 4000",

--- a/examples/react/CHANGELOG.md
+++ b/examples/react/CHANGELOG.md
@@ -1,12 +1,5 @@
 # example-react
 
-## 0.0.29
-
-### Patch Changes
-
-- Updated dependencies [417b58c]
-  - @evervault/react@2.24.0
-
 ## 0.0.28
 
 ### Patch Changes

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-react",
   "private": true,
-  "version": "0.0.29",
+  "version": "0.0.28",
   "type": "module",
   "scripts": {
     "dev": "vite --port 4000",

--- a/examples/three-d-secure/CHANGELOG.md
+++ b/examples/three-d-secure/CHANGELOG.md
@@ -1,12 +1,5 @@
 # example-three-d-secure
 
-## 0.0.49
-
-### Patch Changes
-
-- Updated dependencies [417b58c]
-  - @evervault/js@2.11.0
-
 ## 0.0.48
 
 ### Patch Changes

--- a/examples/three-d-secure/package.json
+++ b/examples/three-d-secure/package.json
@@ -1,7 +1,7 @@
 {
   "name": "example-three-d-secure",
   "private": true,
-  "version": "0.0.49",
+  "version": "0.0.48",
   "type": "module",
   "scripts": {
     "dev": "concurrently --kill-others \"pnpm run client:dev\" \"pnpm run server:dev\"",

--- a/packages/browser/CHANGELOG.md
+++ b/packages/browser/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @evervault/browser
 
-## 2.54.0
-
-### Minor Changes
-
-- 417b58c: Expose `card.paymentMethodType` on the Apple Pay and Google Pay payloads. The value is one of `"credit"`, `"debit"`, `"prepaid"`, or `"store"` and reflects the funding type of the card the user selected in their wallet. For Apple Pay it is sourced from `ApplePayPaymentMethod.type`; for Google Pay from `CardInfo.cardFundingSource`. This helps distinguish the selected funding type more reliably than BIN-derived fields, which can return `credit` for dual-network cards even when the user selected their debit card.
-
 ## 2.53.0
 
 ### Minor Changes

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -1,7 +1,7 @@
 {
   "private": false,
   "name": "@evervault/browser",
-  "version": "2.54.0",
+  "version": "2.53.0",
   "engines": {
     "node": "~24"
   },

--- a/packages/inputs/CHANGELOG.md
+++ b/packages/inputs/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @evervault/inputs
 
-## 2.18.29
-
-### Patch Changes
-
-- Updated dependencies [417b58c]
-  - @evervault/browser@2.54.0
-
 ## 2.18.28
 
 ### Patch Changes

--- a/packages/inputs/package.json
+++ b/packages/inputs/package.json
@@ -1,7 +1,7 @@
 {
   "private": false,
   "name": "@evervault/inputs",
-  "version": "2.18.29",
+  "version": "2.18.28",
   "description": "Repo for the backend for Evervault Inputs",
   "types": "./src/types.d.ts",
   "scripts": {

--- a/packages/js/CHANGELOG.md
+++ b/packages/js/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @evervault/js
 
-## 2.11.0
-
-### Minor Changes
-
-- 417b58c: Expose `card.paymentMethodType` on the Apple Pay and Google Pay payloads. The value is one of `"credit"`, `"debit"`, `"prepaid"`, or `"store"` and reflects the funding type of the card the user selected in their wallet. For Apple Pay it is sourced from `ApplePayPaymentMethod.type`; for Google Pay from `CardInfo.cardFundingSource`. This helps distinguish the selected funding type more reliably than BIN-derived fields, which can return `credit` for dual-network cards even when the user selected their debit card.
-
 ## 2.10.0
 
 ### Minor Changes

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -1,7 +1,7 @@
 {
   "private": false,
   "name": "@evervault/js",
-  "version": "2.11.0",
+  "version": "2.10.0",
   "description": "Evervault.js loader for client-side browser applications",
   "license": "MIT",
   "type": "module",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @evervault/react
 
-## 2.24.0
-
-### Minor Changes
-
-- 417b58c: Expose `card.paymentMethodType` on the Apple Pay and Google Pay payloads. The value is one of `"credit"`, `"debit"`, `"prepaid"`, or `"store"` and reflects the funding type of the card the user selected in their wallet. For Apple Pay it is sourced from `ApplePayPaymentMethod.type`; for Google Pay from `CardInfo.cardFundingSource`. This helps distinguish the selected funding type more reliably than BIN-derived fields, which can return `credit` for dual-network cards even when the user selected their debit card.
-
 ## 2.23.1
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "private": false,
   "name": "@evervault/react",
-  "version": "2.24.0",
+  "version": "2.23.1",
   "description": "React package for the Evervault SDK",
   "license": "MIT",
   "type": "module",

--- a/packages/ui-components/CHANGELOG.md
+++ b/packages/ui-components/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @evervault/ui-components
 
-## 1.39.2
-
-### Patch Changes
-
-- Updated dependencies [417b58c]
-  - @evervault/react@2.24.0
-
 ## 1.39.1
 
 ### Patch Changes

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@evervault/ui-components",
   "private": false,
-  "version": "1.39.2",
+  "version": "1.39.1",
   "type": "module",
   "scripts": {
     "build": "vite build",


### PR DESCRIPTION
# Why
We should have referenced the workflow on npmjs to the root repo, but one that is called through workflow_dispatch.  I've updated it there, and the parent workflow (push.yml) needs to set the `id-token:write` permission and the other dispatched workflows inherit those permissions.

I've also added a 'verbose' flag for debugging.

# How
Describe how you've approached the problem
