### PR TITLE
Fix domain resolution for Apple Pay SDK

### DIFF
--- a/.changeset/apple-pay-iframe-domain.md
+++ b/.changeset/apple-pay-iframe-domain.md
@@ -1,0 +1,5 @@
+---
+"@evervault/browser": patch
+---
+
+Resolve the Apple Pay merchant-validation domain from the top-level document origin (`window.location.ancestorOrigins`) instead of the current frame's origin. This fixes Apple Pay failing with "Payment Not Completed" when the component runs inside a cross-origin iframe (e.g. a PSP-hosted widget embedded in a merchant store), where the merchant session was previously issued for the iframe host rather than the top-level merchant origin. Falls back to the current frame's origin when not embedded.

--- a/packages/browser/lib/resources/transaction.ts
+++ b/packages/browser/lib/resources/transaction.ts
@@ -4,6 +4,7 @@ import {
   DisbursementTransactionDetails,
   RecurringTransactionDetails,
 } from "types";
+import { resolveTopLevelDomain } from "../utils";
 
 export class Transaction {
   details: TransactionDetailsWithDomain;
@@ -17,7 +18,7 @@ export class Transaction {
     this.details = {
       ...details,
       type: details.type ?? "payment",
-      domain: window.location.origin.replace(/https?:\/\//, ""),
+      domain: resolveTopLevelDomain(),
     } as TransactionDetailsWithDomain;
   }
 }

--- a/packages/browser/lib/utils/index.ts
+++ b/packages/browser/lib/utils/index.ts
@@ -13,3 +13,4 @@ export { default as deriveSharedSecret } from "./deriveSharedSecret";
 export { default as crc32 } from "./crc32";
 export { default as getContext } from "./getContext";
 export { default as getStringDimensionOrDefault } from "./getStringDimensionOrDefault";
+export { default as resolveTopLevelDomain } from "./resolveTopLevelDomain";

--- a/packages/browser/lib/utils/resolveTopLevelDomain.ts
+++ b/packages/browser/lib/utils/resolveTopLevelDomain.ts
@@ -1,0 +1,37 @@
+function stripProtocol(origin: string): string {
+  return origin.replace(/https?:\/\//, "");
+}
+
+/**
+ * Resolves the domain used for Apple Pay merchant validation.
+ *
+ * Apple Pay (and Safari) validate a merchant session against the *top-level*
+ * document's origin — the one in the address bar that the shopper actually
+ * sees. When the SDK runs inside a cross-origin iframe (e.g. a PSP-hosted
+ * widget embedded in a merchant store), `window.location.origin` is the
+ * iframe's own origin, not the top-level page, so the merchant session is
+ * issued for the wrong domain and `completeMerchantValidation` is rejected.
+ *
+ * `window.location.ancestorOrigins` is populated by the browser from the real
+ * frame tree and cannot be spoofed by page-level JS, so it is the only
+ * trustworthy source for the top-level origin. It is ordered from the
+ * immediate parent (index 0) to the top-level document (last index), so the
+ * final entry is the address-bar origin regardless of nesting depth.
+ *
+ * Falls back to the current frame's origin when not embedded, when
+ * `ancestorOrigins` is unavailable, or when the top-level origin is opaque
+ * (reported as "null", e.g. a sandboxed ancestor) — an opaque origin can never
+ * be a registered Apple Pay domain, so we avoid sending "null" downstream.
+ */
+export default function resolveTopLevelDomain(): string {
+  const { ancestorOrigins } = window.location;
+
+  if (ancestorOrigins && ancestorOrigins.length > 0) {
+    const topLevelOrigin = ancestorOrigins[ancestorOrigins.length - 1];
+    if (topLevelOrigin && topLevelOrigin !== "null") {
+      return stripProtocol(topLevelOrigin);
+    }
+  }
+
+  return stripProtocol(window.location.origin);
+}

--- a/packages/browser/test/resolveTopLevelDomain.test.ts
+++ b/packages/browser/test/resolveTopLevelDomain.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, assert, afterEach } from "vitest";
+import resolveTopLevelDomain from "../lib/utils/resolveTopLevelDomain";
+
+const originalLocation = window.location;
+
+function makeAncestorOrigins(origins: string[]): DOMStringList {
+  const indexed: Record<number, string> = {};
+  origins.forEach((origin, i) => {
+    indexed[i] = origin;
+  });
+  return {
+    ...indexed,
+    length: origins.length,
+    item: (i: number) => origins[i] ?? null,
+    contains: (s: string) => origins.includes(s),
+  } as unknown as DOMStringList;
+}
+
+function mockLocation(origin: string, ancestorOrigins?: string[]): void {
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: {
+      origin,
+      ancestorOrigins: ancestorOrigins
+        ? makeAncestorOrigins(ancestorOrigins)
+        : undefined,
+    },
+  });
+}
+
+describe("resolveTopLevelDomain", () => {
+  afterEach(() => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: originalLocation,
+    });
+  });
+
+  it("uses the current frame origin when not embedded", () => {
+    mockLocation("https://widget.example.com", []);
+    assert.equal(resolveTopLevelDomain(), "widget.example.com");
+  });
+
+  it("uses the current frame origin when ancestorOrigins is unavailable", () => {
+    mockLocation("https://widget.example.com");
+    assert.equal(resolveTopLevelDomain(), "widget.example.com");
+  });
+
+  it("uses the top-level origin when embedded one level deep", () => {
+    mockLocation("https://widget.psp.example", [
+      "https://store.merchant.example",
+    ]);
+    assert.equal(resolveTopLevelDomain(), "store.merchant.example");
+  });
+
+  it("uses the furthest ancestor (top-level) when nested multiple levels", () => {
+    mockLocation("https://widget.psp.example", [
+      "https://middle.example.com",
+      "https://shop.example.com",
+    ]);
+    assert.equal(resolveTopLevelDomain(), "shop.example.com");
+  });
+
+  it("falls back to the current frame origin when the top-level origin is opaque", () => {
+    mockLocation("https://widget.psp.example", ["null"]);
+    assert.equal(resolveTopLevelDomain(), "widget.psp.example");
+  });
+
+  it("strips the protocol from the resolved origin", () => {
+    mockLocation("http://localhost:3000", ["http://top.example.com:8080"]);
+    assert.equal(resolveTopLevelDomain(), "top.example.com:8080");
+  });
+});


### PR DESCRIPTION
# Why
When the @evervault/browser Apple Pay component runs inside a cross-origin iframe, the merchant session was issued with domainName set to the iframe's own origin rather than the top-level page origin. 
Safari validates a cross-origin-iframe Apple Pay session against the top-level origin, so completeMerchantValidation was rejected and the sheet showed "Payment Not Completed" after the user authorized.

The cause was in the Transaction constructor, which derived domain unconditionally from window.location.origin — i.e. the current frame.

# Fix
Resolve the validation domain from the top-level document origin via window.location.ancestorOrigins:

New resolveTopLevelDomain() helper returns the top-level origin (the furthest ancestorOrigins entry — the address-bar origin, regardless of nesting depth). ancestorOrigins is browser-populated and cannot be spoofed by page JS, so it's a safe source of truth.

Falls back to the current frame's origin when not embedded, when ancestorOrigins is unavailable, or when the top origin is opaque ("null").

The existing backend check (which validates the supplied domain against the merchant's registered, active Apple Pay domains) remains the authoritative trust boundary, so no new client-trust surface is introduced.

# Tests

- Tested manually:
  - Reproduced the issue (ApplePay doesn't work inside iframe)
  - With this fix applied, ApplePay works both with/without iframe
