### PR TITLE
fix: split out aws operations from preflight acceptance testing in playwright container

### DIFF
--- a/.github/workflows/publish-static-bundle.yml
+++ b/.github/workflows/publish-static-bundle.yml
@@ -66,8 +66,6 @@ jobs:
   # This is to ensure that the preview deployment is working as expected before we promote to production.
   deploy-preview:
     runs-on: ubuntu-latest
-    container:
-      image: mcr.microsoft.com/playwright:v1.57.0-noble
     environment: ${{ inputs.preview-environment }}
     if: ${{ inputs.perform-gated-preview-deployment }}
     name: "[PREVIEW] Deploy ${{ inputs.package-name }} to ${{ inputs.stage }}"
@@ -136,6 +134,23 @@ jobs:
           aws cloudfront create-invalidation --distribution-id ${{ secrets[env.CF_DISTRO_SECRET_NAME] }} --invalidation-batch file://invalidation.json
         env:
           CF_DISTRO_SECRET_NAME: ${{ inputs.cloudfront-distribution-id }}
+
+  validate-preview-deployment:
+    needs: [get-artifact-name, deploy-preview]
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.preview-environment }}
+    container:
+      image: mcr.microsoft.com/playwright:v1.57.0-noble
+    if: ${{ inputs.perform-gated-preview-deployment }}
+    name: "[PREVIEW] Validate ${{ inputs.package-name }} preview"
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+      - name: Download Build Artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ needs.get-artifact-name.outputs.artifact-name }}
+          path: dist
       - uses: pnpm/action-setup@v6
       - name: Setup Node.js environment
         uses: actions/setup-node@v6
@@ -182,7 +197,7 @@ jobs:
   # The logic for this release process is largely consistent with the preview deployment above.
   deploy:
     runs-on: ubuntu-latest
-    needs: [get-artifact-name, deploy-preview]
+    needs: [get-artifact-name, validate-preview-deployment]
     # The live deployment should happen if:
     # - The current package supports preview deployments and the preview deployment was successful.
     # - The current package does not support preview deployments, in which case we should always deploy to live.


### PR DESCRIPTION
# Why

preview deployment aren't working as expected due to the lack of access to an aws cli. This isn't vendored into the playwright container that the preview deployment step is now running in. 

These 2 steps should happen separately - we should push the artifact from the runner and then spawn the playwright image to verify it.

# How

Split out artifact deployment and testing.
