### PR TITLE
Fix ApplePay checkout failure - desktop Chrome QR 

### DIFF
--- a/.changeset/shy-donuts-relax.md
+++ b/.changeset/shy-donuts-relax.md
@@ -1,0 +1,6 @@
+---
+"@evervault/browser": patch
+"@evervault/js": patch
+---
+
+Fix a crash in Apple Pay's `onshippingaddresschange` handler when `event.target` is `null`. This could happen during the desktop-Chrome + phone-QR "remote continuity" handoff, throwing `Cannot read properties of null (reading 'shippingAddress')` and leaving the sheet stuck on "Processing" until it timed out.

--- a/packages/browser/lib/ui/ApplePay/utilities.ts
+++ b/packages/browser/lib/ui/ApplePay/utilities.ts
@@ -190,9 +190,12 @@ export async function buildSession(
   // Coupon updates may also arrive here (methodDetails.couponCode) without a
   // shipping address — never return early without updateWith.
   baseRequest.onshippingaddresschange = (event: PaymentRequestUpdateEvent) => {
+    // event.target can be null here — e.g. Apple's apple-pay-sdk.js polyfill
+    // invokes this with a null target during the desktop-Chrome + phone-QR
+    // remote-continuity handoff.
     const target = event.target as unknown as {
       shippingAddress?: ShippingAddress;
-    };
+    } | null;
     const methodDetails = (
       event as PaymentRequestUpdateEvent & { methodDetails?: unknown }
     ).methodDetails;
@@ -209,7 +212,7 @@ export async function buildSession(
       return;
     }
 
-    if (target.shippingAddress && config.onShippingAddressChange) {
+    if (target?.shippingAddress && config.onShippingAddressChange) {
       // Do not await this promise — PaymentRequest expects updateWith(promise).
       event.updateWith(
         updatePaymentRequest(target.shippingAddress, config, tx, merchant)

--- a/packages/browser/test/applePay.test.ts
+++ b/packages/browser/test/applePay.test.ts
@@ -176,6 +176,72 @@ describe("buildSession sandbox label", () => {
   });
 });
 
+describe("buildSession onshippingaddresschange", () => {
+  beforeEach(() => {
+    server.use(
+      http.get(`${apiUrl}/frontend/sdk/config`, () =>
+        HttpResponse.json({ is_sandbox: false }, { status: 200 })
+      )
+    );
+  });
+
+  const shippingAddress = {
+    addressLine: ["1 Main St"],
+    city: "Dublin",
+    country: "Ireland",
+    dependentLocality: "",
+    organization: "",
+    phone: "",
+    postalCode: "D01",
+    recipient: "Jane Doe",
+    region: "Leinster",
+    sortingCode: "",
+  };
+
+  it("does not throw and still calls updateWith when event.target is null", async () => {
+    // Repro for a customer-reported crash on desktop Chrome + phone-QR Apple
+    // Pay handoff: apple-pay-sdk.js's polyfill invokes onshippingaddresschange
+    // with event.target === null in that remote-continuity flow, which threw
+    // "Cannot read properties of null (reading 'shippingAddress')" and left
+    // the sheet stuck on "Processing" since updateWith was never called.
+    const onShippingAddressChange = vi.fn().mockResolvedValue({ amount: 500 });
+    const request = await buildSession(applePay, {
+      transaction,
+      requestShipping: true,
+      onShippingAddressChange,
+    });
+
+    const updateWith = vi.fn();
+    const event = {
+      target: null,
+      updateWith,
+    } as unknown as PaymentRequestUpdateEvent;
+
+    expect(() => request.onshippingaddresschange?.(event)).not.toThrow();
+    expect(updateWith).toHaveBeenCalled();
+  });
+
+  it("calls onShippingAddressChange and updateWith when a shipping address is present", async () => {
+    const onShippingAddressChange = vi.fn().mockResolvedValue({ amount: 500 });
+    const request = await buildSession(applePay, {
+      transaction,
+      requestShipping: true,
+      onShippingAddressChange,
+    });
+
+    const updateWith = vi.fn();
+    const event = {
+      target: { shippingAddress },
+      updateWith,
+    } as unknown as PaymentRequestUpdateEvent;
+
+    request.onshippingaddresschange?.(event);
+
+    expect(onShippingAddressChange).toHaveBeenCalledWith(shippingAddress);
+    expect(updateWith).toHaveBeenCalled();
+  });
+});
+
 describe("resolveMerchantIdentifier", () => {
   it("returns the Evervault merchant identifier by default", () => {
     expect(resolveMerchantIdentifier("merchant_abc")).toBe(


### PR DESCRIPTION
# Why
https://linear.app/evervault/issue/PE-112/fix-apple-pay-desktop-chrome-qr-checkout-failure

`event.target` is normally the reference back to the object that dispatched the event  — for a real `PaymentRequestUpdateEvent`, that's supposed to be the `PaymentRequest` instance itself, which is why the code expects `target.shippingAddress to work (the spec puts the current shipping address on the request object during this event).

In this bug, `event.target` is null instead of that instance. We know this specifically because of the exact wording of the error: Cannot read properties of null (reading 'shippingAddress'). V8 distinguishes null from undefined in that message, so the value being dereferenced is literally null — not a `PaymentRequest` missing a `shippingAddress` field, and not undefined.

Why would it be null at all? Our code never constructs this event — Apple's apple-pay-sdk.js polyfill In the normal same-device flow it presumably sets target correctly. In the desktop-Chrome + phone-QR "remote continuity" flow the session is reconstructed from a signal relayed from the phone, and Apple's polyfill apparently synthesizes the event without wiring up target at all, leaving it null.

**Tested** manually + unit test added
