### PR TITLE
fix: bump vitest to 4.1.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,8 +241,8 @@ catalogs:
       specifier: ^7.2.1
       version: 7.2.1
     vitest:
-      specifier: ^4.0.18
-      version: 4.0.18
+      specifier: ^4.1.0
+      version: 4.1.8
     wait-on:
       specifier: ^9.0.4
       version: 9.0.4
@@ -780,7 +780,7 @@ importers:
         version: 7.2.1(vite@7.3.3(@types/node@24.10.10)(lightningcss@1.27.0)(terser@5.39.0)(yaml@2.9.0))
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@24.10.10)(jsdom@25.0.1)(lightningcss@1.27.0)(msw@2.12.8(@types/node@24.10.10)(typescript@5.5.4))(terser@5.39.0)(yaml@2.9.0)
+        version: 4.1.8(@types/node@24.10.10)(jsdom@25.0.1)(msw@2.12.8(@types/node@24.10.10)(typescript@5.5.4))(vite@7.3.3(@types/node@24.10.10)(lightningcss@1.27.0)(terser@5.39.0)(yaml@2.9.0))
 
   packages/card-validator:
     devDependencies:
@@ -801,7 +801,7 @@ importers:
         version: 4.5.4(@types/node@24.10.10)(rollup@4.59.0)(typescript@5.5.4)(vite@7.3.3(@types/node@24.10.10)(lightningcss@1.27.0)(terser@5.39.0)(yaml@2.9.0))
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@24.10.10)(jsdom@25.0.1)(lightningcss@1.27.0)(msw@2.12.8(@types/node@24.10.10)(typescript@5.5.4))(terser@5.39.0)(yaml@2.9.0)
+        version: 4.1.8(@types/node@24.10.10)(jsdom@25.0.1)(msw@2.12.8(@types/node@24.10.10)(typescript@5.5.4))(vite@7.3.3(@types/node@24.10.10)(lightningcss@1.27.0)(terser@5.39.0)(yaml@2.9.0))
 
   packages/encryption:
     dependencies:
@@ -835,7 +835,7 @@ importers:
         version: 4.2.0
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@24.10.10)(jsdom@25.0.1)(lightningcss@1.27.0)(msw@2.12.8(@types/node@24.10.10)(typescript@5.9.3))(terser@5.39.0)(yaml@2.9.0)
+        version: 4.1.8(@types/node@24.10.10)(jsdom@25.0.1)(msw@2.12.8(@types/node@24.10.10)(typescript@5.9.3))(vite@7.3.3(@types/node@24.10.10)(lightningcss@1.27.0)(terser@5.39.0)(yaml@2.9.0))
 
   packages/eslint-config-custom:
     devDependencies:
@@ -1072,7 +1072,7 @@ importers:
         version: link:../tsconfig
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@24.10.10)(jsdom@25.0.1)(lightningcss@1.27.0)(msw@2.12.8(@types/node@24.10.10)(typescript@5.9.3))(terser@5.39.0)(yaml@2.9.0)
+        version: 4.1.8(@types/node@24.10.10)(jsdom@25.0.1)(msw@2.12.8(@types/node@24.10.10)(typescript@5.9.3))(vite@7.3.3(@types/node@24.10.10)(lightningcss@1.27.0)(terser@5.39.0)(yaml@2.9.0))
       vitest-react-native:
         specifier: ^0.1.5
         version: 0.1.5(react-native@0.76.9(@babel/core@7.29.0)(@babel/preset-env@7.26.0(@babel/core@7.29.0))(@react-native-community/cli@17.0.1(typescript@5.9.3))(@types/react@18.3.18)(react@18.2.0))(react@18.2.0)(vite@7.3.3(@types/node@24.10.10)(lightningcss@1.27.0)(terser@5.39.0)(yaml@2.9.0))
@@ -1197,7 +1197,7 @@ importers:
         version: 7.2.1(vite@7.3.3(@types/node@24.10.10)(lightningcss@1.27.0)(terser@5.39.0)(yaml@2.9.0))
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@24.10.10)(jsdom@22.1.0)(lightningcss@1.27.0)(msw@2.12.8(@types/node@24.10.10)(typescript@5.5.4))(terser@5.39.0)(yaml@2.9.0)
+        version: 4.1.8(@types/node@24.10.10)(jsdom@22.1.0)(msw@2.12.8(@types/node@24.10.10)(typescript@5.5.4))(vite@7.3.3(@types/node@24.10.10)(lightningcss@1.27.0)(terser@5.39.0)(yaml@2.9.0))
 
 packages:
 
