### PR TITLE
Expose selectable disbursement merchantCapabilities (CARD-850)

### DIFF
--- a/.changeset/apple-pay-merchant-capabilities.md
+++ b/.changeset/apple-pay-merchant-capabilities.md
@@ -1,0 +1,6 @@
+---
+"@evervault/browser": minor
+"@evervault/js": minor
+---
+
+Add optional `merchantCapabilities` on Apple Pay disbursement transactions so merchants can select capabilities per call, matching iOS disbursement configuration.

--- a/packages/browser/lib/ui/ApplePay/utilities.ts
+++ b/packages/browser/lib/ui/ApplePay/utilities.ts
@@ -1,5 +1,6 @@
 import { getAppSDKConfig } from "shared/getAppSDKConfig";
 import {
+  ApplePayMerchantCapability,
   DisbursementTransactionDetails,
   MerchantDetail,
   PaymentTransactionDetails,
@@ -43,6 +44,22 @@ type BuildSessionOptions = {
     lineItems?: TransactionLineItem[];
   }>;
 };
+
+export function resolveDisbursementMerchantCapabilities(
+  tx: DisbursementTransactionDetails
+): ApplePayMerchantCapability[] {
+  if (tx.merchantCapabilities?.length) {
+    return tx.merchantCapabilities;
+  }
+
+  const merchantCapabilities: ApplePayMerchantCapability[] = ["supports3DS"];
+
+  if (tx.instantTransfer) {
+    merchantCapabilities.push("supportsInstantFundsOut");
+  }
+
+  return merchantCapabilities;
+}
 
 export async function buildSession(
   applePay: ApplePayButton,
@@ -365,11 +382,7 @@ function buildDisbursementSession(
       },
     })) || [];
 
