### PR TITLE
Append sandbox label to Apple Pay merchant name

### DIFF
--- a/.changeset/light-starfishes-switch.md
+++ b/.changeset/light-starfishes-switch.md
@@ -1,0 +1,5 @@
+---
+"@evervault/browser": minor
+---
+
+Append "(Card is not charged)" to the merchant name in the Apple Pay sheet when the app is sandbox-flagged.

--- a/packages/browser/lib/ui/ApplePay/utilities.ts
+++ b/packages/browser/lib/ui/ApplePay/utilities.ts
@@ -1,4 +1,5 @@
 import {
+  AppSDKConfig,
   DisbursementTransactionDetails,
   MerchantDetail,
   PaymentTransactionDetails,
@@ -52,6 +53,14 @@ export async function buildSession(
   const merchant = await getMerchant(applePay, tx.merchantId);
   if (!merchant) {
     throw new Error("Merchant not found");
+  }
+
+  const appConfig = await getAppSDKConfig(
+    applePay.client.config.appId,
+    applePay.client.config.http.apiUrl
+  );
+  if (appConfig.is_sandbox) {
+    merchant.name = `${merchant.name} (Card is not charged)`;
   }
 
   let baseRequest: ApplePayPaymentRequest;
@@ -509,6 +518,30 @@ async function getMerchant(
   }
 
   return response.json();
+}
+
+async function getAppSDKConfig(
+  app: string,
+  apiUrl: string
+): Promise<AppSDKConfig> {
+  try {
+    const response = await fetch(`${apiUrl}/frontend/sdk/config`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Evervault-App-Id": app,
+      },
+    });
+
+    if (response.ok) {
+      return response.json() as Promise<AppSDKConfig>;
+    }
+
+    console.error(`Failed to fetch app SDK config details for ${app}`);
+  } catch (error) {
+    console.error(`Failed to fetch app SDK config details for ${app}`, error);
+  }
+  return { is_sandbox: false };
 }
 
 export function resolveUnit(input: string | number) {

--- a/packages/browser/lib/ui/ApplePay/utilities.ts
+++ b/packages/browser/lib/ui/ApplePay/utilities.ts
@@ -1,5 +1,5 @@
+import { getAppSDKConfig } from "shared";
 import {
-  AppSDKConfig,
   DisbursementTransactionDetails,
   MerchantDetail,
   PaymentTransactionDetails,
@@ -518,30 +518,6 @@ async function getMerchant(
   }
 
   return response.json();
-}
-
-async function getAppSDKConfig(
-  app: string,
-  apiUrl: string
-): Promise<AppSDKConfig> {
-  try {
-    const response = await fetch(`${apiUrl}/frontend/sdk/config`, {
-      method: "GET",
-      headers: {
-        "Content-Type": "application/json",
-        "X-Evervault-App-Id": app,
-      },
-    });
-
-    if (response.ok) {
-      return response.json() as Promise<AppSDKConfig>;
-    }
-
-    console.error(`Failed to fetch app SDK config details for ${app}`);
-  } catch (error) {
-    console.error(`Failed to fetch app SDK config details for ${app}`, error);
-  }
-  return { is_sandbox: false };
 }
 
 export function resolveUnit(input: string | number) {

--- a/packages/browser/lib/ui/ApplePay/utilities.ts
+++ b/packages/browser/lib/ui/ApplePay/utilities.ts
@@ -1,4 +1,4 @@
-import { getAppSDKConfig } from "shared";
+import { getAppSDKConfig } from "shared/getAppSDKConfig";
 import {
   DisbursementTransactionDetails,
   MerchantDetail,

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -43,6 +43,7 @@
     "asn1js": "catalog:",
     "deepmerge": "catalog:",
     "events": "catalog:",
+    "shared": "workspace:*",
     "themes": "workspace:*",
     "types": "workspace:*"
   },

--- a/packages/browser/test/applePay.test.ts
+++ b/packages/browser/test/applePay.test.ts
@@ -1,0 +1,95 @@
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import {
+  describe,
+  assert,
+  it,
+  beforeAll,
+  afterAll,
+  afterEach,
+  beforeEach,
+} from "vitest";
+import { buildSession } from "../lib/ui/ApplePay/utilities";
+import ApplePayButton from "../lib/ui/ApplePay";
+import { setupCrypto } from "./setup";
+
+const apiUrl = "https://api.test.evervault.com";
+const app = "app_test123";
+const merchantId = "merchant_abc";
+const merchantName = "Acme Co";
+
+const paymentRequestCalls: PaymentDetailsInit[] = [];
+
+class MockPaymentRequest {
+  constructor(_methodData: unknown, details: PaymentDetailsInit) {
+    paymentRequestCalls.push(details);
+  }
+}
+
+const applePay = {
+  client: { config: { appId: app, http: { apiUrl } } },
+} as unknown as ApplePayButton;
+
+const transaction = {
+  type: "payment" as const,
+  amount: 1000,
+  currency: "USD",
+  country: "US",
+  merchantId,
+  domain: "shop.example.com",
+};
+
+const server = setupServer();
+
+beforeAll(() => {
+  setupCrypto();
+  (globalThis as unknown as { PaymentRequest: unknown }).PaymentRequest =
+    MockPaymentRequest;
+  server.listen();
+});
+
+beforeEach(() => {
+  paymentRequestCalls.length = 0;
+  server.use(
+    http.get(`${apiUrl}/frontend/merchants/${merchantId}`, () =>
+      HttpResponse.json({ id: merchantId, name: merchantName }, { status: 200 })
+    )
+  );
+});
+
+afterEach(() => {
+  server.resetHandlers();
+});
+
+afterAll(() => {
+  server.close();
+});
+
+describe("buildSession sandbox label", () => {
+  it("appends '(Card is not charged)' to the merchant name when is_sandbox is true", async () => {
+    server.use(
+      http.get(`${apiUrl}/frontend/sdk/config`, () =>
+        HttpResponse.json({ is_sandbox: true }, { status: 200 })
+      )
+    );
+
+    await buildSession(applePay, { transaction });
+
+    assert(
+      paymentRequestCalls[0].total?.label ===
+        `${merchantName} (Card is not charged)`
+    );
+  });
+
+  it("leaves the merchant name unchanged when is_sandbox is false", async () => {
+    server.use(
+      http.get(`${apiUrl}/frontend/sdk/config`, () =>
+        HttpResponse.json({ is_sandbox: false }, { status: 200 })
+      )
+    );
+
+    await buildSession(applePay, { transaction });
+
+    assert(paymentRequestCalls[0].total?.label === merchantName);
+  });
+});

--- a/packages/browser/test/getAppSDKConfig.test.ts
+++ b/packages/browser/test/getAppSDKConfig.test.ts
@@ -1,13 +1,6 @@
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
-import {
-  describe,
-  assert,
-  it,
-  beforeAll,
-  afterAll,
-  afterEach,
-} from "vitest";
+import { describe, assert, it, beforeAll, afterAll, afterEach } from "vitest";
 import { getAppSDKConfig } from "shared/getAppSDKConfig";
 import { setupCrypto } from "./setup";
 

--- a/packages/browser/test/getAppSDKConfig.test.ts
+++ b/packages/browser/test/getAppSDKConfig.test.ts
@@ -1,0 +1,64 @@
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import {
+  describe,
+  assert,
+  it,
+  beforeAll,
+  afterAll,
+  afterEach,
+} from "vitest";
+import { getAppSDKConfig } from "shared/getAppSDKConfig";
+import { setupCrypto } from "./setup";
+
+const apiUrl = "https://api.test.evervault.com";
+const app = "app_test123";
+
+const server = setupServer();
+
+beforeAll(() => {
+  setupCrypto();
+  server.listen();
+});
+
+afterEach(() => {
+  server.resetHandlers();
+});
+
+afterAll(() => {
+  server.close();
+});
+
+describe("getAppSDKConfig", () => {
+  it("returns the parsed config when the API returns 200", async () => {
+    server.use(
+      http.get(`${apiUrl}/frontend/sdk/config`, ({ request }) => {
+        assert(request.headers.get("X-Evervault-App-Id") === app);
+        return HttpResponse.json({ is_sandbox: true }, { status: 200 });
+      })
+    );
+
+    const config = await getAppSDKConfig(app, apiUrl);
+    assert(config.is_sandbox === true);
+  });
+
+  it("returns the default config when the API responds non-2xx", async () => {
+    server.use(
+      http.get(`${apiUrl}/frontend/sdk/config`, () =>
+        HttpResponse.json({}, { status: 500 })
+      )
+    );
+
+    const config = await getAppSDKConfig(app, apiUrl);
+    assert(config.is_sandbox === false);
+  });
+
+  it("returns the default config when fetch throws", async () => {
+    server.use(
+      http.get(`${apiUrl}/frontend/sdk/config`, () => HttpResponse.error())
+    );
+
+    const config = await getAppSDKConfig(app, apiUrl);
+    assert(config.is_sandbox === false);
+  });
+});

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -3,6 +3,10 @@
   "private": true,
   "version": "1.1.21",
   "main": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./getAppSDKConfig": "./src/getAppSDKConfig.ts"
+  },
   "dependencies": {
     "types": "workspace:*",
     "@evervault/card-validator": "workspace:*"

--- a/packages/shared/src/getAppSDKConfig.ts
+++ b/packages/shared/src/getAppSDKConfig.ts
@@ -1,16 +1,17 @@
 import { AppSDKConfig } from "types";
 
-const API = import.meta.env.VITE_API_URL as string;
-
 export function getDefaultAppSDKConfig(): AppSDKConfig {
   return {
     is_sandbox: false,
   };
 }
 
-export async function getAppSDKConfig(app: string): Promise<AppSDKConfig> {
+export async function getAppSDKConfig(
+  app: string,
+  apiUrl: string
+): Promise<AppSDKConfig> {
   try {
-    const response = await fetch(`${API}/frontend/sdk/config`, {
+    const response = await fetch(`${apiUrl}/frontend/sdk/config`, {
       method: "GET",
       headers: {
         "Content-Type": "application/json",
@@ -19,7 +20,7 @@ export async function getAppSDKConfig(app: string): Promise<AppSDKConfig> {
     });
 
     if (response.ok) {
-      return response.json() as Promise<AppSDKConfig>;
+      return (await response.json()) as AppSDKConfig;
     }
 
     console.error(`Failed to fetch app SDK config details for ${app}`);

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./useForm";
 export * from "./useTranslations";
+export * from "./getAppSDKConfig";

--- a/packages/ui-components/src/GooglePay/index.tsx
+++ b/packages/ui-components/src/GooglePay/index.tsx
@@ -11,7 +11,7 @@ import {
 } from "types";
 import { useSearchParams } from "../utilities/useSearchParams";
 import { getMerchant } from "../utilities/useMerchant";
-import { getAppSDKConfig } from "../utilities/getAppSDKConfig";
+import { getAppSDKConfig } from "shared";
 import { apiConfig } from "../utilities/config";
 
 const FUNDING_SOURCE_MAP: Partial<
@@ -51,7 +51,7 @@ export function GooglePay({ config }: GooglePayProps) {
     called.current = true;
 
     async function onLoad() {
-      const appConfig = await getAppSDKConfig(app);
+      const appConfig = await getAppSDKConfig(app, apiConfig.apiUrl);
       const paymentsClient = new google.payments.api.PaymentsClient({
         // Always use 'test' in staging, but use the resolved environment in production
         environment:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -724,6 +724,9 @@ importers:
       events:
         specifier: 'catalog:'
         version: 3.3.0
+      shared:
+        specifier: workspace:*
+        version: link:../shared
       themes:
         specifier: workspace:*
         version: link:../themes


### PR DESCRIPTION
# How
For Apple Pay, when the app is flagged as sandbox, append "(Card is not charged)" to the merchant name displayed in the Apple Pay sheet.

# Why
So test transactions are visibly distinguished from live ones.

# Other changes in this PR
- Moved `getAppSDKConfig` from `ui-components` into `shared` so Apple Pay and Google Pay share it. See comment on `packages/shared/package.json` re: the `exports` field.
- Fixed a latent bug in `ui-components` GooglePay: API URL now comes from `apiConfig.apiUrl` (production-aware) instead of `VITE_API_URL` (could be undefined in production builds).
- Added vitest coverage: 3 cases for `getAppSDKConfig`, 2 for the Apple Pay label append behaviour.
