### PR TITLE
Track RN Android dependencies via Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,7 @@ updates:
     directory: "packages/react-native-v2"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "gradle"
+    directory: "packages/react-native-v2/android"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
# Why

Updates our Dependabot config to track Android/Gradle dependencies used in our React Native SDK
