### PR TITLE
Add custom brand support to card-validator

### DIFF
--- a/.changeset/card-validator-custom-brands.md
+++ b/.changeset/card-validator-custom-brands.md
@@ -1,0 +1,5 @@
+---
+"@evervault/card-validator": minor
+---
+
+Add custom brand support to card-validator. `validateNumber` and `validateCVC` now accept an optional `options` parameter with a `customBrands` field, allowing callers to supply additional `CustomBrand` definitions at validation time. The `ranges` type has been tightened from `number[] | [number[]]` to `Array<number | [number, number]>`.

--- a/packages/card-validator/brands.ts
+++ b/packages/card-validator/brands.ts
@@ -1,4 +1,4 @@
-import { type CardBrand } from "./types";
+import { type DefaultBrand } from "./types";
 
 const brands = [
   {
@@ -256,6 +256,6 @@ const brands = [
       lengths: [3],
     },
   },
-] as CardBrand[];
+] as DefaultBrand[];
 
 export default brands;

--- a/packages/card-validator/index.ts
+++ b/packages/card-validator/index.ts
@@ -3,9 +3,9 @@ import type {
   CardCVCValidationResult,
   CardExpiryValidationResult,
   CardNumberValidationResult,
+  CardNumberValidationOptions,
 } from "./types";
 import defaultBrands from "./brands";
-import { type CardBrandName } from "types";
 
 export * from "./types";
 
@@ -39,7 +39,25 @@ function getBin(cardNumber: string): string {
   }
 }
 
