### PR TITLE
chore: force @xmldom/xmldom to 0.8.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
       "@isaacs/brace-expansion": "^5.0.1",
       "@babel/plugin-transform-modules-systemjs@>=7.12.0 <=7.29.3": "7.29.4",
       "@tootallnate/once@>=2.0.0 <2.0.1": "^2.0.1",
-      "@xmldom/xmldom@>=0.8.0 <0.8.13": "0.8.13",
+      "@xmldom/xmldom@>=0.7.0 <0.8.13": "0.8.13",
       "ajv@>=7.0.0 <8.18.0": "^8.18.0",
       "axios@>=1.0.0 <1.15.2": "^1.15.2",
       "brace-expansion@>=4.0.0 <4.0.4": "^4.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,8 +103,8 @@ catalogs:
       specifier: ^3.3.0
       version: 3.3.0
     expo:
-      specifier: ~52.0.47
-      version: 52.0.47
+      specifier: ~52.0.49
+      version: 52.0.49
     expo-dev-client:
       specifier: ~5.0.20
       version: 5.0.20
@@ -251,7 +251,7 @@ overrides:
   '@isaacs/brace-expansion': ^5.0.1
   '@babel/plugin-transform-modules-systemjs@>=7.12.0 <=7.29.3': 7.29.4
   '@tootallnate/once@>=2.0.0 <2.0.1': ^2.0.1
-  '@xmldom/xmldom@>=0.8.0 <0.8.13': 0.8.13
+  '@xmldom/xmldom@>=0.7.0 <0.8.13': 0.8.13
   ajv@>=7.0.0 <8.18.0: ^8.18.0
   axios@>=1.0.0 <1.15.2: ^1.15.2
   brace-expansion@>=4.0.0 <4.0.4: ^4.0.4
@@ -508,16 +508,16 @@ importers:
         version: 7.0.15(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)
       expo:
         specifier: 'catalog:'
-        version: 52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)
+        version: 52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)
       expo-build-properties:
         specifier: ~0.13.2
-        version: 0.13.2(expo@52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))
+        version: 0.13.2(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))
       expo-dev-client:
         specifier: 'catalog:'
-        version: 5.0.20(expo@52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))
+        version: 5.0.20(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))
       expo-splash-screen:
         specifier: 'catalog:'
-        version: 0.29.22(expo@52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))
+        version: 0.29.22(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))
       react:
         specifier: 'catalog:'
         version: 18.2.0
@@ -666,7 +666,7 @@ importers:
         version: link:../../packages/react-native
       expo:
         specifier: 'catalog:'
-        version: 52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)
+        version: 52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)
       expo-status-bar:
         specifier: 'catalog:'
         version: 1.12.1
@@ -1395,6 +1395,10 @@ packages:
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/compat-data@7.29.0':
     resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
     engines: {node: '>=6.9.0'}
@@ -1405,6 +1409,10 @@ packages:
 
   '@babel/generator@7.29.1':
     resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-annotate-as-pure@7.25.9':
@@ -1434,6 +1442,10 @@ packages:
 
   '@babel/helper-globals@7.28.0':
     resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-member-expression-to-functions@7.25.9':
@@ -1478,8 +1490,16 @@ packages:
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-option@7.27.1':
@@ -1500,6 +1520,11 @@ packages:
 
   '@babel/parser@7.29.0':
     resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -2087,12 +2112,24 @@ packages:
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/traverse@7.29.0':
     resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@0.2.3':
@@ -2977,12 +3014,12 @@ packages:
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
     engines: {node: '>=0.10.0'}
 
-  '@expo/cli@0.22.26':
-    resolution: {integrity: sha512-I689wc8Fn/AX7aUGiwrh3HnssiORMJtR2fpksX+JIe8Cj/EDleblYMSwRPd0025wrwOV9UN1KM/RuEt/QjCS3Q==}
+  '@expo/cli@0.22.28':
+    resolution: {integrity: sha512-lvt72KNitGuixYD2l3SZmRKVu2G4zJpmg5V7WfUBNpmUU5oODBw/6qmiJ6kSLAlfDozscUk+BBGknBBzxUrwrA==}
     hasBin: true
 
