### PR TITLE
Parallelize the two independent GETs

### DIFF
--- a/.changeset/parallelize-merchant-sdk-config-gets.md
+++ b/.changeset/parallelize-merchant-sdk-config-gets.md
@@ -1,0 +1,6 @@
+---
+"@evervault/browser": patch
+"@evervault/ui-components": patch
+---
+
+Parallelize the independent `getMerchant`/`getAppSDKConfig` requests in ApplePay's `buildSession` and GooglePay's SDK-load handler (`Promise.all`/concurrent kickoff instead of sequential awaits), removing one round-trip of latency from the critical path.

--- a/packages/browser/lib/ui/ApplePay/utilities.ts
+++ b/packages/browser/lib/ui/ApplePay/utilities.ts
@@ -398,15 +398,18 @@ export async function buildSession(
   const { transaction: tx } = config;
   assertShippingMethodsAllowed(tx, config);
 
-  const merchant = await getMerchant(applePay, tx.merchantId);
+  const [merchant, appConfig] = await Promise.all([
+    getMerchant(applePay, tx.merchantId),
+    getAppSDKConfig(
+      applePay.client.config.appId,
+      applePay.client.config.http.apiUrl
+    ),
+  ]);
+
   if (!merchant) {
     throw new Error("Merchant not found");
   }
 
-  const appConfig = await getAppSDKConfig(
-    applePay.client.config.appId,
-    applePay.client.config.http.apiUrl
-  );
   if (appConfig.is_sandbox) {
     merchant.name = `${merchant.name} (Card is not charged)`;
   }

--- a/packages/browser/test/applePay.test.ts
+++ b/packages/browser/test/applePay.test.ts
@@ -198,6 +198,42 @@ describe("buildSession sandbox label", () => {
   });
 });
 
