### PR TITLE
Map Apple Pay web paymentDataType to transaction category (CARD-849)

### DIFF
--- a/.changeset/apple-pay-payment-data-type.md
+++ b/.changeset/apple-pay-payment-data-type.md
@@ -1,0 +1,6 @@
+---
+"@evervault/browser": minor
+"@evervault/js": minor
+---
+
+Map Apple Pay web `process()` `paymentDataType` to the transaction category (`oneOff`, `recurring`, or `disbursement`) to match the iOS SDK response shape.

--- a/.changeset/apple-pay-payment-data-type.md
+++ b/.changeset/apple-pay-payment-data-type.md
@@ -3,4 +3,4 @@
 "@evervault/js": minor
 ---
 
-Map Apple Pay web `process()` `paymentDataType` to the transaction category (`oneOff`, `recurring`, or `disbursement`) to match the iOS SDK response shape.
+Add `transactionType` to the Apple Pay web `process()` payload (`oneOff`, `recurring`, or `disbursement`) based on the transaction category. `paymentDataType` continues to reflect the Apple token format returned by the credentials API (e.g. `3DSecure`).

--- a/packages/browser/lib/ui/ApplePay/index.ts
+++ b/packages/browser/lib/ui/ApplePay/index.ts
@@ -8,7 +8,7 @@ import type {
 import { resolveSelector } from "../utils";
 import {
   buildSession,
-  mapTransactionPaymentDataType,
+  mapTransactionType,
   resolveUnit,
 } from "./utilities";
 import EventManager from "../eventManager";
@@ -188,7 +188,7 @@ export default class ApplePayButton {
         encrypted.shippingContact = response.details.shippingContact;
       }
 
-      encrypted.paymentDataType = mapTransactionPaymentDataType(
+      encrypted.transactionType = mapTransactionType(
         this.transaction.details.type
       );
 

--- a/packages/browser/lib/ui/ApplePay/index.ts
+++ b/packages/browser/lib/ui/ApplePay/index.ts
@@ -6,11 +6,7 @@ import type {
   TransactionLineItem,
 } from "types";
 import { resolveSelector } from "../utils";
-import {
-  buildSession,
-  mapTransactionType,
-  resolveUnit,
-} from "./utilities";
+import { buildSession, mapTransactionType, resolveUnit } from "./utilities";
 import EventManager from "../eventManager";
 import {
   ApplePayButtonLocale,

--- a/packages/browser/lib/ui/ApplePay/index.ts
+++ b/packages/browser/lib/ui/ApplePay/index.ts
@@ -6,7 +6,11 @@ import type {
   TransactionLineItem,
 } from "types";
 import { resolveSelector } from "../utils";
-import { buildSession, resolveUnit } from "./utilities";
+import {
+  buildSession,
+  mapTransactionPaymentDataType,
+  resolveUnit,
+} from "./utilities";
 import EventManager from "../eventManager";
 import {
   ApplePayButtonLocale,
@@ -172,6 +176,10 @@ export default class ApplePayButton {
         encrypted.card.lastFour = lastFour[0];
       }
     }
+
+    encrypted.paymentDataType = mapTransactionPaymentDataType(
+      this.transaction.details.type
+    );
 
     let failed = false;
 

--- a/packages/browser/lib/ui/ApplePay/utilities.ts
+++ b/packages/browser/lib/ui/ApplePay/utilities.ts
@@ -1,9 +1,11 @@
 import { getAppSDKConfig } from "shared/getAppSDKConfig";
 import {
+  ApplePayTransactionPaymentDataType,
   DisbursementTransactionDetails,
   MerchantDetail,
   PaymentTransactionDetails,
   RecurringTransactionDetails,
+  TransactionDetails,
   TransactionDetailsWithDomain,
   TransactionLineItem,
 } from "types";
@@ -43,6 +45,19 @@ type BuildSessionOptions = {
     lineItems?: TransactionLineItem[];
   }>;
 };
+
+export function mapTransactionPaymentDataType(
+  type: TransactionDetails["type"]
+): ApplePayTransactionPaymentDataType {
+  switch (type) {
+    case "payment":
+      return "oneOff";
+    case "recurring":
+      return "recurring";
+    case "disbursement":
+      return "disbursement";
+  }
+}
 
 export async function buildSession(
   applePay: ApplePayButton,

--- a/packages/browser/lib/ui/ApplePay/utilities.ts
+++ b/packages/browser/lib/ui/ApplePay/utilities.ts
@@ -1,6 +1,6 @@
 import { getAppSDKConfig } from "shared/getAppSDKConfig";
 import {
-  ApplePayTransactionPaymentDataType,
+  ApplePayTransactionType,
   DisbursementTransactionDetails,
   MerchantDetail,
   PaymentTransactionDetails,
@@ -46,9 +46,9 @@ type BuildSessionOptions = {
   }>;
 };
 
-export function mapTransactionPaymentDataType(
+export function mapTransactionType(
   type: TransactionDetails["type"]
-): ApplePayTransactionPaymentDataType {
+): ApplePayTransactionType {
   switch (type) {
     case "payment":
       return "oneOff";

--- a/packages/browser/test/applePay.test.ts
+++ b/packages/browser/test/applePay.test.ts
@@ -4,12 +4,16 @@ import {
   describe,
   assert,
   it,
+  expect,
   beforeAll,
   afterAll,
   afterEach,
   beforeEach,
 } from "vitest";
-import { buildSession } from "../lib/ui/ApplePay/utilities";
+import {
+  buildSession,
+  mapTransactionPaymentDataType,
+} from "../lib/ui/ApplePay/utilities";
 import ApplePayButton from "../lib/ui/ApplePay";
 import { setupCrypto } from "./setup";
 
@@ -91,5 +95,19 @@ describe("buildSession sandbox label", () => {
     await buildSession(applePay, { transaction });
 
     assert(paymentRequestCalls[0].total?.label === merchantName);
+  });
+});
+
+describe("mapTransactionPaymentDataType", () => {
+  it("maps payment to oneOff", () => {
+    expect(mapTransactionPaymentDataType("payment")).toBe("oneOff");
+  });
+
+  it("maps recurring to recurring", () => {
+    expect(mapTransactionPaymentDataType("recurring")).toBe("recurring");
+  });
+
+  it("maps disbursement to disbursement", () => {
+    expect(mapTransactionPaymentDataType("disbursement")).toBe("disbursement");
   });
 });

--- a/packages/browser/test/applePay.test.ts
+++ b/packages/browser/test/applePay.test.ts
@@ -17,7 +17,7 @@ import { Transaction } from "../lib/resources/transaction";
 import type EvervaultClient from "../lib/main";
 import { setupCrypto } from "./setup";
 
-const { buildSession, mapTransactionPaymentDataType } = applePayUtilities;
+const { buildSession, mapTransactionType } = applePayUtilities;
 const buildSessionMock = vi.fn();
 
 const apiUrl = "https://api.test.evervault.com";
@@ -101,17 +101,17 @@ describe("buildSession sandbox label", () => {
   });
 });
 
-describe("mapTransactionPaymentDataType", () => {
+describe("mapTransactionType", () => {
   it("maps payment to oneOff", () => {
-    expect(mapTransactionPaymentDataType("payment")).toBe("oneOff");
+    expect(mapTransactionType("payment")).toBe("oneOff");
   });
 
   it("maps recurring to recurring", () => {
-    expect(mapTransactionPaymentDataType("recurring")).toBe("recurring");
+    expect(mapTransactionType("recurring")).toBe("recurring");
   });
 
   it("maps disbursement to disbursement", () => {
-    expect(mapTransactionPaymentDataType("disbursement")).toBe("disbursement");
+    expect(mapTransactionType("disbursement")).toBe("disbursement");
   });
 });
 

--- a/packages/types/uiComponents.ts
+++ b/packages/types/uiComponents.ts
@@ -321,7 +321,7 @@ export interface ApplePayHostMessages extends EvervaultFrameHostMessages {
   EV_APPLE_PAY_SUCCESS: undefined;
 }
 
-export type ApplePayTransactionPaymentDataType =
+export type ApplePayTransactionType =
   | "oneOff"
   | "recurring"
   | "disbursement";
@@ -335,7 +335,8 @@ export type EncryptedApplePayData = Omit<EncryptedDPAN<"apple">, "token"> & {
     phoneNumber?: string;
     address?: unknown;
   };
-  paymentDataType: ApplePayTransactionPaymentDataType;
+  paymentDataType: string;
+  transactionType: ApplePayTransactionType;
   deviceManufacturerIdentifier: string;
   shippingContact?: {
     givenName?: string;

--- a/packages/types/uiComponents.ts
+++ b/packages/types/uiComponents.ts
@@ -321,6 +321,11 @@ export interface ApplePayHostMessages extends EvervaultFrameHostMessages {
   EV_APPLE_PAY_SUCCESS: undefined;
 }
 
+export type ApplePayTransactionPaymentDataType =
+  | "oneOff"
+  | "recurring"
+  | "disbursement";
+
 export type EncryptedApplePayData = Omit<EncryptedDPAN<"apple">, "token"> & {
   networkToken: PaymentToken<"apple"> & { rawExpiry: string };
   billingContact?: {
@@ -330,7 +335,7 @@ export type EncryptedApplePayData = Omit<EncryptedDPAN<"apple">, "token"> & {
     phoneNumber?: string;
     address?: unknown;
   };
-  paymentDataType: string;
+  paymentDataType: ApplePayTransactionPaymentDataType;
   deviceManufacturerIdentifier: string;
   shippingContact?: {
     givenName?: string;

--- a/packages/types/uiComponents.ts
+++ b/packages/types/uiComponents.ts
@@ -321,10 +321,7 @@ export interface ApplePayHostMessages extends EvervaultFrameHostMessages {
   EV_APPLE_PAY_SUCCESS: undefined;
 }
 
-export type ApplePayTransactionType =
-  | "oneOff"
-  | "recurring"
-  | "disbursement";
+export type ApplePayTransactionType = "oneOff" | "recurring" | "disbursement";
 
 export type EncryptedApplePayData = Omit<EncryptedDPAN<"apple">, "token"> & {
   networkToken: PaymentToken<"apple"> & { rawExpiry: string };


### PR DESCRIPTION
Align the process() payload with iOS by setting paymentDataType to oneOff, recurring, or disbursement based on the transaction type.