-  '@expo/code-signing-certificates@0.0.5':
-    resolution: {integrity: sha512-BNhXkY1bblxKZpltzAx98G2Egj9g1Q+JRcvR7E99DOj862FTCX+ZPsAUtPTr7aHxwtrL7+fL3r0JSmM9kBm+Bw==}
+  '@expo/code-signing-certificates@0.0.6':
+    resolution: {integrity: sha512-iNe0puxwBNEcuua9gmTGzq+SuMDa0iATai1FlFTMHJ/vUmKvN/V//drXoLJkVb5i5H3iE/n/qIJxyoBnXouD0w==}
 
   '@expo/config-plugins@9.0.17':
     resolution: {integrity: sha512-m24F1COquwOm7PBl5wRbkT9P9DviCXe0D7S7nQsolfbhdCWuvMkfXeoWmgjtdhy7sDlOyIgBrAdnB6MfsWKqIg==}
@@ -3528,6 +3565,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.30':
     resolution: {integrity: sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
@@ -4782,11 +4822,6 @@ packages:
   '@web-std/file@1.1.0':
     resolution: {integrity: sha512-VyKHE0eN713xBoRe7wrUjamct1KoALrkxCPEHiAusdBvOw7bSu4nmP+1i7b8L0cBUDawUEQyT7+7kPIykUla6A==}
 
-  '@xmldom/xmldom@0.7.13':
-    resolution: {integrity: sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==}
-    engines: {node: '>=10.0.0'}
-    deprecated: this version has critical issues, please update to the latest version
-
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
@@ -5079,8 +5114,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  babel-preset-expo@12.0.11:
-    resolution: {integrity: sha512-4m6D92nKEieg+7DXa8uSvpr0GjfuRfM/G0t0I/Q5hF8HleEv5ms3z4dJ+p52qXSJsm760tMqLdO93Ywuoi7cCQ==}
+  babel-preset-expo@12.0.12:
+    resolution: {integrity: sha512-qAuaGGZIN//DyQVackP7Czr1SMq5dYb5tpu/uQqL/f1bRARb74r+kBWQRLJGxQ3QujsEw13SyAodCZIOUoD6KQ==}
     peerDependencies:
       babel-plugin-react-compiler: ^19.0.0-beta-9ee70a1-20241017
       react-compiler-runtime: ^19.0.0-beta-8a03594-20241020
@@ -6154,8 +6189,8 @@ packages:
     peerDependencies:
       expo: '*'
 
-  expo@52.0.47:
-    resolution: {integrity: sha512-Mkvl7Qi2k+V3FdNRUD+yDj8GqU4IiYulLfl36BmSZs8lh/kCYPhTiyBLiEGPfz7d25QKbPWG727ESozbkbvatw==}
+  expo@52.0.49:
+    resolution: {integrity: sha512-ge3gUnuyGEePWWKzPY7TQ7FsvtFTdmsdYDHeBVUjMr9KIoQig/gf8A03oH26p3UtTL6sUJcyOIg9vwIHGNPSUw==}
     hasBin: true
     peerDependencies:
       '@expo/dom-webview': '*'
@@ -9942,8 +9977,8 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.20.1:
-    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -10581,6 +10616,12 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
   '@babel/compat-data@7.29.0': {}
 
   '@babel/core@7.29.0':
@@ -10609,6 +10650,14 @@ snapshots:
       '@babel/types': 7.29.0
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.30
+      jsesc: 3.1.0
+
+  '@babel/generator@7.29.7':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
   '@babel/helper-annotate-as-pure@7.25.9':
@@ -10656,10 +10705,12 @@ snapshots:
 
   '@babel/helper-globals@7.28.0': {}
 
+  '@babel/helper-globals@7.29.7': {}
+
   '@babel/helper-member-expression-to-functions@7.25.9':
     dependencies:
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -10681,7 +10732,7 @@ snapshots:
 
   '@babel/helper-optimise-call-expression@7.25.9':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@babel/helper-plugin-utils@7.28.6': {}
 
@@ -10712,15 +10763,19 @@ snapshots:
 
   '@babel/helper-string-parser@7.27.1': {}
 
+  '@babel/helper-string-parser@7.29.7': {}
+
   '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
 
   '@babel/helper-validator-option@7.27.1': {}
 
   '@babel/helper-wrap-function@7.25.9':
     dependencies:
-      '@babel/template': 7.28.6
+      '@babel/template': 7.29.7
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -10731,7 +10786,7 @@ snapshots:
 
   '@babel/highlight@7.25.9':
     dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       chalk: 2.4.2
       js-tokens: 4.0.0
       picocolors: 1.1.1
@@ -10739,6 +10794,10 @@ snapshots:
   '@babel/parser@7.29.0':
     dependencies:
       '@babel/types': 7.29.0
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
 
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.25.9(@babel/core@7.29.0)':
     dependencies:
@@ -11445,6 +11504,12 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/types': 7.29.0
 
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
   '@babel/traverse@7.29.0':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -11457,10 +11522,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/traverse@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/types@7.29.0':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@bcoe/v8-coverage@0.2.3': {}
 
@@ -12228,11 +12310,11 @@ snapshots:
     dependencies:
       uuid: 11.1.1
 
-  '@expo/cli@0.22.26(graphql@16.12.0)':
+  '@expo/cli@0.22.28(graphql@16.12.0)':
     dependencies:
       '@0no-co/graphql.web': 1.0.13(graphql@16.12.0)
       '@babel/runtime': 7.26.0
-      '@expo/code-signing-certificates': 0.0.5
+      '@expo/code-signing-certificates': 0.0.6
       '@expo/config': 10.0.11
       '@expo/config-plugins': 9.0.17
       '@expo/devcert': 1.1.4
@@ -12288,7 +12370,7 @@ snapshots:
       resolve: 1.22.10
       resolve-from: 5.0.0
       resolve.exports: 2.0.3
-      semver: 7.6.3
+      semver: 7.8.0
       send: 0.19.1
       slugify: 1.6.6
       source-map-support: 0.5.21
@@ -12301,7 +12383,7 @@ snapshots:
       undici: 6.25.0
       unique-string: 2.0.0
       wrap-ansi: 7.0.0
-      ws: 8.18.3
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -12309,10 +12391,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@expo/code-signing-certificates@0.0.5':
+  '@expo/code-signing-certificates@0.0.6':
     dependencies:
       node-forge: 1.3.3
-      nullthrows: 1.1.1
 
   '@expo/config-plugins@9.0.17':
     dependencies:
@@ -12325,7 +12406,7 @@ snapshots:
       getenv: 1.0.0
       glob: 10.5.0
       resolve-from: 5.0.0
-      semver: 7.6.3
+      semver: 7.8.0
       slash: 3.0.0
       slugify: 1.6.6
       xcode: 3.0.1
@@ -12347,7 +12428,7 @@ snapshots:
       require-from-string: 2.0.2
       resolve-from: 5.0.0
       resolve-workspace-root: 2.0.0
-      semver: 7.6.3
+      semver: 7.8.0
       slugify: 1.6.6
       sucrase: 3.35.0
     transitivePeerDependencies:
@@ -12391,7 +12472,7 @@ snapshots:
       minimatch: 3.1.3
       p-limit: 3.1.0
       resolve-from: 5.0.0
-      semver: 7.6.3
+      semver: 7.8.0
     transitivePeerDependencies:
       - supports-color
 
@@ -12417,9 +12498,9 @@ snapshots:
   '@expo/metro-config@0.19.12':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/parser': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/generator': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       '@expo/config': 10.0.11
       '@expo/env': 0.4.2
       '@expo/json-file': 9.0.2
@@ -12469,7 +12550,7 @@ snapshots:
 
   '@expo/plist@0.2.2':
     dependencies:
-      '@xmldom/xmldom': 0.7.13
+      '@xmldom/xmldom': 0.8.13
       base64-js: 1.5.1
       xmlbuilder: 14.0.0
 
@@ -13059,11 +13140,16 @@ snapshots:
   '@jridgewell/source-map@0.3.6':
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.30
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@jridgewell/trace-mapping@0.3.30':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@jridgewell/trace-mapping@0.3.31':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -13176,7 +13262,7 @@ snapshots:
 
   '@npmcli/fs@3.1.1':
     dependencies:
-      semver: 7.6.3
+      semver: 7.8.0
 
   '@octokit/auth-token@4.0.0': {}
 
@@ -13568,7 +13654,7 @@ snapshots:
       '@babel/plugin-transform-sticky-regex': 7.25.9(@babel/core@7.29.0)
       '@babel/plugin-transform-typescript': 7.26.5(@babel/core@7.29.0)
       '@babel/plugin-transform-unicode-regex': 7.25.9(@babel/core@7.29.0)
-      '@babel/template': 7.28.6
+      '@babel/template': 7.29.7
       '@react-native/babel-plugin-codegen': 0.76.9(@babel/preset-env@7.26.0(@babel/core@7.29.0))
       babel-plugin-syntax-hermes-parser: 0.25.1
       babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.29.0)
@@ -14747,7 +14833,7 @@ snapshots:
 
   '@vue/compiler-core@3.5.13':
     dependencies:
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.7
       '@vue/shared': 3.5.13
       entities: 4.5.0
       estree-walker: 2.0.2
@@ -14786,8 +14872,6 @@ snapshots:
   '@web-std/file@1.1.0':
     dependencies:
       '@web-std/blob': 2.1.3
-
-  '@xmldom/xmldom@0.7.13': {}
 
   '@xmldom/xmldom@0.8.13': {}
 
@@ -15066,15 +15150,15 @@ snapshots:
 
   babel-plugin-jest-hoist@28.1.3:
     dependencies:
-      '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.20.3
 
   babel-plugin-jest-hoist@29.6.3:
     dependencies:
       '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.20.3
 
@@ -15134,7 +15218,7 @@ snapshots:
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.0)
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.0)
 
