### PR TITLE
Prevent 3DS callback events from firing multiple times

### DIFF
--- a/.changeset/mean-flowers-promise.md
+++ b/.changeset/mean-flowers-promise.md
@@ -1,0 +1,8 @@
+---
+"@evervault/ui-components": patch
+"@evervault/browser": patch
+---
+
+- idempotency guard to prevent `handleOutcome` firing multiple times
+- removing the message listener before processing, to prevent duplicate events
+- disabling the cancel button after first click to prevent duplicate cancellation calls

--- a/e2e-tests/ui-components/tests/threeDSecure.spec.js
+++ b/e2e-tests/ui-components/tests/threeDSecure.spec.js
@@ -193,6 +193,108 @@ test.describe("threeDSecure component", () => {
     await code.pressSequentially("111111");
     await expect.poll(async () => success, { timeout: 7500 }).toBeTruthy();
   });
+
+  test.describe("cancel button", () => {
+    // 4242... triggers a challenge flow (requires code entry)
+    const CHALLENGE_CARD = "4242424242424242";
+
+    let failureCount;
+    let successCount;
+
+    test.beforeEach(async ({ page }) => {
+      failureCount = 0;
+      successCount = 0;
+
+      await page.exposeFunction("handleFailure", () => {
+        failureCount++;
+      });
+      await page.exposeFunction("handleSuccess", () => {
+        successCount++;
+      });
+
+      const session = await createThreeDSSession(CHALLENGE_CARD);
+      await page.evaluate((sessionId) => {
+        const comp = window.evervault.ui.threeDSecure(sessionId);
+        comp.on("failure", window.handleFailure);
+        comp.on("success", window.handleSuccess);
+        comp.mount();
+      }, session.id);
+
+      // Wait for challenge frame to be ready before each test
+      const frame = page.frameLocator("iframe[data-evervault]");
+      const acsFrame = frame.frameLocator("iframe[name='challengeFrame']");
+      await acsFrame.locator("input").waitFor({ state: "visible" });
+    });
+
+    test("fires failure callback exactly once when clicked once", async ({
+      page,
+    }) => {
+      const frame = page.frameLocator("iframe[data-evervault]");
+      const cancelButton = frame.locator(".overlayClose");
+      await cancelButton.waitFor({ state: "visible" });
+      await cancelButton.click();
+
+      await expect.poll(async () => failureCount).toBe(1);
+      await expect.poll(async () => successCount, { timeout: 1000 }).toBe(0);
+    });
+
+    test("spamming the cancel button only fires failure callback once", async ({
+      page,
+    }) => {
+      const frame = page.frameLocator("iframe[data-evervault]");
+      const cancelButton = frame.locator(".overlayClose");
+      await cancelButton.waitFor({ state: "visible" });
+
+      // Spam the cancel button as fast as possible
+      await cancelButton.click();
+      await cancelButton.click({ force: true });
+      await cancelButton.click({ force: true });
+      await cancelButton.click({ force: true });
+      await cancelButton.click({ force: true });
+
+      await expect.poll(async () => failureCount, { timeout: 5000 }).toBe(1);
+      // Assert disabled state confirms deduplication at the UI level too
+      await expect(cancelButton).toBeDisabled();
+      await expect.poll(async () => successCount, { timeout: 1000 }).toBe(0);
+    });
+
+    test("is disabled after first click", async ({ page }) => {
+      const frame = page.frameLocator("iframe[data-evervault]");
+      const cancelButton = frame.locator(".overlayClose");
+      await cancelButton.waitFor({ state: "visible" });
+
+      await expect(cancelButton).toBeEnabled();
+      await cancelButton.click();
+      await expect(cancelButton).toBeDisabled();
+    });
+
+    test("fires failure and not success when cancelled mid-challenge", async ({
+      page,
+    }) => {
+      const frame = page.frameLocator("iframe[data-evervault]");
+      const cancelButton = frame.locator(".overlayClose");
+      await cancelButton.click();
+
+      await expect.poll(async () => failureCount).toBe(1);
+      await expect.poll(async () => successCount, { timeout: 1000 }).toBe(0);
+    });
+
+    test("fires failure only once when cancelled after partial code entry", async ({
+      page,
+    }) => {
+      const frame = page.frameLocator("iframe[data-evervault]");
+      const acsFrame = frame.frameLocator("iframe[name='challengeFrame']");
+
+      // Start typing the success code but cancel before it completes
+      await acsFrame.locator("input").pressSequentially("111");
+
+      const cancelButton = frame.locator(".overlayClose");
+      await cancelButton.click();
+
+      await expect.poll(async () => failureCount, { timeout: 5000 }).toBe(1);
+      await expect.poll(async () => successCount, { timeout: 1000 }).toBe(0);
+    });
+  });
 });
 
 async function createThreeDSSession(number) {

--- a/e2e-tests/ui-components/tests/threeDSecure.spec.js
+++ b/e2e-tests/ui-components/tests/threeDSecure.spec.js
@@ -238,26 +238,6 @@ test.describe("threeDSecure component", () => {
       await expect.poll(async () => successCount, { timeout: 1000 }).toBe(0);
     });
 
-    test("spamming the cancel button only fires failure callback once", async ({
-      page,
-    }) => {
-      const frame = page.frameLocator("iframe[data-evervault]");
-      const cancelButton = frame.locator(".overlayClose");
-      await cancelButton.waitFor({ state: "visible" });
-
-      // Spam the cancel button as fast as possible
-      await cancelButton.click();
-      await cancelButton.click({ force: true });
-      await cancelButton.click({ force: true });
-      await cancelButton.click({ force: true });
-      await cancelButton.click({ force: true });
-
-      await expect.poll(async () => failureCount, { timeout: 5000 }).toBe(1);
-      // Assert disabled state confirms deduplication at the UI level too
-      await expect(cancelButton).toBeDisabled();
-      await expect.poll(async () => successCount, { timeout: 1000 }).toBe(0);
-    });
-
     test("is disabled after first click", async ({ page }) => {
       const frame = page.frameLocator("iframe[data-evervault]");
       const cancelButton = frame.locator(".overlayClose");

--- a/packages/browser/lib/ui/threeDSecure.ts
+++ b/packages/browser/lib/ui/threeDSecure.ts
@@ -27,6 +27,7 @@ export default class ThreeDSecure {
   >;
 
   #events = new EventManager<ThreeDSecureEvents>();
+  #handled = false;
 
   constructor(
     client: EvervaultClient,
@@ -92,6 +93,8 @@ export default class ThreeDSecure {
     cres?: string | null,
     abortedOnChallenge: boolean = false
   ) {
+    if (this.#handled) return;
+    this.#handled = true;
     await this.#updateOutcome(outcome, cres, abortedOnChallenge);
     this.#events.dispatch(outcome === "success" ? "success" : "failure");
     this.unmount();

--- a/packages/browser/lib/ui/threeDSecure.ts
+++ b/packages/browser/lib/ui/threeDSecure.ts
@@ -95,7 +95,12 @@ export default class ThreeDSecure {
   ) {
     if (this.#handled) return;
     this.#handled = true;
-    await this.#updateOutcome(outcome, cres, abortedOnChallenge);
+    try {
+      await this.#updateOutcome(outcome, cres, abortedOnChallenge);
+    } catch {
+      this.#handled = false;
+      return;
+    }
     this.#events.dispatch(outcome === "success" ? "success" : "failure");
     this.unmount();
   }

--- a/packages/browser/test/threeDSecure.test.ts
+++ b/packages/browser/test/threeDSecure.test.ts
@@ -199,6 +199,75 @@ describe("ThreeDSecure#handleOutcome idempotency", () => {
     expect(unmountSpy).toHaveBeenCalledTimes(1);
   });
 
+  it("ignores a success event after a cancel has already been processed", async () => {
+    const patchRequests: RecordedPatch[] = [];
+    server.use(patchHandler(patchRequests));
+
+    const failureHandler = vi.fn();
+    const successHandler = vi.fn();
+    const { tds } = createThreeDSecure();
+    tds.on("failure", failureHandler);
+    tds.on("success", successHandler);
+
+    lastFrame.trigger("EV_CANCEL");
+    await vi.waitFor(() => expect(patchRequests).toHaveLength(1));
+
+    lastFrame.trigger("EV_SUCCESS", null);
+
+    expect(patchRequests).toHaveLength(1);
+    expect(patchRequests[0]).toEqual({
+      body: { outcome: "cancelled", cres: null },
+      appId,
+    });
+    expect(failureHandler).toHaveBeenCalledTimes(1);
+    expect(successHandler).not.toHaveBeenCalled();
+  });
+
+  it("ignores a cancel event after a success has already been processed", async () => {
+    const patchRequests: RecordedPatch[] = [];
+    server.use(patchHandler(patchRequests));
+
+    const failureHandler = vi.fn();
+    const successHandler = vi.fn();
+    const { tds } = createThreeDSecure();
+    tds.on("failure", failureHandler);
+    tds.on("success", successHandler);
+
+    lastFrame.trigger("EV_SUCCESS", null);
+    await vi.waitFor(() => expect(patchRequests).toHaveLength(1));
+
+    lastFrame.trigger("EV_CANCEL");
+
+    expect(patchRequests).toHaveLength(1);
+    expect(patchRequests[0]).toEqual({
+      body: { outcome: "success", cres: null },
+      appId,
+    });
+    expect(successHandler).toHaveBeenCalledTimes(1);
+    expect(failureHandler).not.toHaveBeenCalled();
+  });
+
+  it("ignores a cancel event after a failure has already been processed", async () => {
+    const patchRequests: RecordedPatch[] = [];
+    server.use(patchHandler(patchRequests));
+
+    const failureHandler = vi.fn();
+    const { tds } = createThreeDSecure();
+    tds.on("failure", failureHandler);
+
+    lastFrame.trigger("EV_FAILURE", "cres_token");
+    await vi.waitFor(() => expect(patchRequests).toHaveLength(1));
+
+    lastFrame.trigger("EV_CANCEL");
+
+    expect(patchRequests).toHaveLength(1);
+    expect(patchRequests[0]).toEqual({
+      body: { outcome: "failure", cres: "cres_token" },
+      appId,
+    });
+    expect(failureHandler).toHaveBeenCalledTimes(1);
+  });
+
   it("resets the handled flag if fetch rejects (network error), allowing a retry", async () => {
     let callCount = 0;
     const originalFetch = globalThis.fetch;

--- a/packages/browser/test/threeDSecure.test.ts
+++ b/packages/browser/test/threeDSecure.test.ts
@@ -1,0 +1,241 @@
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  afterAll,
+  afterEach,
+} from "vitest";
+import ThreeDSecure from "../lib/ui/threeDSecure";
+import { setupCrypto } from "./setup";
+import type EvervaultClient from "../lib/main";
+
+const apiUrl = "https://api.test.evervault.com";
+const appId = "app_test123";
+const session = "sess_abc123";
+const patchUrl = `${apiUrl}/frontend/3ds/browser-sessions/${session}`;
+
+type RecordedPatch = {
+  body: unknown;
+  appId: string | null;
+};
+
+function patchHandler(patchRequests: RecordedPatch[]) {
+  return http.patch(patchUrl, async ({ request }) => {
+    patchRequests.push({
+      body: await request.json(),
+      appId: request.headers.get("X-Evervault-App-Id"),
+    });
+    return HttpResponse.json({}, { status: 200 });
+  });
+}
+
+const mockClient = {
+  config: { appId, http: { apiUrl } },
+} as unknown as EvervaultClient;
+
+// Mock the EvervaultFrame class
+class MockFrame {
+  handlers = new Map<string, (...args: unknown[]) => void>();
+
+  on(event: string, handler: (...args: unknown[]) => void) {
+    this.handlers.set(event, handler);
+    return this;
+  }
+
+  send() {}
+  mount() {
+    return this;
+  }
+  unmount() {
+    return this;
+  }
+  createOverlay() {
+    return document.createElement("div");
+  }
+  setSize() {}
+  update() {}
+
+  trigger(event: string, ...args: unknown[]) {
+    this.handlers.get(event)?.(...args);
+  }
+}
+
+let lastFrame: MockFrame;
+
+// Hijack the EvervaultFrame class and return a mock instance
+vi.mock("../lib/ui/evervaultFrame", () => ({
+  EvervaultFrame: class {
+    constructor() {
+      // Expose the last frame instance to the test
+      lastFrame = new MockFrame();
+      return lastFrame;
+    }
+  },
+}));
+
+function createThreeDSecure(sessionId = session) {
+  const tds = new ThreeDSecure(mockClient, sessionId);
+  return { tds, frame: lastFrame };
+}
+
+const server = setupServer();
+
+beforeAll(() => {
+  setupCrypto();
+  server.listen();
+});
+
+afterEach(() => {
+  server.resetHandlers();
+  vi.restoreAllMocks();
+});
+
+afterAll(() => {
+  server.close();
+});
+
+describe("ThreeDSecure#handleOutcome idempotency", () => {
+  it("only calls PATCH once when EV_CANCEL fires multiple times", async () => {
+    const patchRequests: RecordedPatch[] = [];
+    server.use(patchHandler(patchRequests));
+
+    const failureHandler = vi.fn();
+    const { tds, frame } = createThreeDSecure();
+    const unmountSpy = vi.spyOn(frame, "unmount");
+    tds.on("failure", failureHandler);
+
+    lastFrame.trigger("EV_CANCEL");
+    lastFrame.trigger("EV_CANCEL");
+    lastFrame.trigger("EV_CANCEL");
+
+    await vi.waitFor(() => {
+      expect(patchRequests).toHaveLength(1);
+    });
+
+    expect(patchRequests[0]).toEqual({
+      body: { outcome: "cancelled", cres: null },
+      appId,
+    });
+    expect(failureHandler).toHaveBeenCalledTimes(1);
+    expect(unmountSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("only dispatches the success callback once even if EV_SUCCESS fires multiple times", async () => {
+    const patchRequests: RecordedPatch[] = [];
+    server.use(patchHandler(patchRequests));
+
+    const successHandler = vi.fn();
+    const { tds, frame } = createThreeDSecure();
+    const unmountSpy = vi.spyOn(frame, "unmount");
+    tds.on("success", successHandler);
+
+    lastFrame.trigger("EV_SUCCESS", null);
+    lastFrame.trigger("EV_SUCCESS", null);
+    lastFrame.trigger("EV_SUCCESS", null);
+
+    await vi.waitFor(() => {
+      expect(patchRequests).toHaveLength(1);
+    });
+
+    expect(patchRequests[0]).toEqual({
+      body: { outcome: "success", cres: null },
+      appId,
+    });
+    expect(successHandler).toHaveBeenCalledTimes(1);
+    expect(unmountSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("only dispatches the failure callback once even if EV_FAILURE fires multiple times", async () => {
+    const patchRequests: RecordedPatch[] = [];
+    server.use(patchHandler(patchRequests));
+
+    const failureHandler = vi.fn();
+    const { tds, frame } = createThreeDSecure();
+    const unmountSpy = vi.spyOn(frame, "unmount");
+    tds.on("failure", failureHandler);
+
+    lastFrame.trigger("EV_FAILURE", "cres_token");
+    lastFrame.trigger("EV_FAILURE", "cres_token");
+    lastFrame.trigger("EV_FAILURE", "cres_token");
+
+    await vi.waitFor(() => {
+      expect(patchRequests).toHaveLength(1);
+    });
+
+    expect(patchRequests[0]).toEqual({
+      body: { outcome: "failure", cres: "cres_token" },
+      appId,
+    });
+    expect(failureHandler).toHaveBeenCalledTimes(1);
+    expect(unmountSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("only PATCHes aborted-on-challenge once when EV_FAILURE_FORCED_DUE_TO_CHALLENGE fires multiple times", async () => {
+    const patchRequests: RecordedPatch[] = [];
+    server.use(patchHandler(patchRequests));
+
+    const failureHandler = vi.fn();
+    const { tds, frame } = createThreeDSecure();
+    const unmountSpy = vi.spyOn(frame, "unmount");
+    tds.on("failure", failureHandler);
+
+    lastFrame.trigger("EV_FAILURE_FORCED_DUE_TO_CHALLENGE", "cres_token");
+    lastFrame.trigger("EV_FAILURE_FORCED_DUE_TO_CHALLENGE", "cres_token");
+    lastFrame.trigger("EV_FAILURE_FORCED_DUE_TO_CHALLENGE", "cres_token");
+
+    await vi.waitFor(() => {
+      expect(patchRequests).toHaveLength(1);
+    });
+
+    expect(patchRequests[0]).toEqual({
+      body: { outcome: "aborted-on-challenge", cres: "cres_token" },
+      appId,
+    });
+    expect(failureHandler).toHaveBeenCalledTimes(1);
+    expect(unmountSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets the handled flag if fetch rejects (network error), allowing a retry", async () => {
+    let callCount = 0;
+    const originalFetch = globalThis.fetch;
+    vi.spyOn(globalThis, "fetch").mockImplementation((...args) => {
+      callCount++;
+      if (callCount === 1) return Promise.reject(new Error("network error"));
+      return originalFetch(...args);
+    });
+
+    const patchRequests: RecordedPatch[] = [];
+    server.use(patchHandler(patchRequests));
+
+    const successHandler = vi.fn();
+    const { tds } = createThreeDSecure();
+    tds.on("success", successHandler);
+
+    // #updateOutcome does not check response.ok — only fetch rejections reset #handled
+    lastFrame.trigger("EV_SUCCESS", null);
+    await vi.waitFor(() => {
+      expect(callCount).toBe(1);
+    });
+    expect(patchRequests).toHaveLength(0);
+    expect(successHandler).not.toHaveBeenCalled();
+
+    // Let the rejected fetch settle so #handleOutcome's catch resets #handled
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    lastFrame.trigger("EV_SUCCESS", null);
+    await vi.waitFor(() => {
+      expect(patchRequests).toHaveLength(1);
+    });
+
+    expect(callCount).toBe(2);
+    expect(patchRequests[0]).toEqual({
+      body: { outcome: "success", cres: null },
+      appId,
+    });
+    expect(successHandler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui-components/src/ThreeDSecure/BrowserFingerprint.tsx
+++ b/packages/ui-components/src/ThreeDSecure/BrowserFingerprint.tsx
@@ -33,8 +33,9 @@ export function BrowserFingerprint({
 
     const handleMessage = (e: MessageEvent) => {
       if (isTrampolineMessage(e)) {
-        onComplete();
+        window.removeEventListener("message", handleMessage);
         if (timeout.current) clearTimeout(timeout.current);
+        onComplete();
       }
     };
 

--- a/packages/ui-components/src/ThreeDSecure/ChallengeFrame.tsx
+++ b/packages/ui-components/src/ThreeDSecure/ChallengeFrame.tsx
@@ -36,6 +36,7 @@ export function ChallengeFrame({ nextAction, onLoad }: ChallengeFrameProps) {
   useEffect(() => {
     function handleMessage(e: MessageEvent) {
       if (isTrampolineMessage(e)) {
+        window.removeEventListener("message", handleMessage);
         if (check3DSSuccess(e)) {
           send("EV_SUCCESS", cresForOutcome(e.data.cres));
         } else {

--- a/packages/ui-components/src/ThreeDSecure/Overlay.tsx
+++ b/packages/ui-components/src/ThreeDSecure/Overlay.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import { ReactNode, useState } from "react";
 
 export function Overlay({
   enabled,
@@ -9,12 +9,23 @@ export function Overlay({
   children: ReactNode;
   onCancel: () => void;
 }) {
+  const [cancelling, setCancelling] = useState(false);
+
   if (!enabled) return children;
+
+  const handleCancel = () => {
+    setCancelling(true);
+    onCancel();
+  };
 
   return (
     <div ev-overlay="" className="overlay">
       <div className="overlayWindow">
-        <button className="overlayClose" onClick={onCancel}>
+        <button
+          className="overlayClose"
+          onClick={handleCancel}
+          disabled={cancelling}
+        >
           <svg
             xmlns="http://www.w3.org/2000/svg"
             width="16"

--- a/packages/ui-components/src/index.css
+++ b/packages/ui-components/src/index.css
@@ -128,6 +128,10 @@ select {
   &:hover {
     background: rgb(0 0 0 / 0.7);
   }
+
+  &:disabled {
+    opacity: 0.5;
+  }
 }
 
 .spinner {


### PR DESCRIPTION
# Why
3DS callback events (`onSuccess`, `onFailure`, `onError`) could fire multiple times for a single session. The root cause was users spamming the cancel button, which sent multiple `EV_CANCEL` messages, each triggering a separate PATCH to update the session outcome and dispatching the user callback again.

Fixes EXP-992.

# How
Three layers of defence:

- **Idempotency guard on `#handleOutcome`** — a `#handled` flag ensures only the first outcome (success, failure, or cancel) is processed, regardless of how many duplicate events arrive
- **Early listener removal in trampoline handlers** — `BrowserFingerprint` and `ChallengeFrame` now remove their `message` listener before acting on the trampoline event, consistent with how the existing timeout path already behaved
- **Cancel button disabled after first click** — the overlay cancel button switches to `Cancelling...` and becomes disabled immediately on click, preventing duplicate `EV_CANCEL` events from being sent