### PR TITLE
Add custom brand support to React SDK

### DIFF
--- a/.changeset/react-custom-brands.md
+++ b/.changeset/react-custom-brands.md
@@ -1,0 +1,5 @@
+---
+"@evervault/react": minor
+---
+
+Add `customBrands` prop to the `<Card>` component in the React SDK. Pass an array of `CustomBrand` objects to enable custom card brand validation. `BrandOptions` and `CustomBrand` types are re-exported from `@evervault/react`.

--- a/packages/browser/lib/main.ts
+++ b/packages/browser/lib/main.ts
@@ -14,12 +14,11 @@ import {
 import type { InputSettings, RevealSettings } from "./types";
 import { Transaction } from "./resources/transaction";
 import {
-  BrandOptions,
-  CustomBrand,
   CreateTransactionDetails,
   DisbursementTransactionDetails,
   RecurringTransactionDetails,
 } from "types";
+import { createBrand } from "shared/createBrand";
 
 export type * from "types";
 export type * from "./config";
@@ -333,20 +332,6 @@ export default class EvervaultClient {
   }
 
   get brands() {
-    return {
-      create: (name: string, options: BrandOptions): CustomBrand => ({
-        name,
-        isLocal: true,
-        numberValidationRules: {
-          luhnCheck: options.numberValidationRules.luhnCheck ?? true,
-          ranges: options.numberValidationRules.ranges,
-          lengths: options.numberValidationRules.lengths,
-        },
-        securityCodeValidationRules: {
-          lengths: options.securityCodeValidationRules.lengths,
-        },
-        iconSrc: options.iconSrc,
-      }),
-    };
+    return { create: createBrand };
   }
 }

--- a/packages/browser/lib/main.ts
+++ b/packages/browser/lib/main.ts
@@ -14,6 +14,7 @@ import {
 import type { InputSettings, RevealSettings } from "./types";
 import { Transaction } from "./resources/transaction";
 import {
+  BrandOptions,
   CreateTransactionDetails,
   DisbursementTransactionDetails,
   RecurringTransactionDetails,
@@ -332,6 +333,9 @@ export default class EvervaultClient {
   }
 
   get brands() {
-    return { create: createBrand };
+    return {
+      create: (name: string, options: BrandOptions) =>
+        createBrand(name, options),
+    };
   }
 }

--- a/packages/react/lib/load.ts
+++ b/packages/react/lib/load.ts
@@ -1,4 +1,5 @@
 import EvervaultClient, {
+  BrandOptions,
   CustomConfig as BrowserConfig,
 } from "@evervault/browser";
 import { createBrand } from "shared";
@@ -17,7 +18,10 @@ export class PromisifiedEvervaultClient extends Promise<EvervaultClient> {
   }
 
   get brands() {
-    return { create: createBrand };
+    return {
+      create: (name: string, options: BrandOptions) =>
+        createBrand(name, options),
+    };
   }
 }
 

--- a/packages/react/lib/load.ts
+++ b/packages/react/lib/load.ts
@@ -1,8 +1,7 @@
 import EvervaultClient, {
   CustomConfig as BrowserConfig,
-  BrandOptions,
-  CustomBrand,
 } from "@evervault/browser";
+import { createBrand } from "shared";
 import React, { useMemo } from "react";
 import { useId } from "react";
 
@@ -18,21 +17,7 @@ export class PromisifiedEvervaultClient extends Promise<EvervaultClient> {
   }
 
   get brands() {
-    return {
-      create: (name: string, options: BrandOptions): CustomBrand => ({
-        name,
-        isLocal: true,
-        numberValidationRules: {
-          luhnCheck: options.numberValidationRules.luhnCheck ?? true,
-          ranges: options.numberValidationRules.ranges,
-          lengths: options.numberValidationRules.lengths,
-        },
-        securityCodeValidationRules: {
-          lengths: options.securityCodeValidationRules.lengths,
-        },
-        iconSrc: options.iconSrc,
-      }),
-    };
+    return { create: createBrand };
   }
 }
 

--- a/packages/react/lib/load.ts
+++ b/packages/react/lib/load.ts
@@ -1,5 +1,7 @@
 import EvervaultClient, {
   CustomConfig as BrowserConfig,
+  BrandOptions,
+  CustomBrand,
 } from "@evervault/browser";
 import React, { useMemo } from "react";
 import { useId } from "react";
