### PR TITLE
Add Apple Pay shipping methods and onShippingMethodSelected (CARD-875…

### DIFF
--- a/.changeset/swift-shipping-methods.md
+++ b/.changeset/swift-shipping-methods.md
@@ -1,0 +1,6 @@
+---
+"@evervault/browser": minor
+"@evervault/js": minor
+---
+
+Add Apple Pay shipping methods and shipping type on the web SDK (`shippingMethods`, `shippingType`, `onShippingMethodSelected`). Merchants can offer selectable shipping options on one-off payment sheets; selecting a method recomputes totals (via the merchant callback or an internal amount adjustment) and the chosen method is returned on the `process()` payload as `shippingMethod`.

--- a/packages/browser/lib/ui/ApplePay/index.ts
+++ b/packages/browser/lib/ui/ApplePay/index.ts
@@ -18,6 +18,8 @@ import {
   ApplePayButtonStyle,
   ApplePayButtonType,
   ApplePayCardNetwork,
+  ApplePayShippingMethod,
+  ApplePayShippingType,
   CouponCodeChangeResult,
   PaymentContact,
   PaymentMethodUpdate,
@@ -52,6 +54,29 @@ export type ApplePayButtonOptions = {
   ) => Promise<{ amount: number; lineItems?: TransactionLineItem[] }>;
   onShippingAddressChange?: (
     newAddress: ShippingAddress
+  ) => Promise<{ amount: number; lineItems?: TransactionLineItem[] }>;
+  /**
+   * Shipping type label on the Apple Pay sheet (shipping / delivery / pickup).
+   * Payment (one-off) transactions only — rejected for recurring and disbursement.
+   */
+  shippingType?: ApplePayShippingType;
+  /**
+   * Shipping methods shown as selectable options on the Apple Pay sheet.
+   * Requires `requestShipping: true` (auto-enabled when methods are provided).
+   * Payment (one-off) transactions only — rejected for recurring and disbursement.
+   *
+   * When the customer selects a method, totals are recomputed. Provide
+   * `onShippingMethodSelected` to control the amount/line items yourself;
+   * otherwise the SDK adjusts the total by the selected method's amount.
+   */
+  shippingMethods?: ApplePayShippingMethod[];
+  /**
+   * Called when the customer selects a shipping method on the sheet.
+   * Return updated totals. Maps to PaymentRequest `shippingoptionchange`.
+   * Requires `shippingMethods` (and shipping to be requested).
+   */
+  onShippingMethodSelected?: (
+    shippingMethod: ApplePayShippingMethod
   ) => Promise<{ amount: number; lineItems?: TransactionLineItem[] }>;
   /**
    * Show the coupon field on the Apple Pay sheet and receive updates when the
@@ -186,8 +211,11 @@ export default class ApplePayButton {
         disbursementOverrides: this.#options.disbursementOverrides,
         requestBillingAddress: this.#options.requestBillingAddress,
         requestShipping: this.#options.requestShipping,
+        shippingType: this.#options.shippingType,
+        shippingMethods: this.#options.shippingMethods,
         onPaymentMethodChange: this.#options.onPaymentMethodChange,
         onShippingAddressChange: this.#options.onShippingAddressChange,
+        onShippingMethodSelected: this.#options.onShippingMethodSelected,
         supportsCouponCode: this.#options.supportsCouponCode,
         couponCode: this.#options.couponCode,
         onCouponCodeChange: this.#options.onCouponCodeChange,
@@ -240,6 +268,28 @@ export default class ApplePayButton {
 
       if (response.details.shippingContact) {
         encrypted.shippingContact = response.details.shippingContact;
+      }
+
+      const shippingOptionId = (
+        response as PaymentResponse & { shippingOption?: string | null }
+      ).shippingOption;
+
+      if (shippingOptionId) {
+        const selectedMethod = this.#options.shippingMethods?.find(
+          (method) => method.id === shippingOptionId
+        );
+        encrypted.shippingMethod = selectedMethod
+          ? {
+              id: selectedMethod.id,
+              label: selectedMethod.label,
+              amount: selectedMethod.amount,
+              detail: selectedMethod.detail,
+            }
+          : {
+              id: shippingOptionId,
+              label: shippingOptionId,
+              amount: 0,
+            };
       }
 
       encrypted.transactionType = mapTransactionType(

--- a/packages/browser/lib/ui/ApplePay/index.ts
+++ b/packages/browser/lib/ui/ApplePay/index.ts
@@ -278,18 +278,25 @@ export default class ApplePayButton {
         const selectedMethod = this.#options.shippingMethods?.find(
           (method) => method.id === shippingOptionId
         );
-        encrypted.shippingMethod = selectedMethod
-          ? {
-              id: selectedMethod.id,
-              label: selectedMethod.label,
-              amount: selectedMethod.amount,
-              detail: selectedMethod.detail,
-            }
-          : {
-              id: shippingOptionId,
-              label: shippingOptionId,
-              amount: 0,
-            };
+        if (selectedMethod) {
+          encrypted.shippingMethod = {
+            id: selectedMethod.id,
+            label: selectedMethod.label,
+            amount: selectedMethod.amount,
+            detail: selectedMethod.detail,
+          };
+        } else {
+          console.warn(
+            `[Evervault Apple Pay] PaymentResponse.shippingOption "${shippingOptionId}" ` +
+              "did not match any configured shippingMethods. " +
+              "Returning a placeholder shippingMethod with amount 0."
+          );
+          encrypted.shippingMethod = {
+            id: shippingOptionId,
+            label: shippingOptionId,
+            amount: 0,
+          };
+        }
       }
 
       encrypted.transactionType = mapTransactionType(

--- a/packages/browser/lib/ui/ApplePay/types.ts
+++ b/packages/browser/lib/ui/ApplePay/types.ts
@@ -103,6 +103,51 @@ export interface ShippingAddress {
 }
 
 /**
+ * Shipping type shown on the Apple Pay sheet. Maps to PaymentOptions.shippingType
+ * (storePickup / servicePickup → "pickup" on the Payment Request bridge).
+ */
+export type ApplePayShippingType =
+  | "shipping"
+  | "delivery"
+  | "storePickup"
+  | "servicePickup";
+
+/**
+ * A shipping method the customer can pick on the Apple Pay sheet.
+ * Amounts use the same smallest-currency-unit convention as line items (e.g. cents).
+ * Maps to PaymentDetailsInit.shippingOptions / PaymentShippingOption.
+ */
+export interface ApplePayShippingMethod {
+  id: string;
+  label: string;
+  amount: number;
+  detail?: string;
+  selected?: boolean;
+}
+
+/** W3C PaymentShippingOption (+ optional Apple `detail`). */
+export interface PaymentShippingOption {
+  id: string;
+  label: string;
+  amount: {
+    currency: string;
+    value: string;
+  };
+  selected?: boolean;
+  detail?: string;
+}
+
+/** PaymentDetailsInit with shippingOptions (missing from some DOM lib versions). */
+export type ApplePayPaymentDetailsInit = PaymentDetailsInit & {
+  shippingOptions?: PaymentShippingOption[];
+};
+
+/** PaymentDetailsUpdate with shippingOptions. */
+export type ApplePayPaymentDetailsUpdate = PaymentDetailsUpdate & {
+  shippingOptions?: PaymentShippingOption[];
+};
+
+/**
  * Maps to ApplePayPaymentContact. Used to prefill billingContact /
  * shippingContact on the Apple Pay request, and for billingContact on
  * payment method change updates.
@@ -157,7 +202,9 @@ export type CouponCodeChangeResult = {
 
 export type ApplePayPaymentRequest = PaymentRequest & {
   onshippingaddresschange?: ((event: PaymentRequestUpdateEvent) => void) | null;
+  onshippingoptionchange?: ((event: PaymentRequestUpdateEvent) => void) | null;
   onmerchantvalidation?: (event: OnMerchantValidationEvent) => void;
+  shippingOption?: string | null;
 };
 
 export interface ApplePayConfig {

--- a/packages/browser/lib/ui/ApplePay/utilities.ts
+++ b/packages/browser/lib/ui/ApplePay/utilities.ts
@@ -804,7 +804,7 @@ function buildRecurringSession(
     requestPayerEmail: config.requestPayerDetails?.includes("email") ?? false,
     requestPayerPhone: config.requestPayerDetails?.includes("phone") ?? false,
     requestShipping: config.requestShipping ?? false,
-    shippingType: "shipping",
+    shippingType: mapPaymentRequestShippingType(config.shippingType),
   };
 
   const paymentOverrides = config.paymentOverrides || {};

--- a/packages/browser/lib/ui/ApplePay/utilities.ts
+++ b/packages/browser/lib/ui/ApplePay/utilities.ts
@@ -16,6 +16,11 @@ import {
   ValidateMerchantResponse,
   ApplePayCardNetwork,
   ApplePayPaymentRequest,
+  ApplePayShippingMethod,
+  ApplePayShippingType,
+  ApplePayPaymentDetailsInit,
+  ApplePayPaymentDetailsUpdate,
+  PaymentShippingOption,
   ShippingAddress,
   PaymentContact,
   PaymentMethodUpdate,
@@ -39,9 +44,11 @@ type BuildSessionOptions = {
   requestPayerDetails?: ("name" | "email" | "phone" | "postalAddress")[];
   requestBillingAddress?: boolean;
   requestShipping?: boolean;
+  shippingType?: ApplePayShippingType;
+  shippingMethods?: ApplePayShippingMethod[];
   paymentOverrides?: {
     paymentMethodData?: PaymentMethodData[];
-    paymentDetails?: PaymentDetailsInit;
+    paymentDetails?: ApplePayPaymentDetailsInit;
   };
   disbursementOverrides?: {
     disbursementDetails?: PaymentDetailsInit;
@@ -51,6 +58,9 @@ type BuildSessionOptions = {
   ) => Promise<{ amount: number; lineItems?: TransactionLineItem[] }>;
   onShippingAddressChange?: (
     newAddress: ShippingAddress
+  ) => Promise<{ amount: number; lineItems?: TransactionLineItem[] }>;
+  onShippingMethodSelected?: (
+    shippingMethod: ApplePayShippingMethod
   ) => Promise<{ amount: number; lineItems?: TransactionLineItem[] }>;
   supportsCouponCode?: boolean;
   couponCode?: string;
@@ -94,6 +104,121 @@ function applyContactFields(
   if (config.shippingContact) {
     data.shippingContact = config.shippingContact;
   }
+}
+
+/**
+ * Shipping methods are only supported on one-off payment transactions.
+ * Recurring and disbursement reject them (CARD-875 AC).
+ */
+function assertShippingMethodsAllowed(
+  tx: TransactionDetailsWithDomain,
+  config: BuildSessionOptions
+) {
+  if (!config.shippingMethods?.length) return;
+
+  if (tx.type !== "payment") {
+    throw new Error(
+      "Apple Pay shipping methods are only supported for one-off payment transactions"
+    );
+  }
+}
+
+function mapPaymentRequestShippingType(
+  shippingType?: ApplePayShippingType
+): "shipping" | "delivery" | "pickup" {
+  if (shippingType === "delivery") return "delivery";
+  if (shippingType === "storePickup" || shippingType === "servicePickup") {
+    return "pickup";
+  }
+  return "shipping";
+}
+
+function mapShippingMethodsToPaymentOptions(
+  methods: ApplePayShippingMethod[],
+  currency: string
+): PaymentShippingOption[] {
+  const hasExplicitSelection = methods.some((method) => method.selected);
+  return methods.map((method, index) => {
+    const option: PaymentShippingOption = {
+      id: method.id,
+      label: method.label,
+      amount: {
+        currency,
+        value: (method.amount / 100).toFixed(2),
+      },
+      selected: hasExplicitSelection ? Boolean(method.selected) : index === 0,
+    };
+    if (method.detail != null) {
+      option.detail = method.detail;
+    }
+    return option;
+  });
+}
+
+function resolveSelectedShippingMethod(
+  shippingOptionId: string | null | undefined,
+  methods: ApplePayShippingMethod[]
+): ApplePayShippingMethod | undefined {
+  if (!methods.length) return undefined;
+  if (shippingOptionId) {
+    return methods.find((method) => method.id === shippingOptionId);
+  }
+  return methods.find((method) => method.selected) ?? methods[0];
+}
+
+/**
+ * Goods total excluding the initially selected shipping method amount.
+ * When a method is marked selected (or the first is defaulted), the transaction
+ * amount is treated as already including that method's cost — matching the iOS
+ * summary-items pattern.
+ */
+function resolveGoodsAmount(
+  tx: TransactionDetailsWithDomain,
+  methods: ApplePayShippingMethod[]
+): number {
+  if (!methods.length) return tx.amount;
+  const initial = methods.find((method) => method.selected) ?? methods[0];
+  return tx.amount - initial.amount;
+}
+
+function withUpdatedShippingSelection(
+  methods: ApplePayShippingMethod[],
+  selectedId: string,
+  currency: string
+): PaymentShippingOption[] {
+  return mapShippingMethodsToPaymentOptions(
+    methods.map((method) => ({
+      ...method,
+      selected: method.id === selectedId,
+    })),
+    currency
+  );
+}
+
+function buildInternalShippingMethodUpdate(
+  selected: ApplePayShippingMethod,
+  config: BuildSessionOptions,
+  tx: TransactionDetailsWithDomain
+): { amount: number; lineItems?: TransactionLineItem[] } {
+  const methods = config.shippingMethods ?? [];
+  const goodsAmount = resolveGoodsAmount(tx, methods);
+  const amount = goodsAmount + selected.amount;
+
+  const methodLabels = new Set(methods.map((method) => method.label));
+  const baseLineItems = (tx.lineItems ?? []).filter(
+    (item) => !methodLabels.has(item.label)
+  );
+
+  return {
+    amount,
+    lineItems: [
+      ...baseLineItems,
+      {
+        label: selected.label,
+        amount: selected.amount,
+      },
+    ],
+  };
 }
 
 function assertBase64ApplicationData(applicationData: string) {
@@ -228,6 +353,7 @@ export async function buildSession(
   config: BuildSessionOptions
 ) {
   const { transaction: tx } = config;
+  assertShippingMethodsAllowed(tx, config);
 
   const merchant = await getMerchant(applePay, tx.merchantId);
   if (!merchant) {
@@ -297,6 +423,17 @@ export async function buildSession(
     event.updateWith({});
   };
 
+  // Apple Pay requires updateWith on every shippingoptionchange or the
+  // selection silently no-ops. Prefer the merchant callback when provided;
+  // otherwise recompute totals from the selected method amount.
+  baseRequest.onshippingoptionchange = (event: PaymentRequestUpdateEvent) => {
+    const target = event.target as ApplePayPaymentRequest | null;
+    const selectedId =
+      target?.shippingOption ?? baseRequest.shippingOption ?? null;
+
+    event.updateWith(updateShippingMethod(selectedId, config, tx, merchant));
+  };
+
   // Apple Pay widens PaymentRequest event types beyond the DOM lib.
   // @ts-expect-error - Apple Pay overrides PaymentRequest properties
   baseRequest.onpaymentmethodchange = (event: PaymentMethodChangeEvent) => {
@@ -335,8 +472,9 @@ async function createPaymentUpdate(
     lineItems?: TransactionLineItem[];
   },
   tx: TransactionDetailsWithDomain,
-  merchant: MerchantDetail
-): Promise<PaymentDetailsUpdate> {
+  merchant: MerchantDetail,
+  shippingOptions?: PaymentShippingOption[]
+): Promise<ApplePayPaymentDetailsUpdate> {
   const displayItems = mapLineItemsToDisplayItems(
     updatedTransactionConfig.lineItems,
     tx.currency
@@ -351,6 +489,7 @@ async function createPaymentUpdate(
   return {
     displayItems,
     total,
+    ...(shippingOptions ? { shippingOptions } : {}),
   };
 }
 
@@ -359,11 +498,19 @@ async function updatePaymentRequest(
   config: BuildSessionOptions,
   tx: TransactionDetailsWithDomain,
   merchant: MerchantDetail
-): Promise<PaymentDetailsUpdate> {
+): Promise<ApplePayPaymentDetailsUpdate> {
   const updatedTransactionConfig = await config.onShippingAddressChange!(
     newAddress
   );
-  return createPaymentUpdate(updatedTransactionConfig, tx, merchant);
+  const shippingOptions = config.shippingMethods?.length
+    ? mapShippingMethodsToPaymentOptions(config.shippingMethods, tx.currency)
+    : undefined;
+  return createPaymentUpdate(
+    updatedTransactionConfig,
+    tx,
+    merchant,
+    shippingOptions
+  );
 }
 
 async function updatePaymentMethod(
@@ -371,11 +518,50 @@ async function updatePaymentMethod(
   config: BuildSessionOptions,
   tx: TransactionDetailsWithDomain,
   merchant: MerchantDetail
-): Promise<PaymentDetailsUpdate> {
+): Promise<ApplePayPaymentDetailsUpdate> {
   const updatedTransactionConfig = await config.onPaymentMethodChange!(
     newMethod
   );
   return createPaymentUpdate(updatedTransactionConfig, tx, merchant);
+}
+
+async function updateShippingMethod(
+  shippingOptionId: string | null,
+  config: BuildSessionOptions,
+  tx: TransactionDetailsWithDomain,
+  merchant: MerchantDetail
+): Promise<ApplePayPaymentDetailsUpdate> {
+  const methods = config.shippingMethods ?? [];
+  const selected = resolveSelectedShippingMethod(shippingOptionId, methods);
+
+  if (!selected) {
+    return {};
+  }
+
+  const shippingOptions = withUpdatedShippingSelection(
+    methods,
+    selected.id,
+    tx.currency
+  );
+
+  if (config.onShippingMethodSelected) {
+    const updatedTransactionConfig = await config.onShippingMethodSelected(
+      selected
+    );
+    return createPaymentUpdate(
+      updatedTransactionConfig,
+      tx,
+      merchant,
+      shippingOptions
+    );
+  }
+
+  return createPaymentUpdate(
+    buildInternalShippingMethodUpdate(selected, config, tx),
+    tx,
+    merchant,
+    shippingOptions
+  );
 }
 
 async function updateCouponCode(
@@ -383,7 +569,7 @@ async function updateCouponCode(
   config: BuildSessionOptions,
   tx: TransactionDetailsWithDomain,
   merchant: MerchantDetail
-): Promise<PaymentDetailsUpdate> {
+): Promise<ApplePayPaymentDetailsUpdate> {
   const result = await config.onCouponCodeChange!(couponCode);
   const update = await createPaymentUpdate(result, tx, merchant);
 
@@ -406,13 +592,19 @@ function buildPaymentSession(
   const lineItems = mapLineItemsToDisplayItems(tx.lineItems, tx.currency);
 
   const paymentMethodData = buildApplePayMethodData(config, tx.country);
+  const shippingOptions = config.shippingMethods?.length
+    ? mapShippingMethodsToPaymentOptions(config.shippingMethods, tx.currency)
+    : undefined;
+  const requestShipping =
+    config.requestShipping || Boolean(config.shippingMethods?.length);
 
-  const paymentDetails: PaymentDetailsInit = {
+  const paymentDetails: ApplePayPaymentDetailsInit = {
     total: {
       label: tx.priceLabel ?? merchant.name,
       amount: { currency: tx.currency, value: (tx.amount / 100).toFixed(2) },
     },
     displayItems: lineItems,
+    ...(shippingOptions ? { shippingOptions } : {}),
   };
 
   const paymentOptions = {
@@ -422,8 +614,8 @@ function buildPaymentSession(
     requestPayerPhone: config.requestPayerDetails?.includes("phone") ?? false,
     requestPostalAddress:
       config.requestPayerDetails?.includes("postalAddress") ?? false,
-    requestShipping: config.requestShipping ?? false,
-    shippingType: "shipping",
+    requestShipping,
+    shippingType: mapPaymentRequestShippingType(config.shippingType),
     onShippingAddressChange: config.onShippingAddressChange,
   };
 

--- a/packages/browser/lib/ui/ApplePay/utilities.ts
+++ b/packages/browser/lib/ui/ApplePay/utilities.ts
@@ -137,7 +137,19 @@ function mapShippingMethodsToPaymentOptions(
   methods: ApplePayShippingMethod[],
   currency: string
 ): PaymentShippingOption[] {
-  const hasExplicitSelection = methods.some((method) => method.selected);
+  const selectedIndexes = methods
+    .map((method, index) => (method.selected ? index : -1))
+    .filter((index) => index >= 0);
+
+  if (selectedIndexes.length > 1) {
+    console.warn(
+      "[Evervault Apple Pay] Multiple shippingMethods have selected: true; " +
+        "only the first will be treated as selected."
+    );
+  }
+
+  const selectedIndex = selectedIndexes[0] ?? 0;
+
   return methods.map((method, index) => {
     const option: PaymentShippingOption = {
       id: method.id,
@@ -146,7 +158,7 @@ function mapShippingMethodsToPaymentOptions(
         currency,
         value: (method.amount / 100).toFixed(2),
       },
-      selected: hasExplicitSelection ? Boolean(method.selected) : index === 0,
+      selected: index === selectedIndex,
     };
     if (method.detail != null) {
       option.detail = method.detail;
@@ -195,6 +207,21 @@ function withUpdatedShippingSelection(
   );
 }
 
+function resolveShippingOptionsForUpdate(
+  config: BuildSessionOptions,
+  currency: string,
+  selectedId: string | null | undefined
+): PaymentShippingOption[] | undefined {
+  const methods = config.shippingMethods;
+  if (!methods?.length) return undefined;
+
+  const selected = resolveSelectedShippingMethod(selectedId, methods);
+  if (!selected) {
+    return mapShippingMethodsToPaymentOptions(methods, currency);
+  }
+  return withUpdatedShippingSelection(methods, selected.id, currency);
+}
+
 function buildInternalShippingMethodUpdate(
   selected: ApplePayShippingMethod,
   config: BuildSessionOptions,
@@ -205,9 +232,25 @@ function buildInternalShippingMethodUpdate(
   const amount = goodsAmount + selected.amount;
 
   const methodLabels = new Set(methods.map((method) => method.label));
-  const baseLineItems = (tx.lineItems ?? []).filter(
+  const originalLineItems = tx.lineItems ?? [];
+  const baseLineItems = originalLineItems.filter(
     (item) => !methodLabels.has(item.label)
   );
+  const removedCount = originalLineItems.length - baseLineItems.length;
+
+  // Internal recompute keys shipping line items by label. A mismatch leaves a
+  // stale shipping row on the sheet while the total uses method.amount.
+  if (originalLineItems.length > 0 && removedCount !== 1) {
+    const expectedLabel =
+      methods.find((method) => method.selected)?.label ?? methods[0]?.label;
+    console.warn(
+      "[Evervault Apple Pay] Internal shipping total recompute expected to " +
+        `replace exactly one line item matching a shippingMethods[].label, but removed ${removedCount}. ` +
+        `Ensure an initial line item uses the same label as the selected shipping method` +
+        (expectedLabel ? ` (e.g. "${expectedLabel}")` : "") +
+        ". Prefer onShippingMethodSelected to control line items explicitly."
+    );
+  }
 
   return {
     amount,
@@ -377,6 +420,13 @@ export async function buildSession(
     baseRequest = buildDisbursementSession(merchant, config, tx);
   }
 
+  // Persist the live selection across address/coupon updates. Rebuilding
+  // shippingOptions from the original config.selected flags would otherwise
+  // reset the sheet to the initially selected method.
+  let activeShippingOptionId: string | null =
+    resolveSelectedShippingMethod(null, config.shippingMethods ?? [])?.id ??
+    null;
+
   baseRequest.onmerchantvalidation = async (event) => {
     const merchantSessionPromise = await validateMerchant(
       applePay,
@@ -395,6 +445,7 @@ export async function buildSession(
     // remote-continuity handoff.
     const target = event.target as unknown as {
       shippingAddress?: ShippingAddress;
+      shippingOption?: string | null;
     } | null;
     const methodDetails = (
       event as PaymentRequestUpdateEvent & { methodDetails?: unknown }
@@ -404,7 +455,13 @@ export async function buildSession(
     if (isCouponCodeUpdate(methodDetails)) {
       if (config.onCouponCodeChange) {
         event.updateWith(
-          updateCouponCode(methodDetails.couponCode, config, tx, merchant)
+          updateCouponCode(
+            methodDetails.couponCode,
+            config,
+            tx,
+            merchant,
+            activeShippingOptionId
+          )
         );
         return;
       }
@@ -413,9 +470,19 @@ export async function buildSession(
     }
 
     if (target?.shippingAddress && config.onShippingAddressChange) {
+      const selectedId =
+        target.shippingOption ??
+        baseRequest.shippingOption ??
+        activeShippingOptionId;
       // Do not await this promise — PaymentRequest expects updateWith(promise).
       event.updateWith(
-        updatePaymentRequest(target.shippingAddress, config, tx, merchant)
+        updatePaymentRequest(
+          target.shippingAddress,
+          config,
+          tx,
+          merchant,
+          selectedId
+        )
       );
       return;
     }
@@ -429,7 +496,13 @@ export async function buildSession(
   baseRequest.onshippingoptionchange = (event: PaymentRequestUpdateEvent) => {
     const target = event.target as ApplePayPaymentRequest | null;
     const selectedId =
-      target?.shippingOption ?? baseRequest.shippingOption ?? null;
+      target?.shippingOption ??
+      baseRequest.shippingOption ??
+      activeShippingOptionId;
+
+    if (selectedId) {
+      activeShippingOptionId = selectedId;
+    }
 
     event.updateWith(updateShippingMethod(selectedId, config, tx, merchant));
   };
@@ -444,7 +517,13 @@ export async function buildSession(
     if (isCouponCodeUpdate(methodDetails)) {
       if (config.onCouponCodeChange) {
         return event.updateWith(
-          updateCouponCode(methodDetails.couponCode, config, tx, merchant)
+          updateCouponCode(
+            methodDetails.couponCode,
+            config,
+            tx,
+            merchant,
+            activeShippingOptionId
+          )
         );
       }
       return event.updateWith({});
@@ -497,14 +576,17 @@ async function updatePaymentRequest(
   newAddress: ShippingAddress,
   config: BuildSessionOptions,
   tx: TransactionDetailsWithDomain,
-  merchant: MerchantDetail
+  merchant: MerchantDetail,
+  selectedShippingOptionId?: string | null
 ): Promise<ApplePayPaymentDetailsUpdate> {
   const updatedTransactionConfig = await config.onShippingAddressChange!(
     newAddress
   );
-  const shippingOptions = config.shippingMethods?.length
-    ? mapShippingMethodsToPaymentOptions(config.shippingMethods, tx.currency)
-    : undefined;
+  const shippingOptions = resolveShippingOptionsForUpdate(
+    config,
+    tx.currency,
+    selectedShippingOptionId
+  );
   return createPaymentUpdate(
     updatedTransactionConfig,
     tx,
@@ -568,10 +650,21 @@ async function updateCouponCode(
   couponCode: string,
   config: BuildSessionOptions,
   tx: TransactionDetailsWithDomain,
-  merchant: MerchantDetail
+  merchant: MerchantDetail,
+  selectedShippingOptionId?: string | null
 ): Promise<ApplePayPaymentDetailsUpdate> {
   const result = await config.onCouponCodeChange!(couponCode);
-  const update = await createPaymentUpdate(result, tx, merchant);
+  const shippingOptions = resolveShippingOptionsForUpdate(
+    config,
+    tx.currency,
+    selectedShippingOptionId
+  );
+  const update = await createPaymentUpdate(
+    result,
+    tx,
+    merchant,
+    shippingOptions
+  );
 
   if (result.error) {
     // Payment Request bridge: ApplePayError via paymentMethodErrors

--- a/packages/browser/test/applePay.test.ts
+++ b/packages/browser/test/applePay.test.ts
@@ -792,6 +792,17 @@ describe("buildSession shipping methods", () => {
     );
   });
 
+  it("passes shippingType through on recurring when only requestShipping is set", async () => {
+    await buildSession(applePay, {
+      transaction: recurringTransaction,
+      requestShipping: true,
+      shippingType: "delivery",
+    });
+
+    expect(paymentOptionsCalls[0].requestShipping).toBe(true);
+    expect(paymentOptionsCalls[0].shippingType).toBe("delivery");
+  });
+
   it("internally recomputes totals on shippingoptionchange when no merchant callback is set", async () => {
     const request = await buildSession(applePay, {
       transaction: {
@@ -1315,7 +1326,7 @@ function createMockClient(): EvervaultClient {
   return {
     config: {
       appId: "app_test",
-      http: { apiUrl: "https://api.evervault.com" },
+      http: { apiUrl },
     },
   } as EvervaultClient;
 }
@@ -1469,5 +1480,120 @@ describe("ApplePayButton.abort", () => {
     });
 
     await expect(apple.abort()).resolves.toBeUndefined();
+  });
+});
+
+describe("ApplePayButton shipping method on process()", () => {
+  function createResolvedSession(shippingOption?: string | null) {
+    return {
+      show: vi.fn().mockResolvedValue({
+        details: {
+          token: {
+            paymentData: {},
+            paymentMethod: { displayName: "Visa 1234", type: "credit" },
+          },
+        },
+        shippingOption,
+        complete: vi.fn().mockResolvedValue(undefined),
+      }),
+      abort: vi.fn(),
+    };
+  }
+
+  beforeEach(() => {
+    buildSessionMock.mockReset();
+    vi.spyOn(applePayUtilities, "buildSession").mockImplementation(
+      buildSessionMock
+    );
+
+    vi.stubGlobal("PaymentRequest", class PaymentRequest {});
+
+    vi.stubGlobal("ApplePaySession", {
+      applePayCapabilities: vi.fn().mockResolvedValue({
+        paymentCredentialStatus: "paymentCredentialsAvailable",
+      }),
+    });
+
+    const script = document.createElement("script");
+    script.src =
+      "https://applepay.cdn-apple.com/jsapi/1.latest/apple-pay-sdk.js";
+    document.body.appendChild(script);
+
+    server.use(
+      http.post(`${apiUrl}/frontend/apple-pay/credentials`, () =>
+        HttpResponse.json({ card: {} })
+      )
+    );
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("attaches the matching shippingMethod to the process() payload", async () => {
+    buildSessionMock.mockResolvedValue(createResolvedSession("express"));
+    const process = vi.fn().mockResolvedValue(undefined);
+    const apple = new ApplePayButton(createMockClient(), createTransaction(), {
+      process,
+      shippingMethods: [
+        { id: "standard", label: "Standard Shipping", amount: 299 },
+        {
+          id: "express",
+          label: "Express Shipping",
+          amount: 999,
+          detail: "1-2 days",
+        },
+      ],
+    });
+
+    await clickApplePayButton(apple);
+    await vi.waitFor(() => expect(process).toHaveBeenCalled());
+
+    expect(process.mock.calls[0][0].shippingMethod).toEqual({
+      id: "express",
+      label: "Express Shipping",
+      amount: 999,
+      detail: "1-2 days",
+    });
+  });
+
+  it("falls back to a placeholder and warns when shippingOption matches nothing", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    buildSessionMock.mockResolvedValue(createResolvedSession("unknown-id"));
+    const process = vi.fn().mockResolvedValue(undefined);
+    const apple = new ApplePayButton(createMockClient(), createTransaction(), {
+      process,
+      shippingMethods: [
+        { id: "standard", label: "Standard Shipping", amount: 299 },
+      ],
+    });
+
+    await clickApplePayButton(apple);
+    await vi.waitFor(() => expect(process).toHaveBeenCalled());
+
+    expect(process.mock.calls[0][0].shippingMethod).toEqual({
+      id: "unknown-id",
+      label: "unknown-id",
+      amount: 0,
+    });
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("did not match any configured shippingMethods")
+    );
+    warn.mockRestore();
+  });
+
+  it("omits shippingMethod entirely when no shippingOption is returned", async () => {
+    buildSessionMock.mockResolvedValue(createResolvedSession(undefined));
+    const process = vi.fn().mockResolvedValue(undefined);
+    const apple = new ApplePayButton(createMockClient(), createTransaction(), {
+      process,
+    });
+
+    await clickApplePayButton(apple);
+    await vi.waitFor(() => expect(process).toHaveBeenCalled());
+
+    expect(process.mock.calls[0][0].shippingMethod).toBeUndefined();
   });
 });

--- a/packages/browser/test/applePay.test.ts
+++ b/packages/browser/test/applePay.test.ts
@@ -17,6 +17,7 @@ import ApplePayButton from "../lib/ui/ApplePay";
 import { Transaction } from "../lib/resources/transaction";
 import type EvervaultClient from "../lib/main";
 import { setupCrypto } from "./setup";
+import type { ApplePayPaymentDetailsInit } from "../lib/ui/ApplePay/types";
 
 const {
   APPLE_PAY_MAX_VERSION,
@@ -33,7 +34,7 @@ const app = "app_test123";
 const merchantId = "merchant_abc";
 const merchantName = "Acme Co";
 
-const paymentRequestCalls: PaymentDetailsInit[] = [];
+const paymentRequestCalls: ApplePayPaymentDetailsInit[] = [];
 const paymentMethodDataCalls: Array<{
   merchantIdentifier?: string;
   merchantCapabilities?: string[];
@@ -45,14 +46,21 @@ const paymentMethodDataCalls: Array<{
   supportedCountries?: string[];
   version?: number;
 }> = [];
+const paymentOptionsCalls: Array<{
+  requestShipping?: boolean;
+  shippingType?: string;
+}> = [];
 const paymentRequestInstances: MockPaymentRequest[] = [];
 
 class MockPaymentRequest {
   onshippingaddresschange: ((event: PaymentRequestUpdateEvent) => void) | null =
     null;
+  onshippingoptionchange: ((event: PaymentRequestUpdateEvent) => void) | null =
+    null;
   onpaymentmethodchange: ((event: PaymentMethodChangeEvent) => void) | null =
     null;
   onmerchantvalidation: ((event: unknown) => void) | null = null;
+  shippingOption: string | null = null;
 
   constructor(
     methodData: Array<{
@@ -68,10 +76,15 @@ class MockPaymentRequest {
         version?: number;
       };
     }>,
-    details: PaymentDetailsInit
+    details: ApplePayPaymentDetailsInit,
+    options?: {
+      requestShipping?: boolean;
+      shippingType?: string;
+    }
   ) {
     paymentMethodDataCalls.push(methodData[0]?.data ?? {});
     paymentRequestCalls.push(details);
+    paymentOptionsCalls.push(options ?? {});
     paymentRequestInstances.push(this);
   }
 }
@@ -139,6 +152,7 @@ beforeAll(() => {
 beforeEach(() => {
   paymentRequestCalls.length = 0;
   paymentMethodDataCalls.length = 0;
+  paymentOptionsCalls.length = 0;
   paymentRequestInstances.length = 0;
   server.use(
     http.get(`${apiUrl}/frontend/merchants/${merchantId}`, () =>
@@ -681,6 +695,203 @@ describe("buildSession contact prefill", () => {
 
     expect(paymentMethodDataCalls[0].billingContact).toBeUndefined();
     expect(paymentMethodDataCalls[0].shippingContact).toBeUndefined();
+  });
+});
+
+describe("buildSession shipping methods", () => {
+  const shippingMethods = [
+    {
+      id: "standard",
+      label: "Standard Shipping",
+      amount: 299,
+      detail: "3-5 business days",
+      selected: true,
+    },
+    {
+      id: "express",
+      label: "Express Shipping",
+      amount: 999,
+      detail: "1-2 business days",
+    },
+  ];
+
+  beforeEach(() => {
+    server.use(
+      http.get(`${apiUrl}/frontend/sdk/config`, () =>
+        HttpResponse.json({ is_sandbox: false }, { status: 200 })
+      )
+    );
+  });
+
+  it("maps shippingType and shippingMethods onto the PaymentRequest", async () => {
+    await buildSession(applePay, {
+      transaction: {
+        ...transaction,
+        amount: 3799,
+        lineItems: [
+          { label: "Mens Shirt", amount: 3000 },
+          { label: "Socks", amount: 500 },
+          { label: "Standard Shipping", amount: 299 },
+        ],
+      },
+      shippingType: "delivery",
+      shippingMethods,
+    });
+
+    expect(paymentOptionsCalls[0].requestShipping).toBe(true);
+    expect(paymentOptionsCalls[0].shippingType).toBe("delivery");
+    expect(paymentRequestCalls[0].shippingOptions).toEqual([
+      {
+        id: "standard",
+        label: "Standard Shipping",
+        amount: { currency: "USD", value: "2.99" },
+        selected: true,
+        detail: "3-5 business days",
+      },
+      {
+        id: "express",
+        label: "Express Shipping",
+        amount: { currency: "USD", value: "9.99" },
+        selected: false,
+        detail: "1-2 business days",
+      },
+    ]);
+  });
+
+  it("maps storePickup shippingType to Payment Request pickup", async () => {
+    await buildSession(applePay, {
+      transaction,
+      shippingType: "storePickup",
+      shippingMethods: [
+        { id: "pickup", label: "Store Pickup", amount: 0, selected: true },
+      ],
+    });
+
+    expect(paymentOptionsCalls[0].shippingType).toBe("pickup");
+  });
+
+  it("rejects shipping methods on recurring transactions", async () => {
+    await expect(
+      buildSession(applePay, {
+        transaction: recurringTransaction,
+        shippingMethods,
+      })
+    ).rejects.toThrow(
+      "Apple Pay shipping methods are only supported for one-off payment transactions"
+    );
+  });
+
+  it("rejects shipping methods on disbursement transactions", async () => {
+    await expect(
+      buildSession(applePay, {
+        transaction: disbursementTransaction,
+        shippingMethods,
+      })
+    ).rejects.toThrow(
+      "Apple Pay shipping methods are only supported for one-off payment transactions"
+    );
+  });
+
+  it("internally recomputes totals on shippingoptionchange when no merchant callback is set", async () => {
+    const request = await buildSession(applePay, {
+      transaction: {
+        ...transaction,
+        amount: 3799,
+        lineItems: [
+          { label: "Mens Shirt", amount: 3000 },
+          { label: "Socks", amount: 500 },
+          { label: "Standard Shipping", amount: 299 },
+        ],
+      },
+      shippingMethods,
+    });
+
+    const session = paymentRequestInstances[0];
+    session.shippingOption = "express";
+    const updateWith = vi.fn();
+    request.onshippingoptionchange?.({
+      target: session,
+      updateWith,
+    } as unknown as PaymentRequestUpdateEvent);
+
+    expect(updateWith).toHaveBeenCalledTimes(1);
+    const update = await updateWith.mock.calls[0][0];
+    expect(update.total?.amount.value).toBe("44.99");
+    expect(update.displayItems).toEqual([
+      {
+        label: "Mens Shirt",
+        amount: { value: "30.00", currency: "USD" },
+      },
+      {
+        label: "Socks",
+        amount: { value: "5.00", currency: "USD" },
+      },
+      {
+        label: "Express Shipping",
+        amount: { value: "9.99", currency: "USD" },
+      },
+    ]);
+    expect(
+      update.shippingOptions?.find((o: { id: string }) => o.id === "express")
+        ?.selected
+    ).toBe(true);
+    expect(
+      update.shippingOptions?.find((o: { id: string }) => o.id === "standard")
+        ?.selected
+    ).toBe(false);
+  });
+
+  it("calls onShippingMethodSelected and updateWith on shippingoptionchange", async () => {
+    const onShippingMethodSelected = vi.fn().mockResolvedValue({
+      amount: 4499,
+      lineItems: [
+        { label: "Mens Shirt", amount: 3000 },
+        { label: "Socks", amount: 500 },
+        { label: "Express Shipping", amount: 999 },
+      ],
+    });
+
+    const request = await buildSession(applePay, {
+      transaction: {
+        ...transaction,
+        amount: 3799,
+      },
+      shippingMethods,
+      onShippingMethodSelected,
+    });
+
+    const session = paymentRequestInstances[0];
+    session.shippingOption = "express";
+    const updateWith = vi.fn();
+    request.onshippingoptionchange?.({
+      target: session,
+      updateWith,
+    } as unknown as PaymentRequestUpdateEvent);
+
+    expect(onShippingMethodSelected).toHaveBeenCalledWith(shippingMethods[1]);
+    const update = await updateWith.mock.calls[0][0];
+    expect(update.total?.amount.value).toBe("44.99");
+    expect(update.shippingOptions).toHaveLength(2);
+  });
+
+  it("still calls updateWith when shippingoptionchange has a null target", async () => {
+    const request = await buildSession(applePay, {
+      transaction: { ...transaction, amount: 3799 },
+      shippingMethods,
+    });
+
+    const updateWith = vi.fn();
+    expect(() =>
+      request.onshippingoptionchange?.({
+        target: null,
+        updateWith,
+      } as unknown as PaymentRequestUpdateEvent)
+    ).not.toThrow();
+    expect(updateWith).toHaveBeenCalled();
+
+    const update = await updateWith.mock.calls[0][0];
+    // Falls back to the initially selected (or first) method.
+    expect(update.total?.amount.value).toBe("37.99");
   });
 });
 

--- a/packages/browser/test/applePay.test.ts
+++ b/packages/browser/test/applePay.test.ts
@@ -893,6 +893,181 @@ describe("buildSession shipping methods", () => {
     // Falls back to the initially selected (or first) method.
     expect(update.total?.amount.value).toBe("37.99");
   });
+
+  it("preserves the selected shipping method after a later shipping address change", async () => {
+    const onShippingAddressChange = vi.fn().mockResolvedValue({
+      amount: 4499,
+      lineItems: [
+        { label: "Mens Shirt", amount: 3000 },
+        { label: "Socks", amount: 500 },
+        { label: "Express Shipping", amount: 999 },
+      ],
+    });
+
+    const request = await buildSession(applePay, {
+      transaction: {
+        ...transaction,
+        amount: 3799,
+        lineItems: [
+          { label: "Mens Shirt", amount: 3000 },
+          { label: "Socks", amount: 500 },
+          { label: "Standard Shipping", amount: 299 },
+        ],
+      },
+      shippingMethods,
+      onShippingAddressChange,
+    });
+
+    const session = paymentRequestInstances[0];
+    session.shippingOption = "express";
+    request.onshippingoptionchange?.({
+      target: session,
+      updateWith: vi.fn(),
+    } as unknown as PaymentRequestUpdateEvent);
+
+    const updateWith = vi.fn();
+    request.onshippingaddresschange?.({
+      // No shippingOption on the address-change target — selection must come
+      // from the live session / persisted activeShippingOptionId.
+      target: {
+        shippingAddress: {
+          addressLine: ["1 Main St"],
+          city: "Dublin",
+          country: "IE",
+          dependentLocality: "",
+          organization: "",
+          phone: "",
+          postalCode: "D01",
+          recipient: "Jane",
+          region: "",
+          sortingCode: "",
+        },
+      },
+      updateWith,
+    } as unknown as PaymentRequestUpdateEvent);
+
+    const update = await updateWith.mock.calls[0][0];
+    expect(onShippingAddressChange).toHaveBeenCalled();
+    expect(
+      update.shippingOptions?.find((o: { id: string }) => o.id === "express")
+        ?.selected
+    ).toBe(true);
+    expect(
+      update.shippingOptions?.find((o: { id: string }) => o.id === "standard")
+        ?.selected
+    ).toBe(false);
+  });
+
+  it("preserves the selected shipping method across coupon updates", async () => {
+    const onCouponCodeChange = vi.fn().mockResolvedValue({
+      amount: 3799,
+      lineItems: [
+        { label: "Mens Shirt", amount: 3000 },
+        { label: "Socks", amount: 500 },
+        { label: "Coupon", amount: -700 },
+        { label: "Express Shipping", amount: 999 },
+      ],
+    });
+
+    const request = await buildSession(applePay, {
+      transaction: {
+        ...transaction,
+        amount: 3799,
+      },
+      shippingMethods,
+      supportsCouponCode: true,
+      onCouponCodeChange,
+    });
+
+    const session = paymentRequestInstances[0];
+    session.shippingOption = "express";
+    request.onshippingoptionchange?.({
+      target: session,
+      updateWith: vi.fn(),
+    } as unknown as PaymentRequestUpdateEvent);
+
+    const updateWith = vi.fn();
+    request.onshippingaddresschange?.({
+      target: {},
+      methodDetails: { couponCode: "SAVE20" },
+      updateWith,
+    } as unknown as PaymentRequestUpdateEvent);
+
+    const update = await updateWith.mock.calls[0][0];
+    expect(onCouponCodeChange).toHaveBeenCalledWith("SAVE20");
+    expect(update.shippingOptions).toHaveLength(2);
+    expect(
+      update.shippingOptions?.find((o: { id: string }) => o.id === "express")
+        ?.selected
+    ).toBe(true);
+  });
+
+  it("warns when internal recompute cannot match a shipping line item by label", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const request = await buildSession(applePay, {
+      transaction: {
+        ...transaction,
+        amount: 3799,
+        lineItems: [
+          { label: "Mens Shirt", amount: 3000 },
+          { label: "Socks", amount: 500 },
+          // Label does not match shippingMethods[].label ("Standard Shipping")
+          { label: "Shipping", amount: 299 },
+        ],
+      },
+      shippingMethods,
+    });
+
+    const session = paymentRequestInstances[0];
+    session.shippingOption = "express";
+    const updateWith = vi.fn();
+    request.onshippingoptionchange?.({
+      target: session,
+      updateWith,
+    } as unknown as PaymentRequestUpdateEvent);
+
+    await updateWith.mock.calls[0][0];
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "expected to replace exactly one line item matching a shippingMethods[].label"
+      )
+    );
+
+    warn.mockRestore();
+  });
+
+  it("warns and keeps only the first selected shipping method when multiple are marked selected", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await buildSession(applePay, {
+      transaction,
+      shippingMethods: [
+        {
+          id: "standard",
+          label: "Standard Shipping",
+          amount: 299,
+          selected: true,
+        },
+        {
+          id: "express",
+          label: "Express Shipping",
+          amount: 999,
+          selected: true,
+        },
+      ],
+    });
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("Multiple shippingMethods have selected: true")
+    );
+    expect(paymentRequestCalls[0].shippingOptions).toEqual([
+      expect.objectContaining({ id: "standard", selected: true }),
+      expect.objectContaining({ id: "express", selected: false }),
+    ]);
+
+    warn.mockRestore();
+  });
 });
 
 describe("buildSession request-config passthrough", () => {

--- a/packages/types/uiComponents.ts
+++ b/packages/types/uiComponents.ts
@@ -358,6 +358,16 @@ export type EncryptedApplePayData = Omit<
     emailAddress?: string;
     phoneNumber?: string;
   };
+  /**
+   * The shipping method the customer selected on the Apple Pay sheet.
+   * Present when `shippingMethods` were configured on the web Apple Pay button.
+   */
+  shippingMethod?: {
+    id: string;
+    label: string;
+    amount: number;
+    detail?: string;
+  };
 };
 
 export interface ApplePayClientMessages extends EvervaultFrameClientMessages {


### PR DESCRIPTION

Expose shippingType/shippingMethods on one-off web Apple Pay sessions, recompute totals on shippingoptionchange, and return the selected method on process().