-  babel-preset-expo@12.0.11(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0)):
+  babel-preset-expo@12.0.12(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0)):
     dependencies:
       '@babel/plugin-proposal-decorators': 7.25.9(@babel/core@7.29.0)
       '@babel/plugin-transform-export-namespace-from': 7.25.9(@babel/core@7.29.0)
@@ -16307,11 +16391,11 @@ snapshots:
       jest-message-util: 28.1.3
       jest-util: 28.1.3
 
-  expo-asset@11.0.5(expo@52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0):
+  expo-asset@11.0.5(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0):
     dependencies:
       '@expo/image-utils': 0.6.5
-      expo: 52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)
-      expo-constants: 17.0.8(expo@52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))
+      expo: 52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)
+      expo-constants: 17.0.8(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))
       invariant: 2.2.4
       md5-file: 3.2.3
       react: 18.2.0
@@ -16319,11 +16403,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  expo-asset@11.0.5(expo@52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0):
+  expo-asset@11.0.5(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0):
     dependencies:
       '@expo/image-utils': 0.6.5
-      expo: 52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)
-      expo-constants: 17.0.8(expo@52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))
+      expo: 52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)
+      expo-constants: 17.0.8(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))
       invariant: 2.2.4
       md5-file: 3.2.3
       react: 18.2.0