+describe("buildSession GET concurrency", () => {
+  it("issues the merchant and sdk-config requests concurrently, not sequentially", async () => {
+    let resolveMerchant: () => void = () => {};
+    const merchantGate = new Promise<void>((resolve) => {
+      resolveMerchant = resolve;
+    });
+    let sdkConfigRequested = false;
+
+    server.use(
+      http.get(`${apiUrl}/frontend/merchants/${merchantId}`, async () => {
+        await merchantGate;
+        return HttpResponse.json(
+          { id: merchantId, name: merchantName },
+          { status: 200 }
+        );
+      }),
+      http.get(`${apiUrl}/frontend/sdk/config`, () => {
+        sdkConfigRequested = true;
+        return HttpResponse.json({ is_sandbox: false }, { status: 200 });
+      })
+    );
+
+    const buildSessionPromise = buildSession(applePay, { transaction });
+
+    // If the two GETs were sequential, sdk-config would never be requested
+    // while the merchant request is still gated open — this only resolves
+    // if both requests are in flight concurrently.
+    await vi.waitFor(() => {
+      expect(sdkConfigRequested).toBe(true);
+    });
+
+    resolveMerchant();
+    await buildSessionPromise;
+  });
+});
+
 describe("buildSession onshippingaddresschange", () => {
   beforeEach(() => {
     server.use(

--- a/packages/ui-components/src/GooglePay/index.tsx
+++ b/packages/ui-components/src/GooglePay/index.tsx
@@ -51,7 +51,10 @@ export function GooglePay({ config }: GooglePayProps) {
     called.current = true;
 
     async function onLoad() {
-      const appConfig = await getAppSDKConfig(app, apiConfig.apiUrl);
+      const appConfigPromise = getAppSDKConfig(app, apiConfig.apiUrl);
+      const merchantPromise = getMerchant(app, config.transaction.merchantId);
+
+      const appConfig = await appConfigPromise;
       const paymentsClient = new google.payments.api.PaymentsClient({
         // Always use 'test' in staging, but use the resolved environment in production
         environment:
@@ -130,7 +133,7 @@ export function GooglePay({ config }: GooglePayProps) {
       });
 
       try {
-        const merchant = await getMerchant(app, config.transaction.merchantId);
+        const merchant = await merchantPromise;
         if (!merchant) {
           throw new Error("Merchant not found");
         }

--- a/packages/ui-components/test/GooglePay.test.tsx
+++ b/packages/ui-components/test/GooglePay.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GooglePay } from "../src/GooglePay";
+import type { GooglePayConfig } from "../src/GooglePay/types";
+
+const getMerchantMock = vi.fn();
+const getAppSDKConfigMock = vi.fn();
+
+vi.mock("../src/utilities/useMerchant", () => ({
+  getMerchant: (...args: unknown[]) => getMerchantMock(...args),
+}));
+
+vi.mock("shared", () => ({
+  getAppSDKConfig: (...args: unknown[]) => getAppSDKConfigMock(...args),
+}));
+
+vi.mock("../src/utilities/useSearchParams", () => ({
+  useSearchParams: () => ({ app: "app_test123", id: "frame1" }),
+}));
+
+class MockPaymentsClient {
+  isReadyToPay = vi.fn().mockResolvedValue({ result: true });
+  createButton = vi.fn().mockReturnValue(document.createElement("div"));
+  loadPaymentData = vi.fn();
+}
+
+const config: GooglePayConfig = {
+  transaction: {
+    type: "payment",
+    amount: 1000,
+    currency: "USD",
+    country: "US",
+    merchantId: "merchant_abc",
+    domain: "shop.example.com",
+  },
+  type: "plain",
+  color: "black",
+  borderRadius: 4,
+};
+
+function getInjectedScript() {
+  return document.querySelector<HTMLScriptElement>(
+    'script[src="https://pay.google.com/gp/p/js/pay.js"]'
+  );
+}
+
+describe("GooglePay onLoad GET concurrency", () => {
+  beforeEach(() => {
+    getMerchantMock.mockReset();
+    getAppSDKConfigMock.mockReset();
+    (globalThis as unknown as { google: unknown }).google = {
+      payments: { api: { PaymentsClient: MockPaymentsClient } },
+    };
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    delete (globalThis as { google?: unknown }).google;
+  });
+
+  it("issues getAppSDKConfig and getMerchant concurrently, not sequentially", async () => {
+    let resolveAppConfig: (value: { is_sandbox: boolean }) => void = () => {};
+    const appConfigGate = new Promise<{ is_sandbox: boolean }>((resolve) => {
+      resolveAppConfig = resolve;
+    });
+    getAppSDKConfigMock.mockReturnValue(appConfigGate);
+    getMerchantMock.mockResolvedValue({ id: "merchant_abc", name: "Acme Co" });
+
+    render(<GooglePay config={config} />);
+
+    const script = getInjectedScript();
+    expect(script).not.toBeNull();
+    script!.dispatchEvent(new Event("load"));
+
+    // If the two calls were sequential, getMerchant would never be invoked
+    // while getAppSDKConfig's request is still gated open.
+    await waitFor(() => {
+      expect(getMerchantMock).toHaveBeenCalledWith(
+        "app_test123",
+        "merchant_abc"
+      );
+    });
+
+    resolveAppConfig({ is_sandbox: false });
+
+    await waitFor(() => {
+      expect(getAppSDKConfigMock).toHaveBeenCalledWith(
+        "app_test123",
+        expect.any(String)
+      );
+    });
+  });
+});


### PR DESCRIPTION
### ApplePay

- **Derived sum** is get-merchant + get-app-sdk-config from this same post-fix run (mathematically clean, but two independent-run comparisons like the "measured" column always carry some noise). 
- **Actual sequential** is the real tap-to-sheet measured in the original baseline. That's a genuine before/after. 

They mostly agree in direction but don't match number-for-number since they're separate live-network sessions.

| Browser | Scenario | `get-merchant` | `get-app-sdk-config` | Actual (parallel, `tap-to-sheet`) | Sequential-equivalent (derived sum) | Actual sequential (measured, pre-fix baseline) | Saved (measured) |
|---|---|---|---|---|---|---|---|
| Desktop Chrome | warm | 35.5ms | 28.4ms | 36.8ms | 64.0ms | 87.0ms | ~50.2ms |
| Desktop Chrome | cold (first tap) | 47.3ms | 46.3ms | 48.1ms | 93.6ms | 97.3ms | ~49.2ms |
| Desktop Safari | warm | 26.5ms | 38.5ms | 39.0ms | 65.0ms | 59.0ms | ~20.0ms |
| Desktop Safari | cold (first tap) | 68.0ms | 72.5ms | 74.5ms | 140.5ms | 105.0ms | ~30.5ms |
| iPhone Safari | warm | 42.0ms | 51.0ms | 53.5ms | 93.0ms | 76.0ms | ~22.5ms |
| iPhone Safari | cold (first tap) | 102.0ms | 100.0ms | 104.0ms | 202.0ms | 137.0ms | ~33.0ms |
| iPhone Chrome (CriOS) | warm | 36.0ms | 35.0ms | 38.0ms | 71.0ms | 68.5ms | ~30.5ms |
| iPhone Chrome (CriOS) | cold (first tap) | 102.5ms | 102.5ms | 107.0ms | 205.0ms | 115.0ms | ~8.0ms |

### GooglePay


| Browser | Before median (n) | After median (n) | Median Δ | Before mean | After mean |
|---|---|---|---|---|---|
| Chrome | 91.3ms (12) | 54.4ms (8) | **-40%** | 116.7ms | 99.5ms |
| Safari | 105.0ms (9) | 53.0ms (15) | **-50%** | 465.1ms | 161.1ms |
