### PR TITLE
feat: allow optional cvc

### DIFF
--- a/.changeset/clever-hairs-bake.md
+++ b/.changeset/clever-hairs-bake.md
@@ -1,0 +1,6 @@
+---
+"types": minor
+"@evervault/ui-components": minor
+---
+
+feat: allow optional cvc

--- a/e2e-tests/ui-components/tests/cardDetails.spec.js
+++ b/e2e-tests/ui-components/tests/cardDetails.spec.js
@@ -922,6 +922,111 @@ test.describe("card component", () => {
     await expect.poll(async () => values.isValid).toBeTruthy();
   });
 
+  test("optional CVC: form is valid and complete with empty CVC", async ({
+    page,
+  }) => {
+    let values = {};
+
+    await page.exposeFunction("handleChange", (newValues) => {
+      values = newValues;
+    });
+
+    await page.evaluate(() => {
+      const card = window.evervault.ui.card({
+        validation: { cvc: { optional: true } },
+      });
+      card.on("change", window.handleChange);
+      card.mount("#form");
+    });
+
+    const frame = page.frameLocator("iframe[data-evervault]");
+    await frame.getByLabel("Number").fill("4242424242424242");
+    await frame.getByLabel("Expiration").fill(getFutureExpiration());
+    await frame.getByLabel("CVC").focus();
+    await frame.getByLabel("CVC").blur();
+    await expect.poll(async () => values.isValid).toBeTruthy();
+    await expect.poll(async () => values.isComplete).toBeTruthy();
+    await expect.poll(async () => values.errors).toBeNull();
+    await expect(frame.getByText("Your CVC is invalid")).not.toBeVisible();
+  });
+
+  test("optional CVC: partial CVC still shows an error", async ({ page }) => {
+    let values = {};
+
+    await page.exposeFunction("handleChange", (newValues) => {
+      values = newValues;
+    });
+
+    await page.evaluate(() => {
+      const card = window.evervault.ui.card({
+        validation: { cvc: { optional: true } },
+      });
+      card.on("change", window.handleChange);
+      card.mount("#form");
+    });
+
+    const frame = page.frameLocator("iframe[data-evervault]");
+    await frame.getByLabel("Number").fill("4242424242424242");
+    await frame.getByLabel("Expiration").fill(getFutureExpiration());
+    await frame.getByLabel("CVC").fill("12");
+    await frame.getByLabel("CVC").blur();
+    await expect(frame.getByText("Your CVC is invalid")).toBeVisible();
+    await expect.poll(async () => values.errors?.cvc).toEqual("invalid");
+    await expect.poll(async () => values.isComplete).toBeFalsy();
+  });
+
+  test("optional CVC: valid CVC is accepted and encrypted", async ({
+    page,
+  }) => {
+    let values = {};
+
+    await page.exposeFunction("handleChange", (newValues) => {
+      values = newValues;
+    });
+
+    await page.evaluate(() => {
+      const card = window.evervault.ui.card({
+        validation: { cvc: { optional: true } },
+      });
+      card.on("change", window.handleChange);
+      card.mount("#form");
+    });
+
+    const frame = page.frameLocator("iframe[data-evervault]");
+    await frame.getByLabel("Number").fill("4242424242424242");
+    await frame.getByLabel("Expiration").fill(getFutureExpiration());
+    await frame.getByLabel("CVC").fill("123");
+    await frame.getByLabel("CVC").blur();
+    await expect.poll(async () => values.isValid).toBeTruthy();
+    await expect.poll(async () => values.isComplete).toBeTruthy();
+    await expect.poll(async () => values.card?.cvc).toBeEncrypted();
+    await expect(frame.getByText("Your CVC is invalid")).not.toBeVisible();
+  });
+
+  test("optional CVC: CVC is mandatory when optional is not set", async ({
+    page,
+  }) => {
+    let values = {};
+
+    await page.exposeFunction("handleChange", (newValues) => {
+      values = newValues;
+    });
+
+    await page.evaluate(() => {
+      const card = window.evervault.ui.card();
+      card.on("change", window.handleChange);
+      card.mount("#form");
+    });
+
+    const frame = page.frameLocator("iframe[data-evervault]");
+    await frame.getByLabel("Number").fill("4242424242424242");
+    await frame.getByLabel("Expiration").fill(getFutureExpiration());
+    await frame.getByLabel("CVC").focus();
+    await frame.getByLabel("CVC").blur();
+    await expect.poll(async () => values.isComplete).toBeFalsy();
+    await expect(frame.getByText("Your CVC is invalid")).toBeVisible();
+  });
+
   test("Can add custom validation for the name field", async ({ page }) => {
     await page.evaluate(() => {
       const card = window.evervault.ui.card({

--- a/e2e-tests/ui-components/tests/cardDetails.spec.js
+++ b/e2e-tests/ui-components/tests/cardDetails.spec.js
@@ -972,6 +972,7 @@ test.describe("card component", () => {
     await frame.getByLabel("CVC").blur();
     await expect(frame.getByText("Your CVC is invalid")).toBeVisible();
     await expect.poll(async () => values.errors?.cvc).toEqual("invalid");
+    await expect.poll(async () => values.isValid).toBeFalsy();
     await expect.poll(async () => values.isComplete).toBeFalsy();
   });
 
@@ -1023,6 +1024,7 @@ test.describe("card component", () => {
     await frame.getByLabel("Expiration").fill(getFutureExpiration());
     await frame.getByLabel("CVC").focus();
     await frame.getByLabel("CVC").blur();
+    await expect.poll(async () => values.isValid).toBeFalsy();
     await expect.poll(async () => values.isComplete).toBeFalsy();
     await expect(frame.getByText("Your CVC is invalid")).toBeVisible();
   });

--- a/packages/types/uiComponents.ts
+++ b/packages/types/uiComponents.ts
@@ -126,6 +126,9 @@ export interface CardOptions {
     name?: {
       regex?: RegExp;
     };
+    cvc?: {
+      optional?: boolean;
+    };
   };
 }
 

--- a/packages/ui-components/src/Card/index.tsx
+++ b/packages/ui-components/src/Card/index.tsx
@@ -103,6 +103,7 @@ export function Card({ config }: { config: CardConfig }) {
       },
       cvc: (values) => {
         if (!fields.includes("cvc")) return undefined;
+        if (config.validation?.cvc?.optional && values.cvc.length === 0) return undefined;
 
         const cardValidation = validateNumber(values.number);
         const cvcValidation = validateCVC(values.cvc, values.number);
@@ -125,6 +126,7 @@ export function Card({ config }: { config: CardConfig }) {
         if (!ev) return;
         const cardData = await changePayload(ev, formState, fields, {
           allow3DigitAmexCVC: config.allow3DigitAmexCVC,
+          cvcOptional: config.validation?.cvc?.optional,
         });
 
         if (cardData.isComplete) {
@@ -169,12 +171,13 @@ export function Card({ config }: { config: CardConfig }) {
           void (async () => {
             const data = await changePayload(ev, formState, fields, {
               allow3DigitAmexCVC: config.allow3DigitAmexCVC,
+              cvcOptional: config.validation?.cvc?.optional,
             });
             send("EV_VALIDATED", data);
           })();
         });
       }),
-    [ev, on, send, form, fields, config.allow3DigitAmexCVC]
+    [ev, on, send, form, fields, config.allow3DigitAmexCVC, config.validation?.cvc?.optional]
   );
 
   useEffect(

--- a/packages/ui-components/src/Card/index.tsx
+++ b/packages/ui-components/src/Card/index.tsx
@@ -103,7 +103,8 @@ export function Card({ config }: { config: CardConfig }) {
       },
       cvc: (values) => {
         if (!fields.includes("cvc")) return undefined;
-        if (config.validation?.cvc?.optional && values.cvc.length === 0) return undefined;
+        if (config.validation?.cvc?.optional && values.cvc.length === 0)
+          return undefined;
 
         const cardValidation = validateNumber(values.number);
         const cvcValidation = validateCVC(values.cvc, values.number);
@@ -177,7 +178,15 @@ export function Card({ config }: { config: CardConfig }) {
           })();
         });
       }),
-    [ev, on, send, form, fields, config.allow3DigitAmexCVC, config.validation?.cvc?.optional]
+    [
+      ev,
+      on,
+      send,
+      form,
+      fields,
+      config.allow3DigitAmexCVC,
+      config.validation?.cvc?.optional,
+    ]
   );
 
   useEffect(

--- a/packages/ui-components/src/Card/types.ts
+++ b/packages/ui-components/src/Card/types.ts
@@ -30,6 +30,9 @@ export interface CardConfig {
     name?: {
       regex?: RegExp;
     };
+    cvc?: {
+      optional?: boolean;
+    };
   };
 }
 

