### PR TITLE
Enable partial cardIcons overrides

### DIFF
--- a/.changeset/hungry-radios-rest.md
+++ b/.changeset/hungry-radios-rest.md
@@ -1,0 +1,7 @@
+---
+"@evervault/react": patch
+"@evervault/ui-components": patch
+"types": patch
+---
+
+Enable partial `cardIcons` overrides. `icons` now accepts `Partial<CardIcons>` so callers can override individual card icons without supplying all of them.

--- a/packages/react/lib/ui/Card.tsx
+++ b/packages/react/lib/ui/Card.tsx
@@ -24,7 +24,7 @@ export interface CardProps {
   autoFocus?: boolean;
   colorScheme?: ColorScheme;
   theme?: ThemeDefinition;
-  icons?: boolean | CardIcons;
+  icons?: boolean | Partial<CardIcons>;
   translations?: CardTranslations;
   fields?: CardField[];
   onReady?: () => void;

--- a/packages/types/uiComponents.ts
+++ b/packages/types/uiComponents.ts
@@ -147,7 +147,7 @@ export interface CustomBrand {
 
 export interface CardOptions {
   colorScheme?: ColorScheme;
-  icons?: boolean | CardIcons;
+  icons?: boolean | Partial<CardIcons>;
   theme?: ThemeDefinition;
   autoFocus?: boolean;
   hiddenFields?: ("number" | "expiry" | "cvc")[]; // deprecated

--- a/packages/ui-components/src/Card/types.ts
+++ b/packages/ui-components/src/Card/types.ts
@@ -8,7 +8,7 @@ import type {
 } from "types";
 
 export interface CardConfig {
-  icons?: boolean | CardIcons;
+  icons?: boolean | Partial<CardIcons>;
   theme?: ThemeObject;
   autoFocus?: boolean;
   hiddenFields?: ("number" | "expiry" | "cvc")[];

--- a/packages/ui-components/src/Card/utilities.ts
+++ b/packages/ui-components/src/Card/utilities.ts
@@ -180,7 +180,7 @@ async function encryptedCVC(
   return ev.encrypt(cvc);
 }
 
-export function collectIcons(icons: boolean | CardIcons) {
+export function collectIcons(icons: boolean | Partial<CardIcons>) {
   if (typeof icons === "boolean") return ICONS;
   return { ...ICONS, ...icons };
 }


### PR DESCRIPTION
# Why

Providing a partial `cardIcons` override (e.g. only overriding `visa`) caused a TypeScript error because the `icons` prop was typed as the full `CardIcons` type, making all card brand keys required.

Fixes [[EXP-993](https://linear.app/evervault/issue/EXP-993/enable-partial-cardicons-overrides-on-js-and-react-sdks)](https://linear.app/evervault/issue/EXP-993/enable-partial-cardicons-overrides-on-js-and-react-sdks).

# How

Changed the `icons` prop type to `Partial<CardIcons>` in the three public-facing locations:

- `CardOptions` in `packages/types/uiComponents.ts` (JS SDK `ui.card` config)
- `CardComponentOptions` in `packages/ui-components/src/Card/types.ts`
- `CardProps` in `packages/react/lib/ui/Card.tsx` (React SDK)

The `collectIcons` utility in `utilities.ts` was also updated to accept `Partial<CardIcons>` and continues to spread the full `ICONS` defaults first, so any unspecified brands fall back to their defaults. `BrandIcon` keeps its `icons` prop typed as the full `CardIcons` since it is an internal component that only ever receives the already-merged result of `collectIcons`.