### PR TITLE
Dedupe applePayCapabilities call, use memoization instead

### DIFF
--- a/.changeset/dedupe-apple-pay-availability.md
+++ b/.changeset/dedupe-apple-pay-availability.md
@@ -1,0 +1,5 @@
+---
+"@evervault/browser": patch
+---
+
+Dedupe the redundant native `ApplePaySession.applePayCapabilities()` call in `ApplePayButton`. `availability()` now memoizes its in-flight/resolved result on the instance, so calling `.availability()` before `.mount()` (the common integration pattern for driving "checking availability" UI) no longer triggers the expensive native capability probe twice per render.

--- a/packages/browser/lib/ui/ApplePay/index.ts
+++ b/packages/browser/lib/ui/ApplePay/index.ts
@@ -153,6 +153,9 @@ export default class ApplePayButton {
   #abortRequested = false;
   #sessionInProgress = false;
   #showStarted = false;
+  #availabilityPromise: Promise<
+    "available" | "unavailable" | "unsupported"
+  > | null = null;
 
   constructor(
     client: EvervaultClient,
@@ -432,6 +435,22 @@ export default class ApplePayButton {
    * - "unsupported": Apple Pay is not supported on this device or browser.
    */
   async availability(): Promise<"available" | "unavailable" | "unsupported"> {
+    if (!this.#availabilityPromise) {
+      this.#availabilityPromise = this.#computeAvailability().catch(
+        (error) => {
+          // Don't cache a failed probe — allow a later call to retry.
+          this.#availabilityPromise = null;
+          throw error;
+        }
+      );
+    }
+
+    return this.#availabilityPromise;
+  }
+
+  async #computeAvailability(): Promise<
+    "available" | "unavailable" | "unsupported"
+  > {
     if (typeof window.PaymentRequest === "undefined") return "unsupported";
     await this.#waitForScript();
 

--- a/packages/browser/lib/ui/ApplePay/index.ts
+++ b/packages/browser/lib/ui/ApplePay/index.ts
@@ -436,13 +436,11 @@ export default class ApplePayButton {
    */
   async availability(): Promise<"available" | "unavailable" | "unsupported"> {
     if (!this.#availabilityPromise) {
-      this.#availabilityPromise = this.#computeAvailability().catch(
-        (error) => {
-          // Don't cache a failed probe — allow a later call to retry.
-          this.#availabilityPromise = null;
-          throw error;
-        }
-      );
+      this.#availabilityPromise = this.#computeAvailability().catch((error) => {
+        // Don't cache a failed probe — allow a later call to retry.
+        this.#availabilityPromise = null;
+        throw error;
+      });
     }
 
     return this.#availabilityPromise;

--- a/packages/browser/test/applePay.test.ts
+++ b/packages/browser/test/applePay.test.ts
@@ -1695,3 +1695,110 @@ describe("ApplePayButton shipping method on process()", () => {
     expect(process.mock.calls[0][0].shippingMethod).toBeUndefined();
   });
 });
+
+describe("ApplePayButton.availability", () => {
+  function stubApplePaySession(
+    capabilities:
+      | { paymentCredentialStatus: string }
+      | (() => Promise<{ paymentCredentialStatus: string }>)
+  ) {
+    vi.stubGlobal("ApplePaySession", {
+      applePayCapabilities:
+        typeof capabilities === "function"
+          ? vi.fn(capabilities)
+          : vi.fn().mockResolvedValue(capabilities),
+    });
+  }
+
+  beforeEach(() => {
+    vi.stubGlobal("PaymentRequest", class PaymentRequest {});
+    stubApplePaySession({
+      paymentCredentialStatus: "paymentCredentialsAvailable",
+    });
+
+    const script = document.createElement("script");
+    script.src =
+      "https://applepay.cdn-apple.com/jsapi/1.latest/apple-pay-sdk.js";
+    document.body.appendChild(script);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("only calls applePayCapabilities once across repeated availability() calls", async () => {
+    const apple = new ApplePayButton(createMockClient(), createTransaction(), {
+      process: vi.fn(),
+    });
+
+    const first = await apple.availability();
+    const second = await apple.availability();
+
+    expect(first).toBe("available");
+    expect(second).toBe("available");
+    expect(ApplePaySession.applePayCapabilities).toHaveBeenCalledOnce();
+  });
+
+  it("only calls applePayCapabilities once when availability() is followed by mount()", async () => {
+    const apple = new ApplePayButton(createMockClient(), createTransaction(), {
+      process: vi.fn(),
+    });
+
+    await apple.availability();
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    await apple.mount(container);
+
+    expect(ApplePaySession.applePayCapabilities).toHaveBeenCalledOnce();
+  });
+
+  it("dedupes concurrent availability() calls into a single in-flight probe", async () => {
+    let resolveCapabilities: (value: {
+      paymentCredentialStatus: string;
+    }) => void = () => {};
+    stubApplePaySession(
+      () =>
+        new Promise((resolve) => {
+          resolveCapabilities = resolve;
+        })
+    );
+
+    const apple = new ApplePayButton(createMockClient(), createTransaction(), {
+      process: vi.fn(),
+    });
+    const firstCall = apple.availability();
+    const secondCall = apple.availability();
+    await vi.waitFor(() => {
+      expect(ApplePaySession.applePayCapabilities).toHaveBeenCalled();
+    });
+
+    resolveCapabilities({
+      paymentCredentialStatus: "paymentCredentialsAvailable",
+    });
+
+    await expect(firstCall).resolves.toBe("available");
+    await expect(secondCall).resolves.toBe("available");
+    expect(ApplePaySession.applePayCapabilities).toHaveBeenCalledOnce();
+  });
+
+  it("does not cache a failed probe, allowing a later call to retry", async () => {
+    stubApplePaySession(() => Promise.reject(new Error("native probe failed")));
+
+    const apple = new ApplePayButton(createMockClient(), createTransaction(), {
+      process: vi.fn(),
+    });
+
+    await expect(apple.availability()).rejects.toThrow("native probe failed");
+    expect(ApplePaySession.applePayCapabilities).toHaveBeenCalledOnce();
+
+    stubApplePaySession({
+      paymentCredentialStatus: "paymentCredentialsAvailable",
+    });
+
+    await expect(apple.availability()).resolves.toBe("available");
+    expect(ApplePaySession.applePayCapabilities).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
Latency for ApplePay button to appeat dropped ~35% on average and ~44% at p90

| Metric | Before (double call) | After (deduped) | Δ |
|---|---|---|---|
| Sessions captured | 66 | 85 | — |
| Sessions with 2× `applePayCapabilities()` | **65/66 (98%)** | **0/85 (0%)** | bug eliminated |
| `mount()` own duration — mean | 204.9ms | 4.4ms | **−200.4ms (−98%)** |
| `mount()` own duration — median | 164.5ms | 4.0ms | **−160.5ms** |
| End-to-end `availability()` + `mount()` — mean | 589.5ms | 382.2ms | **−207.3ms (−35%)** |
| End-to-end `availability()` + `mount()` — median | 452.0ms | 313.8ms | **−138.2ms (−31%)** |
| End-to-end p90 | 1103.0ms | 618.0ms | **−485ms** |
| Redundant 2nd `applePayCapabilities()` cost (before only) | mean 198.9ms | eliminated | — |

`end-to-end = wait-for-script (1st call) + apple-pay-capabilities (1st call) + mount()'s own duration`

