### PR TITLE
Replace ApplePay script-load poll with onload

### DIFF
--- a/.changeset/apple-pay-remove-script-poll.md
+++ b/.changeset/apple-pay-remove-script-poll.md
@@ -1,0 +1,5 @@
+---
+"@evervault/browser": patch
+---
+
+Replace the 100ms `setInterval` poll in `ApplePayButton`'s script-load wait with the SDK script's own `onload` event, removing up to ~100ms of artificial latency from `availability()`/`mount()`.

--- a/packages/browser/lib/ui/ApplePay/index.ts
+++ b/packages/browser/lib/ui/ApplePay/index.ts
@@ -147,6 +147,8 @@ export default class ApplePayButton {
   #options: ApplePayButtonOptions;
   #events = new EventManager<ApplePayEvents>();
   #scriptLoaded = false;
+  #scriptLoadPromise: Promise<void>;
+  #resolveScriptLoad!: () => void;
   #activeSession: PaymentRequest | null = null;
   #abortRequested = false;
   #sessionInProgress = false;
@@ -160,6 +162,9 @@ export default class ApplePayButton {
     this.client = client;
     this.#options = options;
     this.transaction = transaction;
+    this.#scriptLoadPromise = new Promise((resolve) => {
+      this.#resolveScriptLoad = resolve;
+    });
     this.#injectScript();
   }
 
@@ -168,6 +173,7 @@ export default class ApplePayButton {
     const existing = document.querySelector(selector);
     if (existing) {
       this.#scriptLoaded = true;
+      this.#resolveScriptLoad();
       return;
     }
 
@@ -177,6 +183,7 @@ export default class ApplePayButton {
     script.crossOrigin = "anonymous";
     script.onload = () => {
       this.#scriptLoaded = true;
+      this.#resolveScriptLoad();
     };
 
     document.body.appendChild(script);
@@ -402,20 +409,18 @@ export default class ApplePayButton {
     if (this.#scriptLoaded) return;
     const TIMEOUT = 10000;
 
-    return new Promise((resolve, reject) => {
-      const start = Date.now();
-      const interval = setInterval(() => {
-        if (this.#scriptLoaded) {
-          clearInterval(interval);
-          resolve(true);
-        }
-
-        if (Date.now() - start > TIMEOUT) {
-          clearInterval(interval);
-          reject(new Error("Apple Pay SDK script load timeout"));
-        }
-      }, 100);
+    let timeoutId: ReturnType<typeof setTimeout>;
+    const timeout = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(() => {
+        reject(new Error("Apple Pay SDK script load timeout"));
+      }, TIMEOUT);
     });
+
+    try {
+      await Promise.race([this.#scriptLoadPromise, timeout]);
+    } finally {
+      clearTimeout(timeoutId!);
+    }
   }
 
   /**

--- a/packages/browser/test/applePay.test.ts
+++ b/packages/browser/test/applePay.test.ts
@@ -1361,6 +1361,68 @@ async function clickApplePayButton(apple: ApplePayButton) {
   button?.dispatchEvent(new Event("click"));
 }
 
+describe("ApplePayButton script loading", () => {
+  beforeEach(() => {
+    vi.stubGlobal("PaymentRequest", class PaymentRequest {});
+    vi.stubGlobal("ApplePaySession", {
+      applePayCapabilities: vi.fn().mockResolvedValue({
+        paymentCredentialStatus: "paymentCredentialsAvailable",
+      }),
+    });
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("resolves availability() as soon as the SDK script's onload fires, without polling", async () => {
+    const apple = new ApplePayButton(createMockClient(), createTransaction(), {
+      process: vi.fn(),
+    });
+
+    const script = document.querySelector<HTMLScriptElement>(
+      'script[src="https://applepay.cdn-apple.com/jsapi/1.latest/apple-pay-sdk.js"]'
+    );
+    expect(script).not.toBeNull();
+
+    let resolved = false;
+    const availabilityPromise = apple.availability().then((result) => {
+      resolved = true;
+      return result;
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(resolved).toBe(false);
+
+    script!.dispatchEvent(new Event("load"));
+
+    await expect(availabilityPromise).resolves.toBe("available");
+    expect(resolved).toBe(true);
+  });
+
+  it("rejects with a timeout error if the SDK script never loads", async () => {
+    vi.useFakeTimers();
+    try {
+      const apple = new ApplePayButton(
+        createMockClient(),
+        createTransaction(),
+        { process: vi.fn() }
+      );
+
+      const assertion = expect(apple.availability()).rejects.toThrow(
+        "Apple Pay SDK script load timeout"
+      );
+
+      await vi.advanceTimersByTimeAsync(10000);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
 describe("ApplePayButton.abort", () => {
   beforeEach(() => {
     buildSessionMock.mockReset();


### PR DESCRIPTION
Waits on the SDK script's own onload event instead of polling #scriptLoaded via setInterval every 100ms, shaving some latency off availability()/mount().

### F2 — before/after: `ev:apple-pay:mount`

| Browser | Before median | After median | Δ | Before mean | After mean | n (before/after) |
|---|---|---|---|---|---|---|
| Desktop Chrome (macOS) | 159.6ms | 159.9ms | +0.3ms | 165.6ms | 160.4ms | 16 / 18 |
| Desktop Safari (macOS) | 341.0ms | 337.0ms | −4.0ms | 341.3ms | 359.9ms* | 9 / 17 |
| iPhone Safari | 505.5ms | 503.0ms | −2.5ms | 514.0ms | 506.4ms | 20 / 35 |
| iPhone Chrome (CriOS) | 525.0ms | 455.5ms | −69.5ms** | 549.1ms | 476.4ms | 9 / 26 |

\* mean pulled up by a few outlier runs (676ms) — median is the more reliable number here.
\** noisy, small before-sample (n=9) — treat as directional, not conclusive.

### Q4 — isolated script-load wait (`ev:apple-pay:wait-for-script`, post-fix)

Added a temporary perf mark bracketing just `#waitForScript()` to measure the real, unquantized script-load time directly.

| Browser | n | median | mean | min | max | p90 |
|---|---|---|---|---|---|---|
| Desktop Chrome (macOS) | 18 | 13.4ms | 16.8ms | 10.6ms | 50.1ms | 19.0ms |
| Desktop Safari (macOS) | 17 | 16.0ms | 21.5ms | 14.0ms | 45.0ms | 31.0ms |
| iPhone Safari | 38 | 14.0ms | 12.9ms | 4.0ms | 49.0ms | 18.0ms |
| iPhone Chrome (CriOS) | 26 | 15.0ms | 17.8ms | 10.0ms | 51.0ms | 22.0ms |

**Residual answer:** the real script-load time is only ~10-20ms (median) across all browsers. Under the old `setInterval(…, 100)` poll, every one of these would've been rounded up to ~100ms (first check only happens at the t=100ms tick). 
So we removed deterministic ~80-90ms of poll-alignment overhead per mount — it's just masked in the full `mount()` numbers above by run-to-run noise in `ApplePaySession.applePayCapabilities()` and tunnel/network jitter, which dominates the ~350-500ms Safari total. 

**However, the ~350-500ms Safari delay is overwhelmingly `applePayCapabilities()` and native work, not script-load/poll. We will address this in the later PRs.**