--- a/packages/ui-components/src/Card/utilities.ts
+++ b/packages/ui-components/src/Card/utilities.ts
@@ -23,6 +23,7 @@ export async function changePayload(
   fields: CardField[],
   opts?: {
     allow3DigitAmexCVC?: boolean;
+    cvcOptional?: boolean;
   }
 ): Promise<CardPayload> {
   const { name, number, expiry, cvc } = form.values;
@@ -56,6 +57,7 @@ function isComplete(
   fields: CardField[],
   opts?: {
     allow3DigitAmexCVC?: boolean;
+    cvcOptional?: boolean;
   }
 ) {
   if (fields.includes("name")) {
@@ -72,7 +74,7 @@ function isComplete(
     if (!expiryValidation.isValid) return false;
   }
 
-  if (fields.includes("cvc")) {
+  if (fields.includes("cvc") && !(opts?.cvcOptional && form.values.cvc.length === 0)) {
     const cardValidation = validateNumber(form.values.number);
     const cvcValidation = validateCVC(form.values.cvc, form.values.number);
     if (!cvcValidation.isValid) return false;

--- a/packages/ui-components/src/Card/utilities.ts
+++ b/packages/ui-components/src/Card/utilities.ts
@@ -74,7 +74,10 @@ function isComplete(
     if (!expiryValidation.isValid) return false;
   }
 
-  if (fields.includes("cvc") && !(opts?.cvcOptional && form.values.cvc.length === 0)) {
+  if (
+    fields.includes("cvc") &&
+    !(opts?.cvcOptional && form.values.cvc.length === 0)
+  ) {
     const cardValidation = validateNumber(form.values.number);
     const cvcValidation = validateCVC(form.values.cvc, form.values.number);
     if (!cvcValidation.isValid) return false;


### PR DESCRIPTION
Creates a new `validation.cvc.optional` option. If enabled, an empty field passes validation, otherwise regular CVC validation is enforced.
