### PR TITLE
Add custom brand support to JS SDK

### DIFF
--- a/.changeset/browser-js-custom-brands.md
+++ b/.changeset/browser-js-custom-brands.md
@@ -1,0 +1,6 @@
+---
+"@evervault/browser": minor
+"@evervault/js": minor
+---
+
+Add custom brand support to the browser SDK. The `brands.create(name, options)` method lets you define custom card brands. Pass them via the new `customBrands` option on `CardOptions` and they will be forwarded to the card iframe for validation.

--- a/.changeset/ui-components-custom-brands.md
+++ b/.changeset/ui-components-custom-brands.md
@@ -1,0 +1,5 @@
+---
+"@evervault/ui-components": minor
+---
+
+Pass customBrands from CardConfig into validateNumber and validateCVC. Custom brands participate in brand detection, BIN icon display, and are always accepted regardless of the acceptedBrands filter.

--- a/e2e-tests/ui-components/tests/customBrands.spec.js
+++ b/e2e-tests/ui-components/tests/customBrands.spec.js
@@ -152,6 +152,33 @@ test.describe("custom brands", () => {
     await expect.poll(async () => values.errors).toBeNull();
   });
 
+  test("custom brand iconSrc is shown when the card number matches", async ({
+    page,
+  }) => {
+    const ICON_SRC = "https://example.com/acme-icon.png";
+
+    await page.exposeFunction("handleChange", () => {});
+
+    await page.evaluate(
+      ({ customBrandOptions, iconSrc }) => {
+        const customBrand = window.evervault.brands.create("acme-card", {
+          ...customBrandOptions,
+          iconSrc,
+        });
+
+        const card = window.evervault.ui.card({ customBrands: [customBrand], icons: true });
+        card.on("change", window.handleChange);
+        card.mount("#form");
+      },
+      { customBrandOptions: CUSTOM_BRAND_OPTIONS, iconSrc: ICON_SRC }
+    );
+
+    const frame = page.frameLocator("iframe[data-evervault]");
+    await frame.getByLabel("Number").fill(CUSTOM_BRAND_CARD.number);
+
+    await expect(frame.locator(`img[src="${ICON_SRC}"]`)).toBeVisible();
+  });
+
   test("CVC is truncated to the maximum allowed length for the custom brand", async ({
     page,
   }) => {

--- a/e2e-tests/ui-components/tests/customBrands.spec.js
+++ b/e2e-tests/ui-components/tests/customBrands.spec.js
@@ -1,0 +1,153 @@
+import { test, expect, VALID_CARDS } from "../utils";
+
+// A custom brand used across tests.
+// Range [88000, 88999], 16 digits, Luhn-checked, 4-digit CVC.
+// Card number 8810000000000003 matches this range, is 16 digits, and passes Luhn.
+const CUSTOM_BRAND_CARD = {
+  number: "8810000000000003",
+  month: "01",
+  year: "35",
+  cvc: "1234",
+};
+
+function mountWithCustomBrands(page, opts = {}) {
+  return page.evaluate((opts) => {
+    const customBrand = window.evervault.brands.create("acme-card", {
+      numberValidationRules: {
+        luhnCheck: true,
+        ranges: [[88000, 88999]],
+        lengths: [16],
+      },
+      securityCodeValidationRules: {
+        lengths: [4],
+      },
+    });
+
+    const card = window.evervault.ui.card({
+      ...opts,
+      customBrands: [customBrand],
+    });
+    card.on("change", window.handleChange);
+    card.mount("#form");
+  }, opts);
+}
+
+test.describe("custom brands", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("http://localhost:4005");
+    await page.waitForFunction(() => window.Evervault);
+  });
+
+  test("custom brand is detected in localBrands and not in brand", async ({
+    page,
+  }) => {
+    let values = {};
+    await page.exposeFunction("handleChange", (newValues) => {
+      values = newValues;
+    });
+
+    await mountWithCustomBrands(page);
+
+    const frame = page.frameLocator("iframe[data-evervault]");
+    await frame.getByLabel("Number").fill(CUSTOM_BRAND_CARD.number);
+
+    await expect
+      .poll(async () => values.card?.localBrands)
+      .toContain("acme-card");
+    await expect.poll(async () => values.card?.brand).toBeNull();
+  });
+
+  test("custom brand card is valid with matching length, luhn, and CVC", async ({
+    page,
+  }) => {
+    let values = {};
+    await page.exposeFunction("handleChange", (newValues) => {
+      values = newValues;
+    });
+
+    await mountWithCustomBrands(page);
+
+    const frame = page.frameLocator("iframe[data-evervault]");
+    await frame.getByLabel("Number").fill(CUSTOM_BRAND_CARD.number);
+    await frame
+      .getByLabel("Expiration")
+      .fill(`${CUSTOM_BRAND_CARD.month}/${CUSTOM_BRAND_CARD.year}`);
+    await frame.getByLabel("CVC").fill(CUSTOM_BRAND_CARD.cvc);
+
+    await expect.poll(async () => values.isValid).toBeTruthy();
+    await expect.poll(async () => values.errors).toBeNull();
+  });
+
+  test("custom brand is accepted when acceptedBrands is set", async ({
+    page,
+  }) => {
+    let values = {};
+    await page.exposeFunction("handleChange", (newValues) => {
+      values = newValues;
+    });
+
+    await mountWithCustomBrands(page, { acceptedBrands: ["visa"] });
+
+    const frame = page.frameLocator("iframe[data-evervault]");
+    await frame.getByLabel("Number").fill(CUSTOM_BRAND_CARD.number);
+    await frame.getByLabel("Number").blur();
+
+    await expect(
+      frame.getByText("This card brand is not supported")
+    ).not.toBeVisible();
+    await expect
+      .poll(async () => values.errors?.number)
+      .not.toEqual("unsupportedBrand");
+  });
+
+  test("non-custom brand is rejected when acceptedBrands is empty", async ({
+    page,
+  }) => {
+    let values = {};
+    await page.exposeFunction("handleChange", (newValues) => {
+      values = newValues;
+    });
+
+    await mountWithCustomBrands(page, { acceptedBrands: [] });
+
+    const frame = page.frameLocator("iframe[data-evervault]");
+    await frame.getByLabel("Number").fill(VALID_CARDS.visa.number);
+    await frame.getByLabel("Number").blur();
+
+    await expect(
+      frame.getByText("This card brand is not supported")
+    ).toBeVisible();
+    await expect
+      .poll(async () => values.errors?.number)
+      .toEqual("unsupportedBrand");
+  });
+
+  test("CVC validation uses custom brand CVC length rules", async ({
+    page,
+  }) => {
+    let values = {};
+    await page.exposeFunction("handleChange", (newValues) => {
+      values = newValues;
+    });
+
+    await mountWithCustomBrands(page);
+
+    const frame = page.frameLocator("iframe[data-evervault]");
+    await frame.getByLabel("Number").fill(CUSTOM_BRAND_CARD.number);
+    await frame
+      .getByLabel("Expiration")
+      .fill(`${CUSTOM_BRAND_CARD.month}/${CUSTOM_BRAND_CARD.year}`);
+
+    // 3-digit CVC should be invalid for a brand requiring 4 digits
+    await frame.getByLabel("CVC").fill("123");
+    await frame.getByLabel("CVC").blur();
+    await expect(frame.getByText("Your CVC is invalid")).toBeVisible();
+    await expect.poll(async () => values.errors?.cvc).toEqual("invalid");
+
+    // 4-digit CVC should be valid
+    await frame.getByLabel("CVC").fill(CUSTOM_BRAND_CARD.cvc);
+    await expect
+      .poll(async () => values.errors?.cvc)
+      .toBeNull();
+  });
+});

