### PR TITLE
Fix creating releases on github

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -71,6 +71,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: publish
     continue-on-error: true
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
Fixes permissions error when creating a release on Github.
```
👩‍🏭 Creating new GitHub release for tag @evervault/js@2.11.0...
⚠️ GitHub release failed with status: 403
{"message":"Resource not accessible by integration","documentation_url":"https://docs.github.com/rest/releases/releases#create-a-release","status":"403"}
Skip retry — your GitHub token/PAT does not have the required permission to create a release
⚠️ Unexpected error fetching GitHub release for tag refs/heads/master: HttpError: Resource not accessible by integration - https://docs.github.com/rest/releases/releases#create-a-release
Error: Resource not accessible by integration - https://docs.github.com/rest/releases/releases#create-a-release
```
