### PR TITLE
Allow 4-digit CVCs for Discover cards

### DIFF
--- a/packages/card-validator/brands.ts
+++ b/packages/card-validator/brands.ts
@@ -58,7 +58,7 @@ const brands = [
       lengths: [16, 19],
     },
     securityCodeValidationRules: {
-      lengths: [3],
+      lengths: [3, 4],
     },
   },
   {

--- a/packages/ui-components/src/Card/CardCVC.tsx
+++ b/packages/ui-components/src/Card/CardCVC.tsx
@@ -16,7 +16,7 @@ export function getCVCMask(
 ): string {
   if (!cardNumber) return "0000";
   const { brand, localBrands } = validateNumber(cardNumber, { customBrands });
-  if (brand === "american-express") return "0000";
+  if (brand === "american-express" || brand === "discover") return "0000";
 
   const matchedCustomBrand = customBrands?.find((b) =>
     localBrands.includes(b.name)

--- a/packages/ui-components/src/Card/CardNumber.tsx
+++ b/packages/ui-components/src/Card/CardNumber.tsx
@@ -116,7 +116,9 @@ export function CardNumber({
         b.securityCodeValidationRules.lengths.includes(4)
     );
     const allows4DigitCvc =
-      brand === "american-express" || customBrandAllows4DigitCvc;
+      brand === "american-express" ||
+      brand === "discover" ||
+      customBrandAllows4DigitCvc;
 
     if (!allows4DigitCvc && form.values.cvc.length > 3) {
       form.setValues((previous) => ({


### PR DESCRIPTION
**Before merging the customer request needs to be confirmed** [link to thread](https://evervault.slack.com/archives/C05TBHREAG7/p1781027496277409)

## Why

A customer requested support for Discover cards that may have CVC's with 3 or 4 digits, but the validator and UI components only accepts 3 digits CVC's on discover cards.

Relates to PE-79.

## How

Three small changes:

- **`packages/card-validator/brands.ts`** — Added `4` to Discover's `securityCodeValidationRules.lengths` so the validator accepts both 3- and 4-digit CVCs.
- **`packages/ui-components/src/Card/CardCVC.tsx`** — Extended the 4-digit mask (`"0000"`) to apply to `discover` in addition to `american-express`.
- **`packages/ui-components/src/Card/CardNumber.tsx`** — Added `discover` to the `allows4DigitCvc` check so the CVC value isn't truncated to 3 digits when a Discover card number is entered.