--- a/e2e-tests/ui-components/tests/customBrands.spec.js
+++ b/e2e-tests/ui-components/tests/customBrands.spec.js
@@ -10,18 +10,20 @@ const CUSTOM_BRAND_CARD = {
   cvc: "1234",
 };
 
-function mountWithCustomBrands(page, opts = {}) {
-  return page.evaluate((opts) => {
-    const customBrand = window.evervault.brands.create("acme-card", {
-      numberValidationRules: {
-        luhnCheck: true,
-        ranges: [[88000, 88999]],
-        lengths: [16],
-      },
-      securityCodeValidationRules: {
-        lengths: [4],
-      },
-    });
+const CUSTOM_BRAND_OPTIONS = {
+  numberValidationRules: {
+    luhnCheck: true,
+    ranges: [[88000, 88999]],
+    lengths: [16],
+  },
+  securityCodeValidationRules: {
+    lengths: [4],
+  },
+};
+
+function mountWithCustomBrands(page, opts = {}, customBrandOptions = CUSTOM_BRAND_OPTIONS) {
+  return page.evaluate(({opts, customBrandOptions}) => {
+    const customBrand = window.evervault.brands.create("acme-card", customBrandOptions);
 
     const card = window.evervault.ui.card({
       ...opts,
@@ -29,7 +31,7 @@ function mountWithCustomBrands(page, opts = {}) {
     });
     card.on("change", window.handleChange);
     card.mount("#form");
-  }, opts);
+  }, {opts, customBrandOptions});
 }
 
 test.describe("custom brands", () => {
@@ -146,8 +148,44 @@ test.describe("custom brands", () => {
 
     // 4-digit CVC should be valid
     await frame.getByLabel("CVC").fill(CUSTOM_BRAND_CARD.cvc);
-    await expect
-      .poll(async () => values.errors?.cvc)
-      .toBeNull();
+    await expect.poll(async () => values.isValid).toBeTruthy();
+    await expect.poll(async () => values.errors).toBeNull();
+  });
+
+  test("CVC is truncated to the maximum allowed length for the custom brand", async ({
+    page,
+  }) => {
+    let values = {};
+    await page.exposeFunction("handleChange", (newValues) => {
+      values = newValues;
+    });
+
+    await mountWithCustomBrands(page, {}, {
+      ...CUSTOM_BRAND_OPTIONS,
+      securityCodeValidationRules: {
+        lengths: [3, 4],
+      },
+    });
+
+    const frame = page.frameLocator("iframe[data-evervault]");
+    await frame.getByLabel("Number").fill(CUSTOM_BRAND_CARD.number);
+    await frame
+      .getByLabel("Expiration")
+      .fill(`${CUSTOM_BRAND_CARD.month}/${CUSTOM_BRAND_CARD.year}`);
+
+    // 3-digit CVC should not be sliced
+    await frame.getByLabel("CVC").fill("123");
+    await frame.getByLabel("CVC").blur();
+    await expect(frame.getByLabel("CVC")).toHaveValue("123");
+
+    // 4-digit CVC should not be sliced
+    await frame.getByLabel("CVC").fill("1234");
+    await frame.getByLabel("CVC").blur();
+    await expect(frame.getByLabel("CVC")).toHaveValue("1234");
+
+    // >4-digit CVC should be sliced
+    await frame.getByLabel("CVC").fill("1234567890");
+    await frame.getByLabel("CVC").blur();
+    await expect(frame.getByLabel("CVC")).toHaveValue("1234");
   });
 });

--- a/packages/browser/lib/main.ts
+++ b/packages/browser/lib/main.ts
@@ -14,6 +14,8 @@ import {
 import type { InputSettings, RevealSettings } from "./types";
 import { Transaction } from "./resources/transaction";
 import {
+  BrandOptions,
+  CustomBrand,
   CreateTransactionDetails,
   DisbursementTransactionDetails,
   RecurringTransactionDetails,
@@ -327,6 +329,24 @@ export default class EvervaultClient {
           | RecurringTransactionDetails
           | DisbursementTransactionDetails
       ) => new Transaction(details),
+    };
+  }
+
+  get brands() {
+    return {
+      create: (name: string, options: BrandOptions): CustomBrand => ({
+        name,
+        isLocal: true,
+        numberValidationRules: {
+          luhnCheck: options.numberValidationRules.luhnCheck ?? true,
+          ranges: options.numberValidationRules.ranges,
+          lengths: options.numberValidationRules.lengths,
+        },
+        securityCodeValidationRules: {
+          lengths: options.securityCodeValidationRules.lengths,
+        },
+        iconSrc: options.iconSrc,
+      }),
     };
   }
 }

--- a/packages/browser/lib/ui/card.ts
+++ b/packages/browser/lib/ui/card.ts
@@ -111,6 +111,7 @@ export default class Card {
         hiddenFields: (this.#options.hiddenFields ?? [])?.join(","),
         fields: this.#options.fields,
         acceptedBrands: this.#options.acceptedBrands,
+        customBrands: this.#options.customBrands,
         defaultValues: this.#options.defaultValues,
         autoComplete: this.#options.autoComplete,
         autoProgress: this.#options.autoProgress,

--- a/packages/types/uiComponents.ts
+++ b/packages/types/uiComponents.ts
@@ -126,7 +126,7 @@ export interface BrandOptions {
     lengths: number[];
   };
   securityCodeValidationRules: {
-    lengths: number[];
+    lengths: (3 | 4)[];
   };
   iconSrc?: string;
 }
@@ -140,7 +140,7 @@ export interface CustomBrand {
     lengths: number[];
   };
   securityCodeValidationRules: {
-    lengths: number[];
+    lengths: (3 | 4)[];
   };
   iconSrc?: string;
 }

--- a/packages/types/uiComponents.ts
+++ b/packages/types/uiComponents.ts
@@ -101,6 +101,32 @@ export interface CardTranslations extends TranslationsObject {
 
 export type CardIcons = Record<CardBrandName | "default", string>;
 
+export interface BrandOptions {
+  numberValidationRules: {
+    luhnCheck?: boolean;
+    ranges: Array<number | [number, number]>;
+    lengths: number[];
+  };
+  securityCodeValidationRules: {
+    lengths: number[];
+  };
+  iconSrc?: string;
+}
+
+export interface CustomBrand {
+  name: string;
+  isLocal: true;
+  numberValidationRules: {
+    luhnCheck: boolean;
+    ranges: Array<number | [number, number]>;
+    lengths: number[];
+  };
+  securityCodeValidationRules: {
+    lengths: number[];
+  };
+  iconSrc?: string;
+}
+
 export interface CardOptions {
   colorScheme?: ColorScheme;
   icons?: boolean | CardIcons;
@@ -109,6 +135,7 @@ export interface CardOptions {
   hiddenFields?: ("number" | "expiry" | "cvc")[]; // deprecated
   fields?: CardField[];
   acceptedBrands?: CardBrandName[];
+  customBrands?: CustomBrand[];
   translations?: Partial<CardTranslations>;
   autoProgress?: boolean;
   redactCVC?: boolean;

--- a/packages/types/uiComponents.ts
+++ b/packages/types/uiComponents.ts
@@ -51,6 +51,24 @@ export type CardBrandName =
   | "uatp"
   | "rupay";
 
+export const CARD_BRAND_NAMES: CardBrandName[] = [
+  "american-express",
+  "visa",
+  "mastercard",
+  "discover",
+  "jcb",
+  "diners-club",
+  "unionpay",
+  "maestro",
+  "mir",
+  "elo",
+  "hipercard",
+  "hiper",
+  "szep",
+  "uatp",
+  "rupay",
+];
+
 export interface CardExpiry {
   month: string | null;
   year: string | null;

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -12,6 +12,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "preview": "vite preview",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -38,6 +39,7 @@
     "tsconfig": "workspace:*",
     "typescript": "catalog:",
     "vite": "catalog:",
-    "vite-plugin-istanbul": "catalog:"
+    "vite-plugin-istanbul": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/packages/ui-components/src/Card/BrandIcon.tsx
+++ b/packages/ui-components/src/Card/BrandIcon.tsx
@@ -1,6 +1,5 @@
 import { validateNumber } from "@evervault/card-validator";
 import { CustomBrand, CardIcons } from "types";
-import { isDefaultCardBrand } from "./utilities";
 
 export function BrandIcon({
   number,
@@ -12,16 +11,15 @@ export function BrandIcon({
   customBrands?: CustomBrand[];
 }) {
   const { brand, localBrands } = validateNumber(number, { customBrands });
-  const localBrand = localBrands[0];
-  const customBrand = customBrands?.find((b) => b.name === localBrand);
-  const brandName = brand ?? localBrand ?? "default";
-
-  let icon = customBrand?.iconSrc;
-  if (!icon && isDefaultCardBrand(brandName)) {
-    icon = icons[brandName];
-  }
-
-  icon = icon ?? icons.default;
+  const customIcons = Object.fromEntries(
+    customBrands?.map((b) => [b.name, b.iconSrc]) ?? []
+  );
+  const allIcons: Record<string, string | undefined> = {
+    ...icons,
+    ...customIcons,
+  };
+  // local or custom brand > global brand > default icon
+  const icon = allIcons[localBrands[0] ?? brand ?? "default"] ?? icons.default;
 
   return (
     <img

--- a/packages/ui-components/src/Card/BrandIcon.tsx
+++ b/packages/ui-components/src/Card/BrandIcon.tsx
@@ -1,19 +1,27 @@
 import { validateNumber } from "@evervault/card-validator";
-import { CardIcons } from "types";
+import { CustomBrand, CardIcons } from "types";
+import { isDefaultCardBrand } from "./utilities";
 
 export function BrandIcon({
   number,
   icons,
+  customBrands,
 }: {
   number: string;
   icons: CardIcons;
+  customBrands?: CustomBrand[];
 }) {
-  const { brand, localBrands } = validateNumber(number);
-  // TODO: Remove ` as Record<string, string>` cast once @evervault/ui-components is updated
-  let icon = (icons as Record<string, string>)[
-    brand ?? localBrands?.[0] ?? "default"
-  ];
-  icon = icon || icons.default;
+  const { brand, localBrands } = validateNumber(number, { customBrands });
+  const localBrand = localBrands[0];
+  const customBrand = customBrands?.find((b) => b.name === localBrand);
+  const brandName = brand ?? localBrand ?? "default";
+
+  let icon = customBrand?.iconSrc;
+  if (!icon && isDefaultCardBrand(brandName)) {
+    icon = icons[brandName];
+  }
+
+  icon = icon ?? icons.default;
 
   return (
     <img

--- a/packages/ui-components/src/Card/CardCVC.tsx
+++ b/packages/ui-components/src/Card/CardCVC.tsx
@@ -10,6 +10,27 @@ import {
 import { useMask } from "../utilities/useMask";
 import type { CustomBrand } from "types";
 
+export function getCVCMask(
+  cardNumber: string,
+  customBrands?: CustomBrand[]
+): string {
+  if (!cardNumber) return "0000";
+  const { brand, localBrands } = validateNumber(cardNumber, { customBrands });
+  if (brand === "american-express") return "0000";
+
+  const matchedCustomBrand = customBrands?.find((b) =>
+    localBrands.includes(b.name)
+  );
+  if (matchedCustomBrand) {
+    const maxLength = Math.max(
+      ...matchedCustomBrand.securityCodeValidationRules.lengths
+    );
+    return "0".repeat(maxLength);
+  }
+
+  return "000";
+}
+
 interface CVCProps {
   onChange: (v: string) => void;
   onBlur?: (e: FocusEvent<HTMLInputElement>) => void;
@@ -49,25 +70,10 @@ export const CardCVC = forwardRef<HTMLInputElement, CVCProps>(
 
     useImperativeHandle(forwardedRef, () => innerRef.current!);
 
-    const mask = useMemo(() => {
-      if (!cardNumber) return "0000";
-      const { brand, localBrands } = validateNumber(cardNumber, {
-        customBrands,
-      });
-      if (brand === "american-express") return "0000";
-
-      const matchedCustomBrand = customBrands?.find((b) =>
-        localBrands.includes(b.name)
-      );
-      if (matchedCustomBrand) {
-        const maxLength = Math.max(
-          ...matchedCustomBrand.securityCodeValidationRules.lengths
-        );
-        return "0".repeat(maxLength);
-      }
-
-      return "000";
-    }, [cardNumber, customBrands]);
+    const mask = useMemo(
+      () => getCVCMask(cardNumber, customBrands),
+      [cardNumber, customBrands]
+    );
 
     const { setValue } = useMask(innerRef, onChange, {
       mask,

--- a/packages/ui-components/src/Card/CardCVC.tsx
+++ b/packages/ui-components/src/Card/CardCVC.tsx
@@ -8,6 +8,7 @@ import {
   useRef,
 } from "react";
 import { useMask } from "../utilities/useMask";
+import type { CustomBrand } from "types";
 
 interface CVCProps {
   onChange: (v: string) => void;
@@ -22,6 +23,7 @@ interface CVCProps {
   cardNumber: string;
   autoComplete?: boolean;
   redact?: boolean;
+  customBrands?: CustomBrand[];
 }
 
 export const CardCVC = forwardRef<HTMLInputElement, CVCProps>(
@@ -39,6 +41,7 @@ export const CardCVC = forwardRef<HTMLInputElement, CVCProps>(
       onKeyUp,
       onKeyDown,
       redact,
+      customBrands,
     },
     forwardedRef
   ) => {
@@ -48,10 +51,23 @@ export const CardCVC = forwardRef<HTMLInputElement, CVCProps>(
 
     const mask = useMemo(() => {
       if (!cardNumber) return "0000";
-      const type = validateNumber(cardNumber).brand;
-      if (type === "american-express") return "0000";
+      const { brand, localBrands } = validateNumber(cardNumber, {
+        customBrands,
+      });
+      if (brand === "american-express") return "0000";
+
+      const matchedCustomBrand = customBrands?.find((b) =>
+        localBrands.includes(b.name)
+      );
+      if (matchedCustomBrand) {
+        const maxLength = Math.max(
+          ...matchedCustomBrand.securityCodeValidationRules.lengths
+        );
+        return "0".repeat(maxLength);
+      }
+
       return "000";
-    }, [cardNumber]);
+    }, [cardNumber, customBrands]);
 
     const { setValue } = useMask(innerRef, onChange, {
       mask,

--- a/packages/ui-components/src/Card/CardNumber.tsx
+++ b/packages/ui-components/src/Card/CardNumber.tsx
@@ -4,6 +4,7 @@ import { UseFormReturn } from "shared";
 import { useMask } from "../utilities/useMask";
 import { CardForm } from "./types";
 import type { CustomBrand } from "types";
+import { Masked } from "imask";
 
 interface CardNumberProps {
   disabled?: boolean;
@@ -28,7 +29,7 @@ interface CardMask {
   cardLength?: number;
 }
 
-function cardMaskFromLength(length: number): string {
+export function cardMaskFromLength(length: number): string {
   const parts = [];
   let remaining = length;
   while (remaining > 0) {
@@ -45,6 +46,32 @@ const BASE_MASKS: CardMask[] = [
 ];
 
 const BASE_LENGTHS = new Set(BASE_MASKS.map((m) => m.cardLength));
+
+export function getDynamicMask(
+  compiledMasks: CardMask[],
+  number: string,
+  opts?: { customBrands?: CustomBrand[] }
+): CardMask {
+  const { brand, localBrands } = validateNumber(number, {
+    customBrands: opts?.customBrands,
+  });
+
+  if (localBrands.length > 0 && opts?.customBrands) {
+    const matchedCustom = opts.customBrands.find((b) =>
+      localBrands.includes(b.name)
+    );
+    if (matchedCustom) {
+      const maxLength = Math.max(
+        ...matchedCustom.numberValidationRules.lengths
+      );
+      const customMask = compiledMasks.find((m) => m.cardLength === maxLength);
+      if (customMask) return customMask;
+    }
+  }
+
+  const brandMask = compiledMasks.find((m) => m.brand === brand);
+  return brandMask ?? compiledMasks[0];
+}
 
 export function CardNumber({
   autoFocus,
@@ -102,32 +129,13 @@ export function CardNumber({
   };
 
   const { setValue, mask } = useMask(ref, handleCardChange, {
-    mask: masks as CardMask[],
+    mask: masks,
     dispatch: (appended, dynamicMasked) => {
       const number = dynamicMasked.value + appended;
-      const { brand, localBrands } = validateNumber(number, { customBrands });
-
-      if (localBrands.length > 0 && customBrands) {
-        const matchedCustom = customBrands.find((b) =>
-          localBrands.includes(b.name)
-        );
-        if (matchedCustom) {
-          const maxLength = Math.max(
-            ...matchedCustom.numberValidationRules.lengths
-          );
-          const customMask = dynamicMasked.compiledMasks.find(
-            (m) => (m as CardMask).cardLength === maxLength
-          );
-          if (customMask) return customMask;
-        }
-      }
-
-      const brandMask = dynamicMasked.compiledMasks.find((m) => {
-        const maskBrand = (m as CardMask).brand;
-        return maskBrand === brand;
-      });
-
-      return brandMask ?? dynamicMasked.compiledMasks[0];
+      const compiledMasks = dynamicMasked.compiledMasks as CardMask[];
+      return getDynamicMask(compiledMasks, number, {
+        customBrands,
+      }) as Masked;
     },
   });
 

--- a/packages/ui-components/src/Card/CardNumber.tsx
+++ b/packages/ui-components/src/Card/CardNumber.tsx
@@ -1,8 +1,9 @@
 import { validateNumber } from "@evervault/card-validator";
-import { FocusEvent, useEffect, useRef } from "react";
+import { FocusEvent, useMemo, useEffect, useRef } from "react";
 import { UseFormReturn } from "shared";
 import { useMask } from "../utilities/useMask";
 import { CardForm } from "./types";
+import type { CustomBrand } from "types";
 
 interface CardNumberProps {
   disabled?: boolean;
@@ -18,12 +19,32 @@ interface CardNumberProps {
   autoComplete?: boolean;
   autoProgress?: boolean;
   form: UseFormReturn<CardForm>;
+  customBrands?: CustomBrand[];
 }
 
 interface CardMask {
   mask: string;
   brand?: string;
+  cardLength?: number;
 }
+
+function cardMaskFromLength(length: number): string {
+  const parts = [];
+  let remaining = length;
+  while (remaining > 0) {
+    parts.push("0".repeat(Math.min(4, remaining)));
+    remaining -= 4;
+  }
+  return parts.join(" ");
+}
+
+const BASE_MASKS: CardMask[] = [
+  { mask: "0000 0000 0000 0000", cardLength: 16 },
+  { mask: "0000 0000 0000 0000 000", brand: "unionpay", cardLength: 19 },
+  { mask: "0000 000000 00000", brand: "american-express", cardLength: 15 },
+];
+
+const BASE_LENGTHS = new Set(BASE_MASKS.map((m) => m.cardLength));
 
 export function CardNumber({
   autoFocus,
@@ -39,12 +60,38 @@ export function CardNumber({
   onFocus,
   onKeyUp,
   onKeyDown,
+  customBrands,
 }: CardNumberProps) {
   const ref = useRef<HTMLInputElement>(null);
 
+  const masks = useMemo<CardMask[]>(() => {
+    if (!customBrands?.length) return BASE_MASKS;
+    const extra: CardMask[] = [];
+    const seen = new Set(BASE_LENGTHS);
+    for (const brand of customBrands) {
+      const maxLength = Math.max(...brand.numberValidationRules.lengths);
+      if (!seen.has(maxLength)) {
+        seen.add(maxLength);
+        extra.push({
+          mask: cardMaskFromLength(maxLength),
+          cardLength: maxLength,
+        });
+      }
+    }
+    return [...BASE_MASKS, ...extra];
+  }, [customBrands]);
+
   const handleCardChange = (newValue: string) => {
-    const { brand } = validateNumber(newValue);
-    if (brand !== "american-express" && form.values.cvc.length === 4) {
+    const { brand, localBrands } = validateNumber(newValue, { customBrands });
+    const customBrandAllows4DigitCvc = customBrands?.some(
+      (b) =>
+        localBrands.includes(b.name) &&
+        b.securityCodeValidationRules.lengths.includes(4)
+    );
+    const allows4DigitCvc =
+      brand === "american-express" || customBrandAllows4DigitCvc;
+
+    if (!allows4DigitCvc && form.values.cvc.length > 3) {
       form.setValues((previous) => ({
         ...previous,
         cvc: previous.cvc.slice(0, 3),
@@ -55,29 +102,32 @@ export function CardNumber({
   };
 
   const { setValue, mask } = useMask(ref, handleCardChange, {
-    mask: [
-      {
-        mask: "0000 0000 0000 0000",
-      },
-      {
-        mask: "0000 0000 0000 0000 000",
-        brand: "unionpay",
-      },
-      {
-        mask: "0000 000000 00000",
-        brand: "american-express",
-      },
-    ] as CardMask[],
+    mask: masks as CardMask[],
     dispatch: (appended, dynamicMasked) => {
       const number = dynamicMasked.value + appended;
-      const { brand } = validateNumber(number);
+      const { brand, localBrands } = validateNumber(number, { customBrands });
 
-      const mask = dynamicMasked.compiledMasks.find((m) => {
+      if (localBrands.length > 0 && customBrands) {
+        const matchedCustom = customBrands.find((b) =>
+          localBrands.includes(b.name)
+        );
+        if (matchedCustom) {
+          const maxLength = Math.max(
+            ...matchedCustom.numberValidationRules.lengths
+          );
+          const customMask = dynamicMasked.compiledMasks.find(
+            (m) => (m as CardMask).cardLength === maxLength
+          );
+          if (customMask) return customMask;
+        }
+      }
+
+      const brandMask = dynamicMasked.compiledMasks.find((m) => {
         const maskBrand = (m as CardMask).brand;
         return maskBrand === brand;
       });
 
-      return mask ?? dynamicMasked.compiledMasks[0];
+      return brandMask ?? dynamicMasked.compiledMasks[0];
     },
   });
 

--- a/packages/ui-components/src/Card/index.tsx
+++ b/packages/ui-components/src/Card/index.tsx
@@ -282,6 +282,7 @@ export function Card({ config }: { config: CardConfig }) {
             autoComplete={config.autoComplete?.number ?? true}
             autoProgress={config.autoProgress}
             form={form}
+            customBrands={customBrands}
             onFocus={handleFocus("number")}
             onKeyUp={handleKeyUp("number")}
             onKeyDown={handleKeyDown("number")}
@@ -343,6 +344,7 @@ export function Card({ config }: { config: CardConfig }) {
             onKeyDown={handleKeyDown("cvc")}
             autoComplete={config.autoComplete?.cvc ?? true}
             redact={config.redactCVC}
+            customBrands={customBrands}
             {...form.register("cvc", {
               onBlur: handleBlur("cvc"),
             })}

--- a/packages/ui-components/src/Card/index.tsx
+++ b/packages/ui-components/src/Card/index.tsx
@@ -20,7 +20,7 @@ import { useCardReader } from "./useCardReader";
 import {
   changePayload,
   collectIcons,
-  isAcceptedBrand,
+  isBrandSupported,
   swipePayload,
 } from "./utilities";
 import type { CardForm, CardConfig } from "./types";
@@ -40,7 +40,7 @@ export function Card({ config }: { config: CardConfig }) {
   const ev = useEvervault();
   const { t } = useTranslations(DEFAULT_TRANSLATIONS, config?.translations);
 
-  const { acceptedBrands } = config;
+  const { acceptedBrands, customBrands } = config;
 
   const fields = useMemo(() => {
     let result = config.fields ?? ["number", "expiry", "cvc"];
@@ -80,12 +80,14 @@ export function Card({ config }: { config: CardConfig }) {
       number: (values) => {
         if (!fields.includes("number")) return undefined;
 
-        const cardValidation = validateNumber(values.number);
+        const cardValidation = validateNumber(values.number, { customBrands });
         if (!cardValidation.isValid) {
           return "invalid";
         }
 
-        if (!isAcceptedBrand(acceptedBrands, cardValidation)) {
+        if (
+          !isBrandSupported(cardValidation, { acceptedBrands, customBrands })
+        ) {
           return "unsupportedBrand";
         }
 
@@ -106,8 +108,10 @@ export function Card({ config }: { config: CardConfig }) {
         if (config.validation?.cvc?.optional && values.cvc.length === 0)
           return undefined;
 
-        const cardValidation = validateNumber(values.number);
-        const cvcValidation = validateCVC(values.cvc, values.number);
+        const cardValidation = validateNumber(values.number, { customBrands });
+        const cvcValidation = validateCVC(values.cvc, values.number, {
+          customBrands,
+        });
 
         if (!cvcValidation.isValid) {
           return "invalid";
@@ -128,6 +132,7 @@ export function Card({ config }: { config: CardConfig }) {
         const cardData = await changePayload(ev, formState, fields, {
           allow3DigitAmexCVC: config.allow3DigitAmexCVC,
           cvcOptional: config.validation?.cvc?.optional,
+          customBrands,
         });
 
         if (cardData.isComplete) {
@@ -173,6 +178,7 @@ export function Card({ config }: { config: CardConfig }) {
             const data = await changePayload(ev, formState, fields, {
               allow3DigitAmexCVC: config.allow3DigitAmexCVC,
               cvcOptional: config.validation?.cvc?.optional,
+              customBrands,
             });
             send("EV_VALIDATED", data);
           })();
@@ -186,6 +192,7 @@ export function Card({ config }: { config: CardConfig }) {
       fields,
       config.allow3DigitAmexCVC,
       config.validation?.cvc?.optional,
+      customBrands,
     ]
   );
 
@@ -262,6 +269,7 @@ export function Card({ config }: { config: CardConfig }) {
             <BrandIcon
               icons={collectIcons(config.icons)}
               number={form.values.number}
+              customBrands={customBrands}
             />
           )}
 

--- a/packages/ui-components/src/Card/types.ts
+++ b/packages/ui-components/src/Card/types.ts
@@ -1,4 +1,5 @@
 import type {
+  CustomBrand,
   ThemeObject,
   CardField,
   CardTranslations,
@@ -13,6 +14,7 @@ export interface CardConfig {
   hiddenFields?: ("number" | "expiry" | "cvc")[];
   fields?: CardField[];
   acceptedBrands?: CardBrandName[];
+  customBrands?: CustomBrand[];
   translations?: Partial<CardTranslations>;
   autoProgress?: boolean;
   redactCVC?: boolean;

--- a/packages/ui-components/src/Card/utilities.ts
+++ b/packages/ui-components/src/Card/utilities.ts
@@ -3,6 +3,7 @@ import {
   validateExpiry,
   validateCVC,
   CardNumberValidationResult,
+  CardNumberValidationOptions,
 } from "@evervault/card-validator";
 import { PromisifiedEvervaultClient } from "@evervault/react";
 import { UseFormReturn } from "shared";
@@ -171,9 +172,7 @@ async function encryptedCVC(
   ev: PromisifiedEvervaultClient,
   cvc: string,
   cardNumber: string,
-  opts?: {
-    customBrands?: CustomBrand[];
-  }
+  opts?: CardNumberValidationOptions
 ) {
   const { isValid } = validateCVC(cvc, cardNumber, opts);
 

--- a/packages/ui-components/src/Card/utilities.ts
+++ b/packages/ui-components/src/Card/utilities.ts
@@ -10,12 +10,14 @@ import { ICONS } from "./icons";
 import { MagStripeData } from "./useCardReader";
 import type { CardForm } from "./types";
 import type {
+  CustomBrand,
   CardBrandName,
   CardField,
   CardIcons,
   CardPayload,
   SwipedCard,
 } from "types";
+import { CARD_BRAND_NAMES } from "types";
 
 export async function changePayload(
   ev: PromisifiedEvervaultClient,
@@ -24,6 +26,7 @@ export async function changePayload(
   opts?: {
     allow3DigitAmexCVC?: boolean;
     cvcOptional?: boolean;
+    customBrands?: CustomBrand[];
   }
 ): Promise<CardPayload> {
   const { name, number, expiry, cvc } = form.values;
@@ -33,7 +36,7 @@ export async function changePayload(
     bin,
     lastFour,
     isValid: isValidCardNumber,
-  } = validateNumber(number);
+  } = validateNumber(number, { customBrands: opts?.customBrands });
 
   return {
     card: {
@@ -44,7 +47,9 @@ export async function changePayload(
       lastFour,
       number: isValidCardNumber ? await encryptedNumber(ev, number) : null,
       expiry: formatExpiry(expiry),
-      cvc: await encryptedCVC(ev, cvc, number),
+      cvc: await encryptedCVC(ev, cvc, number, {
+        customBrands: opts?.customBrands,
+      }),
     },
     isValid: form.isValid,
     isComplete: isComplete(form, fields, opts),
@@ -58,6 +63,7 @@ function isComplete(
   opts?: {
     allow3DigitAmexCVC?: boolean;
     cvcOptional?: boolean;
+    customBrands?: CustomBrand[];
   }
 ) {
   if (fields.includes("name")) {
@@ -65,7 +71,9 @@ function isComplete(
   }
 
   if (fields.includes("number")) {
-    const cardValidation = validateNumber(form.values.number);
+    const cardValidation = validateNumber(form.values.number, {
+      customBrands: opts?.customBrands,
+    });
     if (!cardValidation.isValid) return false;
   }
 
@@ -78,8 +86,12 @@ function isComplete(
     fields.includes("cvc") &&
     !(opts?.cvcOptional && form.values.cvc.length === 0)
   ) {
-    const cardValidation = validateNumber(form.values.number);
-    const cvcValidation = validateCVC(form.values.cvc, form.values.number);
+    const cardValidation = validateNumber(form.values.number, {
+      customBrands: opts?.customBrands,
+    });
+    const cvcValidation = validateCVC(form.values.cvc, form.values.number, {
+      customBrands: opts?.customBrands,
+    });
     if (!cvcValidation.isValid) return false;
 
     const allow3DigitAmex = opts?.allow3DigitAmexCVC ?? true;
@@ -113,19 +125,31 @@ export async function swipePayload(
   };
 }
 
-export function isAcceptedBrand(
-  acceptedBrands: CardBrandName[] | undefined,
-  cardNumberValidationResult: CardNumberValidationResult
-): boolean {
-  if (!acceptedBrands) return true;
-  const { brand, localBrands } = cardNumberValidationResult;
+export function isDefaultCardBrand(brand: string): brand is CardBrandName {
+  return (CARD_BRAND_NAMES as string[]).includes(brand);
+}
 
-  // TODO: Remove `as string[]` cast once @evervault/ui-components is updated
-  const isBrandAccepted =
-    brand !== null && (acceptedBrands as string[]).includes(brand);
-  const isLocalBrandAccepted = localBrands.some((localBrand) =>
-    (acceptedBrands as string[]).includes(localBrand)
-  );
+export function isBrandSupported(
+  cardNumberValidationResult: CardNumberValidationResult,
+  opts?: {
+    acceptedBrands?: CardBrandName[];
+    customBrands?: CustomBrand[];
+  }
+): boolean {
+  const { acceptedBrands, customBrands } = opts ?? {};
+  if (!acceptedBrands) return true;
+
+  const { brand, localBrands } = cardNumberValidationResult;
+  const customBrandNames = customBrands?.map((b) => b.name) ?? [];
+
+  const isBrandAccepted = brand !== null && acceptedBrands.includes(brand);
+
+  const isLocalBrandAccepted = localBrands.some((localBrand) => {
+    if (isDefaultCardBrand(localBrand)) {
+      return acceptedBrands.includes(localBrand);
+    }
+    return customBrandNames.includes(localBrand);
+  });
 
   return isBrandAccepted || isLocalBrandAccepted;
 }
@@ -146,9 +170,12 @@ async function encryptedNumber(ev: PromisifiedEvervaultClient, number: string) {
 async function encryptedCVC(
   ev: PromisifiedEvervaultClient,
   cvc: string,
-  cardNumber: string
+  cardNumber: string,
+  opts?: {
+    customBrands?: CustomBrand[];
+  }
 ) {
-  const { isValid } = validateCVC(cvc, cardNumber);
+  const { isValid } = validateCVC(cvc, cardNumber, opts);
 
   if (!isValid) return null;
   return ev.encrypt(cvc);

--- a/packages/ui-components/src/Card/utilities.ts
+++ b/packages/ui-components/src/Card/utilities.ts
@@ -125,7 +125,7 @@ export async function swipePayload(
   };
 }
 
-export function isDefaultCardBrand(brand: string): brand is CardBrandName {
+function isDefaultCardBrand(brand: string): brand is CardBrandName {
   return (CARD_BRAND_NAMES as string[]).includes(brand);
 }
 

--- a/packages/ui-components/test/card-cvc-mask.test.ts
+++ b/packages/ui-components/test/card-cvc-mask.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { getCVCMask } from "../src/Card/CardCVC";
+import type { CustomBrand } from "types";
+
+const acmeBrand: CustomBrand = {
+  name: "acme-card",
+  isLocal: true,
+  numberValidationRules: {
+    luhnCheck: true,
+    ranges: [[88000, 88999]],
+    lengths: [16],
+  },
+  securityCodeValidationRules: { lengths: [3, 4] },
+};
+
+describe("getCVCMask", () => {
+  it("returns 4-digit mask when cardNumber is empty", () => {
+    expect(getCVCMask("")).toBe("0000");
+  });
+
+  it("returns 4-digit mask for american-express", () => {
+    expect(getCVCMask("378282246310005")).toBe("0000");
+  });
+
+  it("returns 3-digit mask for a standard card (visa)", () => {
+    expect(getCVCMask("4111111111111111")).toBe("000");
+  });
+
+  it("returns mask matching the custom brand max CVC length (4 digits)", () => {
+    expect(getCVCMask("8810000000000003", [acmeBrand])).toBe("0000");
+  });
+
+  it("falls back to 3-digit mask when no custom brand matches the card number", () => {
+    expect(getCVCMask("4111111111111111", [acmeBrand])).toBe("000");
+  });
+});

--- a/packages/ui-components/test/card-number-mask.test.ts
+++ b/packages/ui-components/test/card-number-mask.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { cardMaskFromLength, getDynamicMask } from "../src/Card/CardNumber";
+import type { CustomBrand } from "types";
+
+// Uses a 17-digit length so the custom mask is distinct from any BASE_MASK entry.
+const acmeBrand: CustomBrand = {
+  name: "acme-card",
+  isLocal: true,
+  numberValidationRules: {
+    luhnCheck: false,
+    ranges: [[8800, 8899]],
+    lengths: [17],
+  },
+  securityCodeValidationRules: { lengths: [4] },
+};
+
+describe("cardMaskFromLength", () => {
+  it("produces a space-separated groups-of-4 mask for 16 digits", () => {
+    expect(cardMaskFromLength(16)).toBe("0000 0000 0000 0000");
+  });
+
+  it("handles lengths that are not a multiple of 4", () => {
+    expect(cardMaskFromLength(7)).toBe("0000 000");
+  });
+
+  it("handles a 19-digit card (unionpay)", () => {
+    expect(cardMaskFromLength(19)).toBe("0000 0000 0000 0000 000");
+  });
+
+  it("handles a short single-group length", () => {
+    expect(cardMaskFromLength(4)).toBe("0000");
+  });
+});
+
+describe("getDynamicMask", () => {
+  const base16 = { mask: "0000 0000 0000 0000", cardLength: 16 };
+  const amex = {
+    mask: "0000 000000 00000",
+    brand: "american-express",
+    cardLength: 15,
+  };
+  const unionpay = {
+    mask: "0000 0000 0000 0000 000",
+    brand: "unionpay",
+    cardLength: 19,
+  };
+  const compiledMasks = [base16, amex, unionpay];
+
+  it("returns the default 16-digit mask when no brand is matched", () => {
+    const result = getDynamicMask(compiledMasks, "0000");
+    expect(result).toBe(base16);
+  });
+
+  it("returns the amex mask for an american-express number", () => {
+    const result = getDynamicMask(compiledMasks, "3782");
+    expect(result).toBe(amex);
+  });
+
+  it("returns the unionpay mask for a unionpay number", () => {
+    const result = getDynamicMask(compiledMasks, "6240");
+    expect(result).toBe(unionpay);
+  });
+
+  it("returns the custom brand mask when a custom brand matches", () => {
+    const custom17 = { mask: "0000 000000000000 0", cardLength: 17 };
+    const masks = [...compiledMasks, custom17];
+    const result = getDynamicMask(masks, "8810", { customBrands: [acmeBrand] });
+    expect(result).toBe(custom17);
+  });
+
+  it("falls back to default mask when no compiled mask exists for the custom brand length", () => {
+    // compiledMasks has no 17-digit entry, so it falls through to the default
+    const result = getDynamicMask(compiledMasks, "8810", {
+      customBrands: [acmeBrand],
+    });
+    expect(result).toBe(base16);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1192,6 +1192,9 @@ importers:
       vite-plugin-istanbul:
         specifier: 'catalog:'
         version: 7.2.1(vite@7.3.3(@types/node@24.10.10)(lightningcss@1.27.0)(terser@5.39.0)(yaml@2.9.0))
+      vitest:
+        specifier: 'catalog:'
+        version: 4.0.18(@types/node@24.10.10)(jsdom@22.1.0)(lightningcss@1.27.0)(msw@2.12.8(@types/node@24.10.10)(typescript@5.5.4))(terser@5.39.0)(yaml@2.9.0)
 
 packages:
 
@@ -20977,6 +20980,44 @@ snapshots:
       react-native: 0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0)
       regenerator-runtime: 0.13.11
       vite: 7.3.3(@types/node@24.10.10)(lightningcss@1.27.0)(terser@5.39.0)(yaml@2.9.0)
+
+  vitest@4.0.18(@types/node@24.10.10)(jsdom@22.1.0)(lightningcss@1.27.0)(msw@2.12.8(@types/node@24.10.10)(typescript@5.5.4))(terser@5.39.0)(yaml@2.9.0):
+    dependencies:
+      '@vitest/expect': 4.0.18
+      '@vitest/mocker': 4.0.18(msw@2.12.8(@types/node@24.10.10)(typescript@5.5.4))(vite@7.3.3(@types/node@24.10.10)(lightningcss@1.27.0)(terser@5.39.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.0.18
+      '@vitest/runner': 4.0.18
+      '@vitest/snapshot': 4.0.18
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      es-module-lexer: 1.7.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 7.3.3(@types/node@24.10.10)(lightningcss@1.27.0)(terser@5.39.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.10.10
+      jsdom: 22.1.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
 
   vitest@4.0.18(@types/node@24.10.10)(jsdom@25.0.1)(lightningcss@1.27.0)(msw@2.12.8(@types/node@24.10.10)(typescript@5.5.4))(terser@5.39.0)(yaml@2.9.0):
     dependencies:


### PR DESCRIPTION
# Why

Adds the public API surface for custom card brands to the browser SDK and wires them through to the card iframe for validation.

Part of the Custom Brands RFC. Blocked on CARD-724.

Linear: CARD-725 (CARD-726, CARD-727, CARD-728)

# How

- Added `CustomBrand` and `BrandOptions` types to the shared `types` package, alongside a `CARD_BRAND_NAMES` constant used for brand type narrowing
- Added `brands.create(name, options)` to `EvervaultClient`, consistent with the `transactions.create` pattern. Always sets `isLocal: true` — custom brands are always local by design
- Added `customBrands?: CustomBrand[]` to `CardOptions` and `CardConfig`
- Wired `customBrands` through the postMessage layer (`EV_INIT` / `EV_UPDATE`) so the card iframe receives brand definitions before validation begins
- Passed `customBrands` into all `validateNumber` and `validateCVC` calls inside the iframe
- Updated `BrandIcon` to show a custom brand's `iconSrc` when matched, falling back to the default icon set
- Custom brands are always accepted regardless of `acceptedBrands` — `isBrandSupported` handles this by short-circuiting on any brand found in `localBrands` that matches a custom brand name