### PR TITLE
Update React Native `evervault-core` dependency

### DIFF
--- a/.changeset/seven-games-sniff.md
+++ b/.changeset/seven-games-sniff.md
@@ -1,0 +1,6 @@
+---
+"@evervault/react-native": minor
+"evervault-expo-example": patch
+---
+
+Update Android dependency to 2.5.0

--- a/examples/expo/CONTRIBUTING.md
+++ b/examples/expo/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing
+
+## Local Android SDK
+
+If you need to test changes to the Android SDK, you can build it locally and use it in your project.
+
+1. Clone the Android SDK repository and make any local changes you need.
+
+```bash
+git clone https://github.com/evervault/evervault-android.git
+cd evervault-android
+```
+
+2. Update the Android SDK's `version.properties` file to include a `-local` suffix.
+
+```diff
+-VERSION_NAME=2.5.0
++VERSION_NAME=2.5.0-local
+```
+
+3. Build the SDK and publish it to your local Maven repository:
+
+```bash
+./gradlew :evervault-core:publishToMavenLocal
+```
+
+4. Add the local Maven repository to `packages/react-native-v2/android/build.gradle` file:
+
+```diff
+ repositories {
++  mavenLocal()
+ }
+
+ dependencies {
+-  implementation 'com.evervault.sdk:evervault-core:2.5.0'
++  implementation 'com.evervault.sdk:evervault-core:2.5.0-local'
+ }
+```
+
+5. Run the local Android build with the `LOCAL_ANDROID_SDK=true` environment variable set.
+
+```gradle
+LOCAL_ANDROID_SDK=true pnpm android
+```

--- a/examples/expo/app.config.js
+++ b/examples/expo/app.config.js
@@ -1,7 +1,19 @@
+const os = require("os");
+
 const buildProperties = {
   android: {},
   ios: {},
 };
+
+if (process.env.LOCAL_ANDROID_SDK === "true") {
+  // Point at the local Maven repo so Expo picks up evervault-core
+  // built & published via `./gradlew :evervault-core:publishToMavenLocal`.
+  buildProperties.android.extraMavenRepos = [
+    `file://${os.homedir()}/.m2/repository`,
+  ];
+
+  console.log("Using local Android SDK.");
+}
 
 if (process.env.PROGUARD_ENABLED === "true") {
   const extraProguardRules = `

--- a/packages/react-native-v2/android/build.gradle
+++ b/packages/react-native-v2/android/build.gradle
@@ -8,7 +8,8 @@ buildscript {
   }
   dependencies {
     classpath("com.android.tools.build:gradle:7.3.1")
-    classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.22")
+    def kotlinVersion = safeExtGet('kotlinVersion', '2.1.20')
+    classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
   }
 }
 
@@ -33,5 +34,5 @@ repositories {
 
 dependencies {
   implementation 'com.facebook.react:react-native'
-  implementation 'com.evervault.sdk:evervault-core:1.1'
+  implementation 'com.evervault.sdk:evervault-core:2.5.0'
 }


### PR DESCRIPTION
# Why

Continues the work in #923 and updates the Android `evervault-core` SDK from 1.1 → 2.5.0

# How

- Updates Android `evervault-core` SDK to 2.5.0
- Updates dependency Kotlin version to 2.1.20 to match `evervault-core`
- Add instructions for how to test Android SDK changes locally
