### PR TITLE
Add changelog entries for #954 3DS iframe and memoization fix

### DIFF
--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - ee0d7fc: Added more script load handling tools (ScriptLoadError, loadTimeout)
 
+### Patch Changes
+
+- a7ddfa7: Fix duplicate 3DS iframe posts and Evervault client memoization
+
 ## 2.27.1
 
 ### Patch Changes

--- a/packages/ui-components/CHANGELOG.md
+++ b/packages/ui-components/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Patch Changes
 
+- a7ddfa7: Fix duplicate 3DS iframe posts and Evervault client memoization
 - Updated dependencies [ee0d7fc]
   - @evervault/react@2.28.0
 


### PR DESCRIPTION
## Summary
- PR #954 (duplicate 3DS iframe posts / Evervault client memoization fix) shipped in `@evervault/react@2.28.0` and `@evervault/ui-components@1.41.4` but was missing a changeset, so it had no changelog entry.
- Retroactively adds a changelog line for both packages under their existing `2.28.0`/`1.41.4` sections to reflect what actually shipped.