-export function validateNumber(cardNumber: string): CardNumberValidationResult {
+function matchesRangeOrPrefix(
+  cardNumber: string,
+  range: number | [number, number]
+): boolean {
+  if (Array.isArray(range)) {
+    if (range[0] && range[1]) {
+      return matchesRange(cardNumber, range[0], range[1]);
+    }
+  } else {
+    return matchesPrefix(cardNumber, range);
+  }
+
+  return false;
+}
+
+export function validateNumber(
+  cardNumber: string,
+  options?: CardNumberValidationOptions
+): CardNumberValidationResult {
   // Remove all spaces from the card number
   const sanitizedCardNumber = String(cardNumber).replace(/\s/g, "");
 
@@ -55,30 +73,30 @@ export function validateNumber(cardNumber: string): CardNumberValidationResult {
   }
 
   // Filter out brands where the card number does not match any of the ranges
-  const cardBrands = defaultBrands.filter((brand) => {
-    return brand.numberValidationRules.ranges.some((range) => {
-      if (Array.isArray(range)) {
-        if (range[0] && range[1]) {
-          return matchesRange(sanitizedCardNumber, range[0], range[1]);
-        }
-      } else {
-        return matchesPrefix(sanitizedCardNumber, range);
-      }
-
-      return false;
-    });
+  const defaultCardBrands = defaultBrands.filter((brand) => {
+    return brand.numberValidationRules.ranges.some((range) =>
+      matchesRangeOrPrefix(sanitizedCardNumber, range)
+    );
   });
 
-  const globalBrands = cardBrands.filter((brand) => !brand.isLocal);
-  const localBrands = cardBrands.filter((brand) => brand.isLocal);
+  const customBrands = (options?.customBrands ?? []).filter((brand) => {
+    return brand.numberValidationRules.ranges.some((range) =>
+      matchesRangeOrPrefix(sanitizedCardNumber, range)
+    );
+  });
+
+  const allCardBrands = [...defaultCardBrands, ...customBrands];
+
+  const globalBrands = defaultCardBrands.filter((brand) => !brand.isLocal);
+  const localBrands = allCardBrands.filter((brand) => brand.isLocal);
 
   // Check if the card number is valid based on:
   // 1. The card number belongs to at least one card brand range
   // 2. The length of the card number is supported, based on all supported card brands
   // 3. The Luhn check passes, based on all supported card brands
   const isValid =
-    cardBrands.length > 0 &&
-    cardBrands.every((creditCardBrand) => {
+    allCardBrands.length > 0 &&
+    allCardBrands.every((creditCardBrand) => {
       const { lengths, luhnCheck } = creditCardBrand.numberValidationRules;
 
       // Check if the length of the sanitized card number is supported
@@ -107,7 +125,8 @@ export function validateNumber(cardNumber: string): CardNumberValidationResult {
 
 export function validateCVC(
   cvc: string,
-  cardNumber?: string
+  cardNumber?: string,
+  options?: CardNumberValidationOptions
 ): CardCVCValidationResult {
   // Check if the CVC only contains numbers with 3 or 4 digits
   if (!/^\d{3,4}$/.test(cvc)) {
@@ -124,7 +143,7 @@ export function validateCVC(
     };
   }
 
-  const validatedCard = validateNumber(cardNumber);
+  const validatedCard = validateNumber(cardNumber, options);
   if (!validatedCard.isValid) {
     return {
       cvc: null,
@@ -132,7 +151,7 @@ export function validateCVC(
     };
   }
 
-  const brands: CardBrandName[] = [];
+  const brands: string[] = [];
   if (validatedCard.brand) {
     brands.push(validatedCard.brand);
   }
@@ -140,7 +159,8 @@ export function validateCVC(
     brands.push(...validatedCard.localBrands);
   }
 
-  const isCVCValid = defaultBrands
+  const allBrands = [...defaultBrands, ...(options?.customBrands ?? [])];
+  const isCVCValid = allBrands
     .filter((brand) => brands.includes(brand.name))
     .some((brand) => {
       return brand.securityCodeValidationRules.lengths.includes(cvc.length);

--- a/packages/card-validator/test/custom-brands.test.ts
+++ b/packages/card-validator/test/custom-brands.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from "vitest";
+import { validateNumber, validateCVC } from "../index";
+import type { CustomBrand } from "../types";
+
+const acmeBrand: CustomBrand = {
+  name: "acme-card",
+  isLocal: true,
+  numberValidationRules: {
+    luhnCheck: true,
+    ranges: [[88000, 88999]],
+    lengths: [16],
+  },
+  securityCodeValidationRules: {
+    lengths: [4],
+  },
+};
+
+const noLuhnBrand: CustomBrand = {
+  name: "no-luhn-brand",
+  isLocal: true,
+  numberValidationRules: {
+    luhnCheck: false,
+    ranges: [9900],
+    lengths: [16],
+  },
+  securityCodeValidationRules: {
+    lengths: [3],
+  },
+};
+
+const anotherBrand: CustomBrand = {
+  name: "another-brand",
+  isLocal: true,
+  numberValidationRules: {
+    luhnCheck: false,
+    ranges: [7700],
+    lengths: [16],
+  },
+  securityCodeValidationRules: {
+    lengths: [3],
+  },
+};
+
+// Overlaps with visa (4111111111111111) to test default + custom brand coexistence
+const customVisaOverlap: CustomBrand = {
+  name: "custom-visa-overlap",
+  isLocal: true,
+  numberValidationRules: {
+    luhnCheck: true,
+    ranges: [[411100, 411199]],
+    lengths: [16],
+  },
+  securityCodeValidationRules: { lengths: [4] },
+};
+
+describe("validateNumber with custom brands", () => {
+  it("surfaces a matched custom brand in localBrands, never in brand", () => {
+    const result = validateNumber("8810000000000003", {
+      customBrands: [acmeBrand],
+    });
+    expect(result.localBrands).toContain("acme-card");
+    expect(result.brand).toBeNull();
+  });
+
+  it("does not match a custom brand when customBrands is not passed", () => {
+    const result = validateNumber("8810000000000003");
+    expect(result.brand).toBeNull();
+    expect(result.localBrands).toEqual([]);
+    expect(result.isValid).toBe(false);
+  });
+
+  it("returns isValid true for a number with correct length and passing luhn", () => {
+    // 8810000000000003 is 16 digits and passes luhn
+    const result = validateNumber("8810000000000003", {
+      customBrands: [acmeBrand],
+    });
+    expect(result.isValid).toBe(true);
+  });
+
+  it("returns isValid false for a number with wrong length", () => {
+    const result = validateNumber("88100000000003", {
+      customBrands: [acmeBrand],
+    });
+    expect(result.localBrands).toContain("acme-card");
+    expect(result.isValid).toBe(false);
+  });
+
+  it("returns isValid false for a number that fails luhn", () => {
+    // 8810000000000001 is in range and 16 digits but fails luhn
+    const result = validateNumber("8810000000000001", {
+      customBrands: [acmeBrand],
+    });
+    expect(result.localBrands).toContain("acme-card");
+    expect(result.isValid).toBe(false);
+  });
+
+  it("skips luhn check when luhnCheck is false", () => {
+    // 9900000000000000 does not pass luhn but luhnCheck is false for noLuhnBrand
+    const result = validateNumber("9900000000000000", {
+      customBrands: [noLuhnBrand],
+    });
+    expect(result.localBrands).toContain("no-luhn-brand");
+    expect(result.isValid).toBe(true);
+  });
+
+  it("surfaces default brand in brand and custom brand in localBrands when both match", () => {
+    const result = validateNumber("4111111111111111", {
+      customBrands: [customVisaOverlap],
+    });
+    expect(result.brand).toBe("visa");
+    expect(result.localBrands).toContain("custom-visa-overlap");
+  });
+
+  it("each of multiple custom brands matches independently", () => {
+    const result = validateNumber("7700000000000000", {
+      customBrands: [acmeBrand, anotherBrand],
+    });
+    expect(result.localBrands).toContain("another-brand");
+    expect(result.localBrands).not.toContain("acme-card");
+  });
+
+  it("returns null brand, empty localBrands and isValid false when no brand matches", () => {
+    const result = validateNumber("0000000000000000", {
+      customBrands: [acmeBrand],
+    });
+    expect(result.brand).toBeNull();
+    expect(result.localBrands).toEqual([]);
+    expect(result.isValid).toBe(false);
+  });
+});
+
+describe("validateCVC with custom brands", () => {
+  it("accepts a CVC matching the custom brand's required length", () => {
+    const result = validateCVC("1234", "8810000000000003", {
+      customBrands: [acmeBrand],
+    });
+    expect(result.isValid).toBe(true);
+    expect(result.cvc).toBe("1234");
+  });
+
+  it("rejects a CVC not matching the custom brand's required length", () => {
+    const result = validateCVC("123", "8810000000000003", {
+      customBrands: [acmeBrand],
+    });
+    expect(result.isValid).toBe(false);
+    expect(result.cvc).toBeNull();
+  });
+
+  it("accepts a CVC that satisfies either the default or custom brand's rules when both match", () => {
+    // visa requires 3 digits, customVisaOverlap requires 4 — both match the card number
+    const result = validateCVC("123", "4111111111111111", {
+      customBrands: [customVisaOverlap],
+    });
+    expect(result.isValid).toBe(true);
+  });
+});

--- a/packages/card-validator/types.ts
+++ b/packages/card-validator/types.ts
@@ -2,7 +2,7 @@ import { CardBrandName } from "types";
 
 export type NumberValidationRules = {
   luhnCheck: boolean;
-  ranges: number[] | [number[]];
+  ranges: Array<number | [number, number]>;
   lengths: number[];
 };
 
@@ -10,20 +10,26 @@ export type SecurityCodeValidationRules = {
   lengths: number[];
 };
 
-export type CardBrand = {
-  name: CardBrandName;
-  isLocal: boolean;
+type BrandDefinition<
+  N extends string = string,
+  Local extends boolean = boolean
+> = {
+  name: N;
+  isLocal: Local;
   numberValidationRules: NumberValidationRules;
   securityCodeValidationRules: SecurityCodeValidationRules;
 };
 
-export type CardValidationOptions = {
-  acceptedBrands?: CardBrandName[];
+export type DefaultBrand = BrandDefinition<CardBrandName>;
+export type CustomBrand = BrandDefinition<string, true>;
+
+export type CardNumberValidationOptions = {
+  customBrands?: CustomBrand[];
 };
 
 export type CardNumberValidationResult = {
   brand: CardBrandName | null;
-  localBrands: CardBrandName[];
+  localBrands: string[];
   bin: string | null;
   lastFour: string | null;
   isValid: boolean;

--- a/packages/card-validator/types.ts
+++ b/packages/card-validator/types.ts
@@ -23,6 +23,14 @@ type BrandDefinition<
 export type DefaultBrand = BrandDefinition<CardBrandName>;
 export type CustomBrand = BrandDefinition<string, true>;
 
+/** @deprecated Use {@link DefaultBrand} instead */
+export type CardBrand = DefaultBrand;
+
+/** @deprecated No longer used internally */
+export type CardValidationOptions = {
+  acceptedBrands?: CardBrandName[];
+};
+
 export type CardNumberValidationOptions = {
   customBrands?: CustomBrand[];
 };

--- a/packages/react-native/src/components/Card/utilities.ts
+++ b/packages/react-native/src/components/Card/utilities.ts
@@ -79,8 +79,9 @@ export function isAcceptedBrand(
   const { brand, localBrands } = cardNumberValidationResult;
 
   const isBrandAccepted = brand !== null && acceptedBrands.includes(brand);
+  // TODO: Remove `as string[]` cast once @evervault/react-native is updated
   const isLocalBrandAccepted = localBrands.some((localBrand) =>
-    acceptedBrands.includes(localBrand)
+    (acceptedBrands as string[]).includes(localBrand)
   );
 
   return isBrandAccepted || isLocalBrandAccepted;

--- a/packages/ui-components/src/Card/BrandIcon.tsx
+++ b/packages/ui-components/src/Card/BrandIcon.tsx
@@ -9,7 +9,10 @@ export function BrandIcon({
   icons: CardIcons;
 }) {
   const { brand, localBrands } = validateNumber(number);
-  let icon = icons[brand ?? localBrands?.[0] ?? "default"];
+  // TODO: Remove ` as Record<string, string>` cast once @evervault/ui-components is updated
+  let icon = (icons as Record<string, string>)[
+    brand ?? localBrands?.[0] ?? "default"
+  ];
   icon = icon || icons.default;
 
   return (

--- a/packages/ui-components/src/Card/utilities.ts
+++ b/packages/ui-components/src/Card/utilities.ts
@@ -115,9 +115,11 @@ export function isAcceptedBrand(
   if (!acceptedBrands) return true;
   const { brand, localBrands } = cardNumberValidationResult;
 
-  const isBrandAccepted = brand !== null && acceptedBrands.includes(brand);
+  // TODO: Remove `as string[]` cast once @evervault/ui-components is updated
+  const isBrandAccepted =
+    brand !== null && (acceptedBrands as string[]).includes(brand);
   const isLocalBrandAccepted = localBrands.some((localBrand) =>
-    acceptedBrands.includes(localBrand)
+    (acceptedBrands as string[]).includes(localBrand)
   );
 
   return isBrandAccepted || isLocalBrandAccepted;


### PR DESCRIPTION
# Why
Adds support for custom card brand definitions in `@evervault/card-validator`. Part of the Custom Brands RFC.

Linear: https://linear.app/evervault/issue/CARD-724

# How
- Added a `Brand` type with an arbitrary `name: string` (as opposed to the closed `CardBrandName` union) alongside `NumberValidationRules` and `SecurityCodeValidationRules`
- Added `CardNumberValidationOptions` (`{ customBrands?: Brand[] }`) as an optional second argument to `validateNumber` and `validateCVC` — custom brands are merged with the built-in defaults at validation time
- Tightened `NumberValidationRules.ranges` from `number[] | [number[]]` to `Array<number | [number, number]>` now that this type is part of the public API
- Widened `CardNumberValidationResult.brand` and `localBrands` from `CardBrandName` to `string` to accommodate arbitrary custom brand names in results, with corresponding fixes in `react-native` and `ui-components`