### PR TITLE
Add optional appleMerchantId to Apple Pay web SDK (CARD-851)

### DIFF
--- a/.changeset/apple-pay-apple-merchant-id.md
+++ b/.changeset/apple-pay-apple-merchant-id.md
@@ -1,0 +1,6 @@
+---
+"@evervault/browser": minor
+"@evervault/js": minor
+---
+
+Add optional `appleMerchantId` to the Apple Pay web SDK. Defaults to `merchant.com.evervault.{merchantId}` for compatibility with Evervault domain verification.

--- a/packages/browser/lib/ui/ApplePay/index.ts
+++ b/packages/browser/lib/ui/ApplePay/index.ts
@@ -6,7 +6,11 @@ import type {
   TransactionLineItem,
 } from "types";
 import { resolveSelector } from "../utils";
-import { buildSession, resolveUnit } from "./utilities";
+import {
+  buildSession,
+  resolveMerchantIdentifier,
+  resolveUnit,
+} from "./utilities";
 import EventManager from "../eventManager";
 import {
   ApplePayButtonLocale,
@@ -50,6 +54,7 @@ export type ApplePayButtonOptions = {
     amount?: number;
     lineItems?: TransactionLineItem[];
   }>;
+  appleMerchantId?: string;
   process: (
     data: EncryptedApplePayData,
     helpers: {
@@ -126,6 +131,7 @@ export default class ApplePayButton {
       onPaymentMethodChange: this.#options.onPaymentMethodChange,
       onShippingAddressChange: this.#options.onShippingAddressChange,
       prepareTransaction: this.#options.prepareTransaction,
+      appleMerchantId: this.#options.appleMerchantId,
     });
 
     const [response, responseError] = await tryCatch(session.show());
@@ -258,7 +264,10 @@ export default class ApplePayButton {
     }
 
     const capabilities = await ApplePaySession.applePayCapabilities(
-      `merchant.com.evervault.${this.transaction.details.merchantId}`
+      resolveMerchantIdentifier(
+        this.transaction.details.merchantId,
+        this.#options.appleMerchantId
+      )
     );
 
     if (capabilities.paymentCredentialStatus === "applePayUnsupported") {

--- a/packages/browser/lib/ui/ApplePay/utilities.ts
+++ b/packages/browser/lib/ui/ApplePay/utilities.ts
@@ -42,7 +42,15 @@ type BuildSessionOptions = {
     amount?: number;
     lineItems?: TransactionLineItem[];
   }>;
+  appleMerchantId?: string;
 };
+
+export function resolveMerchantIdentifier(
+  evervaultMerchantId: string,
+  appleMerchantId?: string
+): string {
+  return appleMerchantId ?? `merchant.com.evervault.${evervaultMerchantId}`;
+}
 
 export async function buildSession(
   applePay: ApplePayButton,
@@ -193,7 +201,10 @@ function buildPaymentSession(
       supportedMethods: "https://apple.com/apple-pay",
       data: {
         version: 3,
-        merchantIdentifier: `merchant.com.evervault.${config.transaction.merchantId}`,
+        merchantIdentifier: resolveMerchantIdentifier(
+          config.transaction.merchantId,
+          config.appleMerchantId
+        ),
         merchantCapabilities: ["supports3DS"],
         supportedNetworks: config.allowedCardNetworks?.map((network) =>
           network.toLowerCase()
@@ -280,7 +291,10 @@ function buildRecurringSession(
       supportedMethods: "https://apple.com/apple-pay",
       data: {
         version: 3,
-        merchantIdentifier: `merchant.com.evervault.${config.transaction.merchantId}`,
+        merchantIdentifier: resolveMerchantIdentifier(
+          config.transaction.merchantId,
+          config.appleMerchantId
+        ),
         merchantCapabilities: ["supports3DS"],
         supportedNetworks: config.allowedCardNetworks?.map((network) =>
           network.toLowerCase()
@@ -376,7 +390,10 @@ function buildDisbursementSession(
       supportedMethods: "https://apple.com/apple-pay",
       data: {
         version: 3,
-        merchantIdentifier: `merchant.com.evervault.${config.transaction.merchantId}`,
+        merchantIdentifier: resolveMerchantIdentifier(
+          config.transaction.merchantId,
+          config.appleMerchantId
+        ),
         merchantCapabilities,
         supportedNetworks: config.allowedCardNetworks,
         countryCode: tx.country,

--- a/packages/browser/test/applePay.test.ts
+++ b/packages/browser/test/applePay.test.ts
@@ -4,12 +4,16 @@ import {
   describe,
   assert,
   it,
+  expect,
   beforeAll,
   afterAll,
   afterEach,
   beforeEach,
 } from "vitest";
-import { buildSession } from "../lib/ui/ApplePay/utilities";
+import {
+  buildSession,
+  resolveMerchantIdentifier,
+} from "../lib/ui/ApplePay/utilities";
 import ApplePayButton from "../lib/ui/ApplePay";
 import { setupCrypto } from "./setup";
 
@@ -19,9 +23,14 @@ const merchantId = "merchant_abc";
 const merchantName = "Acme Co";
 
 const paymentRequestCalls: PaymentDetailsInit[] = [];
+const paymentMethodDataCalls: Array<{ merchantIdentifier?: string }> = [];
 
 class MockPaymentRequest {
-  constructor(_methodData: unknown, details: PaymentDetailsInit) {
+  constructor(
+    methodData: Array<{ data?: { merchantIdentifier?: string } }>,
+    details: PaymentDetailsInit
+  ) {
+    paymentMethodDataCalls.push(methodData[0]?.data ?? {});
     paymentRequestCalls.push(details);
   }
 }
@@ -50,6 +59,7 @@ beforeAll(() => {
 
 beforeEach(() => {
   paymentRequestCalls.length = 0;
+  paymentMethodDataCalls.length = 0;
   server.use(
     http.get(`${apiUrl}/frontend/merchants/${merchantId}`, () =>
       HttpResponse.json({ id: merchantId, name: merchantName }, { status: 200 })
@@ -91,5 +101,50 @@ describe("buildSession sandbox label", () => {
     await buildSession(applePay, { transaction });
 
     assert(paymentRequestCalls[0].total?.label === merchantName);
+  });
+});
+
+describe("resolveMerchantIdentifier", () => {
+  it("returns the Evervault merchant identifier by default", () => {
+    expect(resolveMerchantIdentifier("merchant_abc")).toBe(
+      "merchant.com.evervault.merchant_abc"
+    );
+  });
+
+  it("returns a custom Apple merchant identifier when provided", () => {
+    expect(
+      resolveMerchantIdentifier("merchant_abc", "merchant.com.example.store")
+    ).toBe("merchant.com.example.store");
+  });
+});
+
+describe("buildSession appleMerchantId", () => {
+  beforeEach(() => {
+    server.use(
+      http.get(`${apiUrl}/frontend/sdk/config`, () =>
+        HttpResponse.json({ is_sandbox: false }, { status: 200 })
+      )
+    );
+  });
+
+  it("uses a custom appleMerchantId in the PaymentRequest", async () => {
+    await buildSession(applePay, {
+      transaction,
+      appleMerchantId: "merchant.com.example.custom",
+    });
+
+    assert(
+      paymentMethodDataCalls[0].merchantIdentifier ===
+        "merchant.com.example.custom"
+    );
+  });
+
+  it("falls back to the Evervault merchant identifier when omitted", async () => {
+    await buildSession(applePay, { transaction });
+
+    assert(
+      paymentMethodDataCalls[0].merchantIdentifier ===
+        `merchant.com.evervault.${merchantId}`
+    );
   });
 });

--- a/packages/types/uiComponents.ts
+++ b/packages/types/uiComponents.ts
@@ -577,6 +577,7 @@ export interface ApplePayOptions {
   borderRadius?: number;
   size?: { width: WalletDimension; height: WalletDimension };
   allowedCardNetworks?: ApplePayCardNetwork[];
+  appleMerchantId?: string;
   paymentOverrides?: {
     paymentMethodData?: PaymentMethodData[];
     paymentDetails?: PaymentDetailsInit;


### PR DESCRIPTION
Expose a custom Apple merchant identifier option while defaulting to merchant.com.evervault.{merchantId} for Evervault domain verification.