@@ -16331,100 +16415,100 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  expo-build-properties@0.13.2(expo@52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)):
+  expo-build-properties@0.13.2(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)):
     dependencies:
       ajv: 8.20.0
-      expo: 52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)
+      expo: 52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)
       semver: 7.6.3
 
-  expo-constants@17.0.8(expo@52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)):
+  expo-constants@17.0.8(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)):
     dependencies:
       '@expo/config': 10.0.11
       '@expo/env': 0.4.2
-      expo: 52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)
+      expo: 52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)
       react-native: 0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  expo-constants@17.0.8(expo@52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0)):
+  expo-constants@17.0.8(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0)):
     dependencies:
       '@expo/config': 10.0.11
       '@expo/env': 0.4.2
-      expo: 52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)
+      expo: 52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)
       react-native: 0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0)
     transitivePeerDependencies:
       - supports-color
 
-  expo-dev-client@5.0.20(expo@52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)):
+  expo-dev-client@5.0.20(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)):
     dependencies:
-      expo: 52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)
-      expo-dev-launcher: 5.0.35(expo@52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))
-      expo-dev-menu: 6.0.25(expo@52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))
-      expo-dev-menu-interface: 1.9.3(expo@52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))
-      expo-manifests: 0.15.8(expo@52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))
-      expo-updates-interface: 1.0.0(expo@52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))
+      expo: 52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)
+      expo-dev-launcher: 5.0.35(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))
+      expo-dev-menu: 6.0.25(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))
+      expo-dev-menu-interface: 1.9.3(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))
+      expo-manifests: 0.15.8(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))
+      expo-updates-interface: 1.0.0(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))
     transitivePeerDependencies:
       - supports-color
 
-  expo-dev-launcher@5.0.35(expo@52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)):
+  expo-dev-launcher@5.0.35(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)):
     dependencies:
       ajv: 8.20.0
-      expo: 52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)
-      expo-dev-menu: 6.0.25(expo@52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))
-      expo-manifests: 0.15.8(expo@52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))
+      expo: 52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)
+      expo-dev-menu: 6.0.25(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))
+      expo-manifests: 0.15.8(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))
       resolve-from: 5.0.0
     transitivePeerDependencies:
       - supports-color
 