@@ -4761,34 +4761,34 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
-  '@vitest/expect@4.0.18':
-    resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
+  '@vitest/expect@4.1.8':
+    resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
 
-  '@vitest/mocker@4.0.18':
-    resolution: {integrity: sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==}
+  '@vitest/mocker@4.1.8':
+    resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^6.0.0 || ^7.0.0-0
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       msw:
         optional: true
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.0.18':
-    resolution: {integrity: sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==}
+  '@vitest/pretty-format@4.1.8':
+    resolution: {integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==}
 
-  '@vitest/runner@4.0.18':
-    resolution: {integrity: sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==}
+  '@vitest/runner@4.1.8':
+    resolution: {integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==}
 
-  '@vitest/snapshot@4.0.18':
-    resolution: {integrity: sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==}
+  '@vitest/snapshot@4.1.8':
+    resolution: {integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==}
 
-  '@vitest/spy@4.0.18':
-    resolution: {integrity: sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==}
+  '@vitest/spy@4.1.8':
+    resolution: {integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==}
 
-  '@vitest/utils@4.0.18':
-    resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
+  '@vitest/utils@4.1.8':
+    resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
 
   '@volar/language-core@2.4.28':
     resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
@@ -5944,8 +5944,8 @@ packages:
     resolution: {integrity: sha512-zoMwbCcH5hwUkKJkT8kDIBZSz9I6mVG//+lDCinLCGov4+r7NIy0ld8o03M0cJxl2spVf6ESYVS6/gpIfq1FFw==}
     engines: {node: '>= 0.4'}
 
-  es-module-lexer@1.7.0:
-    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -9134,8 +9134,8 @@ packages:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
-  std-env@3.10.0:
-    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stream-buffers@2.2.0:
     resolution: {integrity: sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg==}
@@ -9372,8 +9372,8 @@ packages:
   tinymask@1.0.2:
     resolution: {integrity: sha512-2FjNINAMq0s3e94ns2PuElOQZOt9QVgnrv0JZ8yNblwecyQDhVsSre6Rs+WJj/IHEcgdfYbDMP7zvECTfV/Xnw==}
 
-  tinyrainbow@3.0.3:
-    resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
   tldts-core@6.1.86:
@@ -9759,20 +9759,23 @@ packages:
       react-native: '*'
       vite: '*'
 
-  vitest@4.0.18:
-    resolution: {integrity: sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==}
+  vitest@4.1.8:
+    resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.0.18
-      '@vitest/browser-preview': 4.0.18
-      '@vitest/browser-webdriverio': 4.0.18
-      '@vitest/ui': 4.0.18
+      '@vitest/browser-playwright': 4.1.8
+      '@vitest/browser-preview': 4.1.8
+      '@vitest/browser-webdriverio': 4.1.8
+      '@vitest/coverage-istanbul': 4.1.8
+      '@vitest/coverage-v8': 4.1.8
+      '@vitest/ui': 4.1.8
       happy-dom: '*'
       jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -9785,6 +9788,10 @@ packages:
       '@vitest/browser-preview':
         optional: true
       '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
         optional: true
       '@vitest/ui':
         optional: true
@@ -14774,54 +14781,56 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/expect@4.0.18':
+  '@vitest/expect@4.1.8':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.0.18
-      '@vitest/utils': 4.0.18
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
       chai: 6.2.2
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.0.18(msw@2.12.8(@types/node@24.10.10)(typescript@5.5.4))(vite@7.3.3(@types/node@24.10.10)(lightningcss@1.27.0)(terser@5.39.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.8(msw@2.12.8(@types/node@24.10.10)(typescript@5.5.4))(vite@7.3.3(@types/node@24.10.10)(lightningcss@1.27.0)(terser@5.39.0)(yaml@2.9.0))':
     dependencies:
-      '@vitest/spy': 4.0.18
+      '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.8(@types/node@24.10.10)(typescript@5.5.4)
       vite: 7.3.3(@types/node@24.10.10)(lightningcss@1.27.0)(terser@5.39.0)(yaml@2.9.0)
 
-  '@vitest/mocker@4.0.18(msw@2.12.8(@types/node@24.10.10)(typescript@5.9.3))(vite@7.3.3(@types/node@24.10.10)(lightningcss@1.27.0)(terser@5.39.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.8(msw@2.12.8(@types/node@24.10.10)(typescript@5.9.3))(vite@7.3.3(@types/node@24.10.10)(lightningcss@1.27.0)(terser@5.39.0)(yaml@2.9.0))':
     dependencies:
-      '@vitest/spy': 4.0.18
+      '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.8(@types/node@24.10.10)(typescript@5.9.3)
       vite: 7.3.3(@types/node@24.10.10)(lightningcss@1.27.0)(terser@5.39.0)(yaml@2.9.0)
 
-  '@vitest/pretty-format@4.0.18':
+  '@vitest/pretty-format@4.1.8':
     dependencies:
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.0.18':
+  '@vitest/runner@4.1.8':
     dependencies:
-      '@vitest/utils': 4.0.18
+      '@vitest/utils': 4.1.8
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.0.18':
+  '@vitest/snapshot@4.1.8':
     dependencies:
-      '@vitest/pretty-format': 4.0.18
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/utils': 4.1.8
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.0.18': {}
+  '@vitest/spy@4.1.8': {}
 
-  '@vitest/utils@4.0.18':
+  '@vitest/utils@4.1.8':
     dependencies:
-      '@vitest/pretty-format': 4.0.18
-      tinyrainbow: 3.0.3
+      '@vitest/pretty-format': 4.1.8
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@volar/language-core@2.4.28':
     dependencies:
@@ -15163,7 +15172,7 @@ snapshots:
 
   babel-plugin-jest-hoist@29.6.3:
     dependencies:
-      '@babel/template': 7.28.6
+      '@babel/template': 7.29.7
       '@babel/types': 7.29.7
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.20.3
@@ -16122,7 +16131,7 @@ snapshots:
       iterator.prototype: 1.1.2
       safe-array-concat: 1.1.2
 
-  es-module-lexer@1.7.0: {}
+  es-module-lexer@2.1.0: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -18445,7 +18454,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.7
-      '@babel/template': 7.28.6
+      '@babel/template': 7.29.7
       '@babel/traverse': 7.29.0
       flow-enums-runtime: 0.0.6
       nullthrows: 1.1.1
@@ -20361,7 +20370,7 @@ snapshots:
 
   statuses@2.0.2: {}
 
-  std-env@3.10.0: {}
+  std-env@4.1.0: {}
 
   stream-buffers@2.2.0: {}
 
@@ -20595,7 +20604,7 @@ snapshots:
 
   tinymask@1.0.2: {}
 
-  tinyrainbow@3.0.3: {}
+  tinyrainbow@3.1.0: {}
 
   tldts-core@6.1.86:
     optional: true
@@ -20984,119 +20993,89 @@ snapshots:
       regenerator-runtime: 0.13.11
       vite: 7.3.3(@types/node@24.10.10)(lightningcss@1.27.0)(terser@5.39.0)(yaml@2.9.0)
 
-  vitest@4.0.18(@types/node@24.10.10)(jsdom@22.1.0)(lightningcss@1.27.0)(msw@2.12.8(@types/node@24.10.10)(typescript@5.5.4))(terser@5.39.0)(yaml@2.9.0):
+  vitest@4.1.8(@types/node@24.10.10)(jsdom@22.1.0)(msw@2.12.8(@types/node@24.10.10)(typescript@5.5.4))(vite@7.3.3(@types/node@24.10.10)(lightningcss@1.27.0)(terser@5.39.0)(yaml@2.9.0)):
     dependencies:
-      '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(msw@2.12.8(@types/node@24.10.10)(typescript@5.5.4))(vite@7.3.3(@types/node@24.10.10)(lightningcss@1.27.0)(terser@5.39.0)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.0.18
-      '@vitest/runner': 4.0.18
-      '@vitest/snapshot': 4.0.18
-      '@vitest/spy': 4.0.18
-      '@vitest/utils': 4.0.18
-      es-module-lexer: 1.7.0
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(msw@2.12.8(@types/node@24.10.10)(typescript@5.5.4))(vite@7.3.3(@types/node@24.10.10)(lightningcss@1.27.0)(terser@5.39.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
       picomatch: 4.0.4
-      std-env: 3.10.0
+      std-env: 4.1.0
       tinybench: 2.9.0
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
       vite: 7.3.3(@types/node@24.10.10)(lightningcss@1.27.0)(terser@5.39.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.10.10
       jsdom: 22.1.0
     transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
 
-  vitest@4.0.18(@types/node@24.10.10)(jsdom@25.0.1)(lightningcss@1.27.0)(msw@2.12.8(@types/node@24.10.10)(typescript@5.5.4))(terser@5.39.0)(yaml@2.9.0):
+  vitest@4.1.8(@types/node@24.10.10)(jsdom@25.0.1)(msw@2.12.8(@types/node@24.10.10)(typescript@5.5.4))(vite@7.3.3(@types/node@24.10.10)(lightningcss@1.27.0)(terser@5.39.0)(yaml@2.9.0)):
     dependencies:
-      '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(msw@2.12.8(@types/node@24.10.10)(typescript@5.5.4))(vite@7.3.3(@types/node@24.10.10)(lightningcss@1.27.0)(terser@5.39.0)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.0.18
-      '@vitest/runner': 4.0.18
-      '@vitest/snapshot': 4.0.18
-      '@vitest/spy': 4.0.18
-      '@vitest/utils': 4.0.18
-      es-module-lexer: 1.7.0
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(msw@2.12.8(@types/node@24.10.10)(typescript@5.5.4))(vite@7.3.3(@types/node@24.10.10)(lightningcss@1.27.0)(terser@5.39.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
       picomatch: 4.0.4
-      std-env: 3.10.0
+      std-env: 4.1.0
       tinybench: 2.9.0
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
       vite: 7.3.3(@types/node@24.10.10)(lightningcss@1.27.0)(terser@5.39.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.10.10
       jsdom: 25.0.1
     transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
 
-  vitest@4.0.18(@types/node@24.10.10)(jsdom@25.0.1)(lightningcss@1.27.0)(msw@2.12.8(@types/node@24.10.10)(typescript@5.9.3))(terser@5.39.0)(yaml@2.9.0):
+  vitest@4.1.8(@types/node@24.10.10)(jsdom@25.0.1)(msw@2.12.8(@types/node@24.10.10)(typescript@5.9.3))(vite@7.3.3(@types/node@24.10.10)(lightningcss@1.27.0)(terser@5.39.0)(yaml@2.9.0)):
     dependencies:
-      '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(msw@2.12.8(@types/node@24.10.10)(typescript@5.9.3))(vite@7.3.3(@types/node@24.10.10)(lightningcss@1.27.0)(terser@5.39.0)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.0.18
-      '@vitest/runner': 4.0.18
-      '@vitest/snapshot': 4.0.18
-      '@vitest/spy': 4.0.18
-      '@vitest/utils': 4.0.18
-      es-module-lexer: 1.7.0
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(msw@2.12.8(@types/node@24.10.10)(typescript@5.9.3))(vite@7.3.3(@types/node@24.10.10)(lightningcss@1.27.0)(terser@5.39.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
       picomatch: 4.0.4
-      std-env: 3.10.0
+      std-env: 4.1.0
       tinybench: 2.9.0
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
       vite: 7.3.3(@types/node@24.10.10)(lightningcss@1.27.0)(terser@5.39.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.10.10
       jsdom: 25.0.1
     transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
 
   vlq@0.2.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -85,7 +85,7 @@ catalog:
   vite: ^7.3.2
   vite-plugin-dts: ^4.5.4
   vite-plugin-istanbul: ^7.2.1
-  vitest: ^4.0.18
+  vitest: ^4.1.0
   wait-on: ^9.0.4
 settings:
   minimumReleaseAge: 10080


### PR DESCRIPTION
## Security Patch

Linear issue: **COM-1181**

### Vulnerability Details

- **Affected Package:** `npm-vitest`
- **Vulnerable Range:** `< 4.1.0`
- **Fixed in:** `4.1.0`
- **Severity:** CRITICAL
- **CVSS:** 9.8
- **SLA Deadline:** 2026-06-09T09:39:55.443Z

### Remediation

Bumped `vitest` from `^4.0.18` to `^4.1.0` in the pnpm workspace catalog (`pnpm-workspace.yaml`) and regenerated `pnpm-lock.yaml`. The resolver now selects `vitest@4.1.8`, which is at or above the fixed version.

This is a patch-level version bump with no breaking API changes.