### PR TITLE
Fix animation on 3ds.evervault.com

### DIFF
--- a/.changeset/shiny-flies-worry.md
+++ b/.changeset/shiny-flies-worry.md
@@ -1,0 +1,5 @@
+---
+"@evervault/3ds": patch
+---
+
+Move animation from parent spinner to SVG

--- a/packages/3ds/src/styles.css
+++ b/packages/3ds/src/styles.css
@@ -12,12 +12,15 @@ body {
   place-items: center;
   color: #5e6077;
   transform-origin: center;
-  animation: spin 0.7s linear infinite;
 }
 
 #spinner.visible {
   opacity: 1;
   pointer-events: all;
+}
+
+.spinner {
+  animation: spin 0.7s linear infinite;
 }
 
 @keyframes spin {


### PR DESCRIPTION
# Why

The animation of the spinner was on an element that was the page size, causing scrollbars to wreak havoc on users' browsers

This moves it to the SVG so the animation is only applied to the spinner itself