### PR TITLE
add name field to CardTranslations with errors.regex support

### DIFF
--- a/packages/types/uiComponents.ts
+++ b/packages/types/uiComponents.ts
@@ -115,6 +115,7 @@ export interface CardTranslations extends TranslationsObject {
   }>;
   expiry: CardFieldTranslations<{ invalid?: string }>;
   cvc: CardFieldTranslations<{ invalid?: string }>;
+  name?: CardFieldTranslations<{ invalid?: string; regex?: string }>;
 }
 
 export type CardIcons = Record<CardBrandName | "default", string>;


### PR DESCRIPTION
# Why

`CardTranslations` in `packages/types/uiComponents.ts` was missing an explicit `name` field, so `translations.name.errors.regex` had no type — even though the runtime default translations in `packages/ui-components/src/Card/translations.ts` already include `name.errors.regex`. Fixes EXP-1023.

# How

Added `name?: CardFieldTranslations<{ invalid?: string; regex?: string }>` to the `CardTranslations` interface, consistent with the existing `DEFAULT_TRANSLATIONS` shape.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCmCRYRgLkTrepYJ4Lp7K5)_