-  expo-dev-menu-interface@1.9.3(expo@52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)):
+  expo-dev-menu-interface@1.9.3(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)):
     dependencies:
-      expo: 52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)
+      expo: 52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)
 
-  expo-dev-menu@6.0.25(expo@52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)):
+  expo-dev-menu@6.0.25(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)):
     dependencies:
-      expo: 52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)
-      expo-dev-menu-interface: 1.9.3(expo@52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))
+      expo: 52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)
+      expo-dev-menu-interface: 1.9.3(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))
 
-  expo-file-system@18.0.12(expo@52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)):
+  expo-file-system@18.0.12(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)):
     dependencies:
-      expo: 52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)
+      expo: 52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)
       react-native: 0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)
       web-streams-polyfill: 3.3.3
 
-  expo-file-system@18.0.12(expo@52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0)):
+  expo-file-system@18.0.12(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0)):
     dependencies:
-      expo: 52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)
+      expo: 52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)
       react-native: 0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0)
       web-streams-polyfill: 3.3.3
 
-  expo-font@13.0.4(expo@52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react@18.2.0):
+  expo-font@13.0.4(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react@18.2.0):
     dependencies:
-      expo: 52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)
+      expo: 52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)
       fontfaceobserver: 2.3.0
       react: 18.2.0
 
-  expo-font@13.0.4(expo@52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react@18.2.0):
+  expo-font@13.0.4(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react@18.2.0):
     dependencies:
-      expo: 52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)
+      expo: 52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)
       fontfaceobserver: 2.3.0
       react: 18.2.0
 
   expo-json-utils@0.14.0: {}
 
-  expo-keep-awake@14.0.3(expo@52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react@18.2.0):
+  expo-keep-awake@14.0.3(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react@18.2.0):
     dependencies:
-      expo: 52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)
+      expo: 52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)
       react: 18.2.0
 
-  expo-keep-awake@14.0.3(expo@52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react@18.2.0):
+  expo-keep-awake@14.0.3(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react@18.2.0):
     dependencies:
-      expo: 52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)
+      expo: 52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)
       react: 18.2.0
 
-  expo-manifests@0.15.8(expo@52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)):
+  expo-manifests@0.15.8(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)):
     dependencies:
       '@expo/config': 10.0.11
-      expo: 52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)
+      expo: 52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)
       expo-json-utils: 0.14.0
     transitivePeerDependencies:
       - supports-color
@@ -16444,34 +16528,34 @@ snapshots:
     dependencies:
       invariant: 2.2.4
 
-  expo-splash-screen@0.29.22(expo@52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)):
+  expo-splash-screen@0.29.22(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)):
     dependencies:
       '@expo/prebuild-config': 8.2.0
-      expo: 52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)
+      expo: 52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)
     transitivePeerDependencies:
       - supports-color
 
   expo-status-bar@1.12.1: {}
 
-  expo-updates-interface@1.0.0(expo@52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)):
+  expo-updates-interface@1.0.0(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)):
     dependencies:
-      expo: 52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)
+      expo: 52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)
 
-  expo@52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0):
+  expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0):
     dependencies:
       '@babel/runtime': 7.26.0
-      '@expo/cli': 0.22.26(graphql@16.12.0)
+      '@expo/cli': 0.22.28(graphql@16.12.0)
       '@expo/config': 10.0.11
       '@expo/config-plugins': 9.0.17
       '@expo/fingerprint': 0.11.11
       '@expo/metro-config': 0.19.12
       '@expo/vector-icons': 14.0.4
-      babel-preset-expo: 12.0.11(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))
-      expo-asset: 11.0.5(expo@52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)
-      expo-constants: 17.0.8(expo@52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))
-      expo-file-system: 18.0.12(expo@52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))
-      expo-font: 13.0.4(expo@52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react@18.2.0)
-      expo-keep-awake: 14.0.3(expo@52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react@18.2.0)
+      babel-preset-expo: 12.0.12(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))
+      expo-asset: 11.0.5(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)
+      expo-constants: 17.0.8(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))
+      expo-file-system: 18.0.12(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))
+      expo-font: 13.0.4(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react@18.2.0)
+      expo-keep-awake: 14.0.3(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.7.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react@18.2.0)
       expo-modules-autolinking: 2.0.8
       expo-modules-core: 2.2.3
       fbemitter: 3.0.0