-  const merchantCapabilities = ["supports3DS"];
-
-  if (tx.instantTransfer) {
-    merchantCapabilities.push("supportsInstantFundsOut");
-  }
+  const merchantCapabilities = resolveDisbursementMerchantCapabilities(tx);
 
   const paymentMethodData = [
     {

--- a/packages/browser/test/applePay.test.ts
+++ b/packages/browser/test/applePay.test.ts
@@ -4,12 +4,17 @@ import {
   describe,
   assert,
   it,
+  expect,
   beforeAll,
   afterAll,
   afterEach,
   beforeEach,
 } from "vitest";
-import { buildSession } from "../lib/ui/ApplePay/utilities";
+import {
+  buildSession,
+  resolveDisbursementMerchantCapabilities,
+} from "../lib/ui/ApplePay/utilities";
+import type { ApplePayMerchantCapability } from "types";
 import ApplePayButton from "../lib/ui/ApplePay";
 import { setupCrypto } from "./setup";
 
@@ -19,9 +24,16 @@ const merchantId = "merchant_abc";
 const merchantName = "Acme Co";
 
 const paymentRequestCalls: PaymentDetailsInit[] = [];
+const paymentMethodDataCalls: Array<{
+  merchantCapabilities?: string[];
+}> = [];
 
 class MockPaymentRequest {
-  constructor(_methodData: unknown, details: PaymentDetailsInit) {
+  constructor(
+    methodData: Array<{ data?: { merchantCapabilities?: string[] } }>,
+    details: PaymentDetailsInit
+  ) {
+    paymentMethodDataCalls.push(methodData[0]?.data ?? {});
     paymentRequestCalls.push(details);
   }
 }
@@ -50,6 +62,7 @@ beforeAll(() => {
 
 beforeEach(() => {
   paymentRequestCalls.length = 0;
+  paymentMethodDataCalls.length = 0;
   server.use(
     http.get(`${apiUrl}/frontend/merchants/${merchantId}`, () =>
       HttpResponse.json({ id: merchantId, name: merchantName }, { status: 200 })
@@ -91,5 +104,70 @@ describe("buildSession sandbox label", () => {
     await buildSession(applePay, { transaction });
 
     assert(paymentRequestCalls[0].total?.label === merchantName);
+  });
+});
+
+describe("resolveDisbursementMerchantCapabilities", () => {
+  const baseDisbursement = {
+    type: "disbursement" as const,
+    amount: 1000,
+    currency: "USD",
+    country: "US",
+    merchantId,
+    domain: "shop.example.com",
+  };
+
+  it("uses explicit merchantCapabilities when provided", () => {
+    expect(
+      resolveDisbursementMerchantCapabilities({
+        ...baseDisbursement,
+        merchantCapabilities: ["supportsEMV", "supportsCredit"],
+      })
+    ).toEqual(["supportsEMV", "supportsCredit"]);
+  });
+
+  it("defaults to supports3DS when no override or instant transfer", () => {
+    expect(resolveDisbursementMerchantCapabilities(baseDisbursement)).toEqual([
+      "supports3DS",
+    ]);
+  });
+
+  it("adds supportsInstantFundsOut when instantTransfer is set", () => {
+    expect(
+      resolveDisbursementMerchantCapabilities({
+        ...baseDisbursement,
+        instantTransfer: { label: "Instant fee", amount: 50 },
+      })
+    ).toEqual(["supports3DS", "supportsInstantFundsOut"]);
+  });
+});
+
+describe("buildSession disbursement merchantCapabilities", () => {
+  const disbursementTransaction = {
+    type: "disbursement" as const,
+    amount: 1000,
+    currency: "USD",
+    country: "US",
+    merchantId,
+    domain: "shop.example.com",
+    merchantCapabilities: [
+      "supportsDebit",
+    ] satisfies ApplePayMerchantCapability[],
+  };
+
+  beforeEach(() => {
+    server.use(
+      http.get(`${apiUrl}/frontend/sdk/config`, () =>
+        HttpResponse.json({ is_sandbox: false }, { status: 200 })
+      )
+    );
+  });
+
+  it("passes explicit merchantCapabilities to the PaymentRequest", async () => {
+    await buildSession(applePay, { transaction: disbursementTransaction });
+
+    assert(
+      paymentMethodDataCalls[0].merchantCapabilities?.[0] === "supportsDebit"
+    );
   });
 });

--- a/packages/browser/test/applePay.test.ts
+++ b/packages/browser/test/applePay.test.ts
@@ -18,8 +18,11 @@ import { Transaction } from "../lib/resources/transaction";
 import type EvervaultClient from "../lib/main";
 import { setupCrypto } from "./setup";
 
-const { buildSession, mapTransactionType, resolveDisbursementMerchantCapabilities } =
-  applePayUtilities;
+const {
+  buildSession,
+  mapTransactionType,
+  resolveDisbursementMerchantCapabilities,
+} = applePayUtilities;
 const buildSessionMock = vi.fn();
 
 const apiUrl = "https://api.test.evervault.com";

--- a/packages/types/uiComponents.ts
+++ b/packages/types/uiComponents.ts
@@ -639,10 +639,19 @@ export interface RecurringTransactionDetails extends BaseTransactionDetails {
 
 // Disbursement-specific fields
 export type RequiredRecipientDetail = "email" | "phone" | "name" | "address";
+
+export type ApplePayMerchantCapability =
+  | "supports3DS"
+  | "supportsEMV"
+  | "supportsCredit"
+  | "supportsDebit"
+  | "supportsInstantFundsOut";
+
 export interface DisbursementTransactionDetails extends BaseTransactionDetails {
   type: "disbursement";
   instantTransfer?: InstantTransferDetails;
   requiredRecipientDetails?: RequiredRecipientDetail[];
+  merchantCapabilities?: ApplePayMerchantCapability[];
 }
 
 export type TransactionDetails =


### PR DESCRIPTION
Allow merchants to pass merchantCapabilities on disbursement transactions while preserving the instantTransfer default behavior.


