### PR TITLE
Expose transactionId to merchants

### DIFF
--- a/.changeset/apple-pay-transaction-id.md
+++ b/.changeset/apple-pay-transaction-id.md
@@ -1,0 +1,6 @@
+---
+"@evervault/browser": minor
+"@evervault/js": minor
+---
+
+Surface Apple Pay's `transactionId` (from the PKPaymentToken header) on the `EncryptedApplePayData` type returned to the `process()` callback. The backend already returns this field; it was not previously exposed on the type.

--- a/packages/types/uiComponents.ts
+++ b/packages/types/uiComponents.ts
@@ -348,6 +348,7 @@ export type EncryptedApplePayData = Omit<
   };
   paymentDataType: string;
   transactionType: ApplePayTransactionType;
+  transactionId: string;
   deviceManufacturerIdentifier: string;
   shippingContact?: {
     givenName?: string;


### PR DESCRIPTION
# Why
Customer request 👀 

https://linear.app/evervault/issue/CARD-1027/apple-pay-expose-token-transactionid-in-api-response-web-ios

Tested manually, transaction id is now returned.
<img width="1467" height="256" alt="Screenshot 2026-07-20 at 11 55 46" src="https://github.com/user-attachments/assets/71355b63-0cc9-4e98-88a5-574ae183d121" />