@@ -16493,21 +16577,21 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  expo@52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0):
+  expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0):
     dependencies:
       '@babel/runtime': 7.26.0
-      '@expo/cli': 0.22.26(graphql@16.12.0)
+      '@expo/cli': 0.22.28(graphql@16.12.0)
       '@expo/config': 10.0.11
       '@expo/config-plugins': 9.0.17
       '@expo/fingerprint': 0.11.11
       '@expo/metro-config': 0.19.12
       '@expo/vector-icons': 14.0.4
-      babel-preset-expo: 12.0.11(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))
-      expo-asset: 11.0.5(expo@52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)
-      expo-constants: 17.0.8(expo@52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))
-      expo-file-system: 18.0.12(expo@52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))
-      expo-font: 13.0.4(expo@52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react@18.2.0)
-      expo-keep-awake: 14.0.3(expo@52.0.47(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react@18.2.0)
+      babel-preset-expo: 12.0.12(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))
+      expo-asset: 11.0.5(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)
+      expo-constants: 17.0.8(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))
+      expo-file-system: 18.0.12(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))
+      expo-font: 13.0.4(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react@18.2.0)
+      expo-keep-awake: 14.0.3(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@expo/metro-runtime@4.0.1(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0)))(graphql@16.12.0)(react-native-webview@13.13.4(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0))(react@18.2.0)
       expo-modules-autolinking: 2.0.8
       expo-modules-core: 2.2.3
       fbemitter: 3.0.0
@@ -17342,7 +17426,7 @@ snapshots:
   istanbul-lib-instrument@5.2.1:
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.7
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 6.3.1
@@ -17587,7 +17671,7 @@ snapshots:
 
   jest-message-util@29.7.0:
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.29.7
       '@jest/types': 29.6.3
       '@types/stack-utils': 2.0.3
       chalk: 4.1.2
@@ -17904,7 +17988,7 @@ snapshots:
       whatwg-encoding: 3.1.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
-      ws: 8.20.1
+      ws: 8.21.0
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -18200,7 +18284,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.6.3
+      semver: 7.8.0
 
   make-error@1.3.6: {}
 
@@ -18328,7 +18412,7 @@ snapshots:
   metro-source-map@0.81.3:
     dependencies:
       '@babel/traverse': 7.29.0
-      '@babel/traverse--for-generate-function-map': '@babel/traverse@7.29.0'
+      '@babel/traverse--for-generate-function-map': '@babel/traverse@7.29.7'
       '@babel/types': 7.29.0
       flow-enums-runtime: 0.0.6
       invariant: 2.2.4
@@ -18354,7 +18438,7 @@ snapshots:
   metro-transform-plugins@0.81.3:
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/generator': 7.29.1
+      '@babel/generator': 7.29.7
       '@babel/template': 7.28.6
       '@babel/traverse': 7.29.0
       flow-enums-runtime: 0.0.6
@@ -18365,9 +18449,9 @@ snapshots:
   metro-transform-worker@0.81.3:
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/parser': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/generator': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       flow-enums-runtime: 0.0.6
       metro: 0.81.3
       metro-babel-transformer: 0.81.3
@@ -18674,7 +18758,7 @@ snapshots:
     dependencies:
       hosted-git-info: 7.0.2
       proc-log: 4.2.0
-      semver: 7.6.3
+      semver: 7.8.0
       validate-npm-package-name: 5.0.1
 
   npm-run-path@2.0.2:
@@ -21170,8 +21254,7 @@ snapshots:
 
   ws@8.18.3: {}
 
-  ws@8.20.1:
-    optional: true
+  ws@8.21.0: {}
 
   xcode@3.0.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,7 +37,7 @@ catalog:
   eslint-plugin-react: ^7.37.1
   eslint-plugin-react-hooks: ^5.2.0
   events: ^3.3.0
-  expo: ~52.0.47
+  expo: ~52.0.49
   expo-dev-client: ~5.0.20
   expo-splash-screen: ~0.29.22
   expo-status-bar: ~1.12.1


### PR DESCRIPTION
# Why

A vulnerable version of @xmldom/xmldom is pulled in through a dependency of expo. It does not pose a real threat to the repo, but is worth removing.

# How

Expand versions considered for version override to remove vulnerable 0.7.13
