### PR TITLE
Bump JS and React SDKs for optional cvc validation

### DIFF
--- a/.changeset/kind-scissors-tap.md
+++ b/.changeset/kind-scissors-tap.md
@@ -1,0 +1,6 @@
+---
+"@evervault/js": minor
+"@evervault/react": minor
+---
+
+Adds `validation.cvc.optional` option to Card configuration


### PR DESCRIPTION
# Why

We didn't bump the SDKs to a new version to include CVC validation option types
