### PR TITLE
Prevent masked input flicker on React Native

### DIFF
--- a/.changeset/mighty-eels-try.md
+++ b/.changeset/mighty-eels-try.md
@@ -1,0 +1,5 @@
+---
+"@evervault/react-native": patch
+---
+
+Fix input flicker on masked Card inputs (Number, Expiry, Cvc)

--- a/examples/expo/app.config.js
+++ b/examples/expo/app.config.js
@@ -60,6 +60,9 @@ module.exports = {
       },
       package: "com.evervault.expoexample",
     },
+    experiments: {
+      reactCanary: true,
+    },
     plugins: [
       [
         "expo-splash-screen",

--- a/packages/react-native-v2/src/Input.tsx
+++ b/packages/react-native-v2/src/Input.tsx
@@ -106,6 +106,16 @@ export function mask(format: string): MaskArray {
   return maskArray;
 }
 
+function getMaskLength(mask: Mask | undefined, value?: string) {
+  if (!mask) {
+    return undefined;
+  } else if (typeof mask === "function") {
+    return mask(value).length;
+  } else {
+    return mask.length;
+  }
+}
+
 export interface EvervaultInputProps<Values extends Record<string, unknown>>
   extends BaseEvervaultInputProps {
   name: keyof Values;
@@ -158,6 +168,7 @@ export const EvervaultInput = forwardRef<
         props.onBlur?.(evt);
       }}
       mask={mask}
+      maxLength={getMaskLength(mask, field.value)}
       maskAutoComplete={!!mask}
       obfuscationCharacter={obfuscationCharacter}
       showObfuscatedValue={!!obfuscateValue}

--- a/packages/react-native-v2/src/Input.tsx
+++ b/packages/react-native-v2/src/Input.tsx
@@ -10,11 +10,10 @@ import {
   useImperativeHandle,
   useMemo,
   useRef,
-  useState,
 } from "react";
 import { TextInput, TextInputProps } from "react-native";
 import { mergeRefs } from "./utils";
-import { Controller, useController, useFormContext } from "react-hook-form";
+import { useController, useFormContext } from "react-hook-form";
 import MaskInput, { Mask, MaskArray } from "react-native-mask-input";
 
 export interface EvervaultInputContextValue {


### PR DESCRIPTION
# Why

Since we know the length of the masked input value ahead of time, we can add the `maxLength` prop to our masked inputs to prevent flicker

## Before

https://github.com/user-attachments/assets/2cb3b14e-a49f-49cc-9079-f5029be7ed53

## After

https://github.com/user-attachments/assets/92dbbd79-54b6-48fb-999d-8af9d922a172