@@ -13,6 +15,24 @@ export class PromisifiedEvervaultClient extends Promise<EvervaultClient> {
   public async decrypt(token: string, data: unknown) {
     const ev = await this;
     return ev.decrypt(token, data);
+  }
+
+  get brands() {
+    return {
+      create: (name: string, options: BrandOptions): CustomBrand => ({
+        name,
+        isLocal: true,
+        numberValidationRules: {
+          luhnCheck: options.numberValidationRules.luhnCheck ?? true,
+          ranges: options.numberValidationRules.ranges,
+          lengths: options.numberValidationRules.lengths,
+        },
+        securityCodeValidationRules: {
+          lengths: options.securityCodeValidationRules.lengths,
+        },
+        iconSrc: options.iconSrc,
+      }),
+    };
   }
 }
 

--- a/packages/react/lib/ui/Card.tsx
+++ b/packages/react/lib/ui/Card.tsx
@@ -8,6 +8,7 @@ import type {
   CardPayload,
   CardTranslations,
   ColorScheme,
+  CustomBrand,
   FieldEvent,
   SwipedCard,
   ThemeDefinition,
@@ -43,6 +44,7 @@ export interface CardProps {
   redactCVC?: boolean;
   allow3DigitAmexCVC?: boolean;
   validation?: CardOptions["validation"];
+  customBrands?: CustomBrand[];
 }
 
 type CardInstance = ReturnType<EvervaultClient["ui"]["card"]>;
@@ -72,6 +74,7 @@ export const Card = React.forwardRef<CardRef, CardProps>(function Card(
     redactCVC,
     allow3DigitAmexCVC,
     validation,
+    customBrands,
   }: CardProps,
   forwardedRef
 ) {
@@ -105,6 +108,7 @@ export const Card = React.forwardRef<CardRef, CardProps>(function Card(
       redactCVC,
       allow3DigitAmexCVC,
       validation,
+      customBrands,
     }),
     [
       colorScheme,
@@ -120,6 +124,7 @@ export const Card = React.forwardRef<CardRef, CardProps>(function Card(
       redactCVC,
       allow3DigitAmexCVC,
       validation,
+      customBrands,
     ]
   );
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "@evervault/browser": "workspace:*",
+    "shared": "workspace:*",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "@vitejs/plugin-react": "catalog:",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -5,7 +5,8 @@
   "main": "src/index.ts",
   "exports": {
     ".": "./src/index.ts",
-    "./getAppSDKConfig": "./src/getAppSDKConfig.ts"
+    "./getAppSDKConfig": "./src/getAppSDKConfig.ts",
+    "./createBrand": "./src/createBrand.ts"
   },
   "dependencies": {
     "types": "workspace:*",

--- a/packages/shared/src/createBrand.ts
+++ b/packages/shared/src/createBrand.ts
@@ -1,0 +1,17 @@
+import { BrandOptions, CustomBrand } from "types";
+
+export function createBrand(name: string, options: BrandOptions): CustomBrand {
+  return {
+    name,
+    isLocal: true,
+    numberValidationRules: {
+      luhnCheck: options.numberValidationRules.luhnCheck ?? true,
+      ranges: options.numberValidationRules.ranges,
+      lengths: options.numberValidationRules.lengths,
+    },
+    securityCodeValidationRules: {
+      lengths: options.securityCodeValidationRules.lengths,
+    },
+    iconSrc: options.iconSrc,
+  };
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./createBrand";
 export * from "./useForm";
 export * from "./useTranslations";
 export * from "./getAppSDKConfig";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -945,6 +945,9 @@ importers:
       react-dom:
         specifier: 'catalog:'
         version: 18.2.0(react@18.2.0)
+      shared:
+        specifier: workspace:*
+        version: link:../shared
       themes:
         specifier: workspace:*
         version: link:../themes


### PR DESCRIPTION
# Why
Part of the Custom Brands feature ([CARD-729](https://linear.app/evervault/issue/CARD-729/add-custom-brand-support-to-react-sdk)).

Exposes `customBrands` in the React SDK's `<Card>` component so consumers can pass custom card brand definitions without importing types from `@evervault/browser` directly.

# How
- Added `customBrands?: CustomBrand[]` prop to `CardProps` in `@evervault/react`
- Added `customBrands` to the `useMemo` config object and its dependency array so re-renders propagate changes correctly via `instance.update(config)`
- `BrandOptions` and `CustomBrand` types are re-exported from `@evervault/react` via the existing `export type * from "types"` — no extra changes needed
- Added changeset for a minor version bump