### PR TITLE
Convert Google Pay amounts using the currency's exponent

### DIFF
--- a/.changeset/google-pay-currency-exponent.md
+++ b/.changeset/google-pay-currency-exponent.md
@@ -1,9 +1,20 @@
 ---
-"@evervault/ui-components": patch
+"@evervault/ui-components": minor
 ---
 
 Fix Google Pay amounts for currencies that do not have two minor units. Amounts
 were always divided by 100 and rendered with two decimal places, so a
-zero-decimal currency (JPY, KRW, VND) was authorised at 1/100th of the intended
-value and a three-decimal currency (KWD, BHD, OMR) at 10x. The total and line
-items are now converted using the currency's own exponent.
+zero-decimal currency (JPY, KRW, VND, ISK) was displayed and authorised at
+1/100th of the intended value, and a three-decimal currency (KWD, BHD, OMR, JOD,
+TND) at 10x. The total and line items are now converted using the currency's own
+exponent.
+
+Google Pay carries at most two fraction digits, so three-decimal currencies are
+supported down to hundredths of a major unit: 1.000 KWD works, 1.005 KWD does
+not and now throws instead of being rounded to a different amount. Previously
+such an amount rendered a button that failed mid-checkout with `OR_BIBED_06`.
+
+Note for anyone already live in a zero-decimal currency: amounts were being
+divided by 100, so if you compensated by passing 100x the intended amount, the
+Google Pay sheet will now show 100x too much and no longer match what you
+charge. Pass the true minor-unit amount.

--- a/.changeset/google-pay-currency-exponent.md
+++ b/.changeset/google-pay-currency-exponent.md
@@ -1,5 +1,5 @@
 ---
-"@evervault/ui-components": minor
+"@evervault/ui-components": major
 ---
 
 Fix Google Pay amounts for currencies that do not have two minor units. Amounts

--- a/.changeset/google-pay-currency-exponent.md
+++ b/.changeset/google-pay-currency-exponent.md
@@ -1,0 +1,9 @@
+---
+"@evervault/ui-components": patch
+---
+
+Fix Google Pay amounts for currencies that do not have two minor units. Amounts
+were always divided by 100 and rendered with two decimal places, so a
+zero-decimal currency (JPY, KRW, VND) was authorised at 1/100th of the intended
+value and a three-decimal currency (KWD, BHD, OMR) at 10x. The total and line
+items are now converted using the currency's own exponent.

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -6,7 +6,8 @@
   "exports": {
     ".": "./src/index.ts",
     "./getAppSDKConfig": "./src/getAppSDKConfig.ts",
-    "./createBrand": "./src/createBrand.ts"
+    "./createBrand": "./src/createBrand.ts",
+    "./currency": "./src/currency.ts"
   },
   "dependencies": {
     "types": "workspace:*",

--- a/packages/shared/src/currency.ts
+++ b/packages/shared/src/currency.ts
@@ -1,0 +1,33 @@
+const DEFAULT_CURRENCY_EXPONENT = 2;
+
+/** Minor units per major unit as a power of ten, from the runtime's CLDR data. */
+function currencyExponent(currency: string): number {
+  try {
+    const { maximumFractionDigits } = new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency,
+    }).resolvedOptions();
+    return maximumFractionDigits ?? DEFAULT_CURRENCY_EXPONENT;
+  } catch {
+    return DEFAULT_CURRENCY_EXPONENT;
+  }
+}
+
+/**
+ * Format an amount given in a currency's minor units as the decimal string
+ * wallet APIs expect: `(1000, "USD") -> "10.00"`, `(1000, "JPY") -> "1000"`,
+ * `(1000, "KWD") -> "1.000"`.
+ */
+export function formatTransactionAmount(
+  amount: number,
+  currency: string
+): string {
+  const exponent = currencyExponent(currency);
+  const digits = Math.round(Math.abs(amount))
+    .toString()
+    .padStart(exponent + 1, "0");
+  const whole = digits.slice(0, digits.length - exponent);
+  const fraction = digits.slice(digits.length - exponent);
+  const sign = amount < 0 ? "-" : "";
+  return fraction ? `${sign}${whole}.${fraction}` : `${sign}${whole}`;
+}

--- a/packages/shared/src/currency.ts
+++ b/packages/shared/src/currency.ts
@@ -1,7 +1,7 @@
 const DEFAULT_CURRENCY_EXPONENT = 2;
 
 /** Minor units per major unit as a power of ten, from the runtime's CLDR data. */
-function currencyExponent(currency: string): number {
+export function currencyExponent(currency: string): number {
   try {
     const { maximumFractionDigits } = new Intl.NumberFormat("en-US", {
       style: "currency",
@@ -14,15 +14,11 @@ function currencyExponent(currency: string): number {
 }
 
 /**
- * Format an amount given in a currency's minor units as the decimal string
- * wallet APIs expect: `(1000, "USD") -> "10.00"`, `(1000, "JPY") -> "1000"`,
- * `(1000, "KWD") -> "1.000"`.
+ * Render an integer amount with an explicit number of fraction digits, using
+ * string arithmetic so the result is exact at any magnitude:
+ * `(1000, 2) -> "10.00"`, `(1000, 0) -> "1000"`.
  */
-export function formatTransactionAmount(
-  amount: number,
-  currency: string
-): string {
-  const exponent = currencyExponent(currency);
+export function formatMinorUnits(amount: number, exponent: number): string {
   const digits = Math.round(Math.abs(amount))
     .toString()
     .padStart(exponent + 1, "0");
@@ -30,4 +26,20 @@ export function formatTransactionAmount(
   const fraction = digits.slice(digits.length - exponent);
   const sign = amount < 0 ? "-" : "";
   return fraction ? `${sign}${whole}.${fraction}` : `${sign}${whole}`;
+}
+
+/**
+ * Format an amount given in a currency's minor units as the decimal string
+ * wallet APIs expect: `(1000, "USD") -> "10.00"`, `(1000, "JPY") -> "1000"`,
+ * `(1000, "KWD") -> "1.000"`.
+ *
+ * Renders the currency's full precision. Google Pay carries only two fraction
+ * digits, so its caller reduces the precision itself rather than this doing it
+ * for every wallet; Apple Pay takes three-decimal currencies as they are.
+ */
+export function formatTransactionAmount(
+  amount: number,
+  currency: string
+): string {
+  return formatMinorUnits(amount, currencyExponent(currency));
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./createBrand";
+export * from "./currency";
 export * from "./useForm";
 export * from "./useTranslations";
 export * from "./getAppSDKConfig";

--- a/packages/ui-components/src/GooglePay/utilities.ts
+++ b/packages/ui-components/src/GooglePay/utilities.ts
@@ -1,3 +1,4 @@
+import { formatTransactionAmount } from "shared/currency";
 import { EncryptedGooglePayData, MerchantDetail } from "types";
 import { GooglePayConfig } from "./types";
 import { apiConfig } from "../utilities/config";
@@ -52,13 +53,13 @@ export function buildPaymentRequest(
     transactionInfo: {
       totalPriceStatus: "FINAL",
       totalPriceLabel: tx.priceLabel ?? `Pay ${merchant.name}`,
-      totalPrice: (tx.amount / 100).toFixed(2).toString(),
+      totalPrice: formatTransactionAmount(tx.amount, tx.currency),
       currencyCode: tx.currency,
       countryCode: tx.country,
       displayItems: tx.lineItems?.map((item) => ({
         label: item.label,
         type: "LINE_ITEM",
-        price: (item.amount / 100).toFixed(2).toString(),
+        price: formatTransactionAmount(item.amount, tx.currency),
       })),
     },
     callbackIntents: ["PAYMENT_AUTHORIZATION"],

--- a/packages/ui-components/src/GooglePay/utilities.ts
+++ b/packages/ui-components/src/GooglePay/utilities.ts
@@ -1,7 +1,44 @@
-import { formatTransactionAmount } from "shared/currency";
+import { currencyExponent, formatMinorUnits } from "shared/currency";
 import { EncryptedGooglePayData, MerchantDetail } from "types";
 import { GooglePayConfig } from "./types";
 import { apiConfig } from "../utilities/config";
+
+// The docs specify totalPrice as 0 or exactly 2 fraction digits, but the client
+// enforces `-?[0-9]*(\.[0-9][0-9]?)?`, quoted from the DEVELOPER_ERROR that Play
+// Services returns for an over-precise displayItems price. One digit is fine;
+// three is not.
+//
+// The ceiling is enforced late. A three-digit price builds, opens the sheet, and
+// only then fails: OR_BIBED_06 on web ("This merchant is having trouble accepting
+// your payment right now"), statusCode 10 with an empty message on Android.
+// Verified on both clients across USD, KWD, BHD, OMR and TND.
+// https://developers.google.com/pay/api/web/reference/request-objects
+const MAX_FRACTION_DIGITS = 2;
+
+/**
+ * Format a minor-unit amount for Google Pay, which carries at most two fraction
+ * digits. A three-decimal currency (KWD, BHD, OMR, JOD, TND) is therefore
+ * limited to whole hundredths: 1.000 KWD is fine, 1.005 KWD is not and throws
+ * rather than being rounded to a different amount.
+ */
+function formatGooglePayAmount(amount: number, currency: string): string {
+  const exponent = currencyExponent(currency);
+  if (exponent <= MAX_FRACTION_DIGITS) {
+    return formatMinorUnits(amount, exponent);
+  }
+
+  const divisor = 10 ** (exponent - MAX_FRACTION_DIGITS);
+  const rounded = Math.round(amount);
+  if (rounded % divisor !== 0) {
+    throw new Error(
+      `Google Pay carries at most ${MAX_FRACTION_DIGITS} fraction digits, so ` +
+        `${currency} amounts must be a multiple of ${divisor} minor units. ` +
+        `${amount} is not.`
+    );
+  }
+
+  return formatMinorUnits(rounded / divisor, MAX_FRACTION_DIGITS);
+}
 
 export function buildPaymentRequest(
   config: GooglePayConfig,
@@ -53,13 +90,13 @@ export function buildPaymentRequest(
     transactionInfo: {
       totalPriceStatus: "FINAL",
       totalPriceLabel: tx.priceLabel ?? `Pay ${merchant.name}`,
-      totalPrice: formatTransactionAmount(tx.amount, tx.currency),
+      totalPrice: formatGooglePayAmount(tx.amount, tx.currency),
       currencyCode: tx.currency,
       countryCode: tx.country,
       displayItems: tx.lineItems?.map((item) => ({
         label: item.label,
         type: "LINE_ITEM",
-        price: formatTransactionAmount(item.amount, tx.currency),
+        price: formatGooglePayAmount(item.amount, tx.currency),
       })),
     },
     callbackIntents: ["PAYMENT_AUTHORIZATION"],

--- a/packages/ui-components/test/googlePayAmount.test.ts
+++ b/packages/ui-components/test/googlePayAmount.test.ts
@@ -33,7 +33,6 @@ describe("buildPaymentRequest", () => {
       { currency: "EUR", amount: 1999, expected: "19.99" },
       { currency: "JPY", amount: 1000, expected: "1000" },
       { currency: "KRW", amount: 5, expected: "5" },
-      { currency: "KWD", amount: 1000, expected: "1.000" },
       { currency: "USD", amount: 0, expected: "0.00" },
       { currency: "USD", amount: 5, expected: "0.05" },
     ];
@@ -57,4 +56,37 @@ describe("buildPaymentRequest", () => {
 
     expect(transactionInfo.totalPrice).toEqual("10.00");
   });
+
+  // Google Pay carries two fraction digits, so these currencies work down to
+  // hundredths of a major unit and no further.
+  it("carries a three-decimal currency to two fraction digits", () => {
+    const cases = [
+      { currency: "KWD", amount: 1000, expected: "1.00" },
+      { currency: "KWD", amount: 1250, expected: "1.25" },
+      { currency: "BHD", amount: 50, expected: "0.05" },
+      { currency: "OMR", amount: 12340, expected: "12.34" },
+      { currency: "TND", amount: 0, expected: "0.00" },
+    ];
+
+    for (const { currency, amount, expected } of cases) {
+      const { transactionInfo } = buildPaymentRequest(
+        buildConfig(currency, amount, amount),
+        merchant
+      );
+
+      expect(transactionInfo.totalPrice).toEqual(expected);
+      expect(transactionInfo.displayItems?.[0].price).toEqual(expected);
+    }
+  });
+
+  // A three-digit price builds fine, opens the sheet, then fails with
+  // OR_BIBED_06. Failing here instead keeps the shopper out of a broken sheet.
+  it.each(["KWD", "BHD", "OMR", "JOD", "TND"])(
+    "refuses an %s amount that needs the third fraction digit",
+    (currency) => {
+      expect(() =>
+        buildPaymentRequest(buildConfig(currency, 1005, 1005), merchant)
+      ).toThrow(/multiple of 10 minor units/);
+    }
+  );
 });

--- a/packages/ui-components/test/googlePayAmount.test.ts
+++ b/packages/ui-components/test/googlePayAmount.test.ts
@@ -48,6 +48,16 @@ describe("buildPaymentRequest", () => {
     }
   });
 
+  it("sends a formatted zero total without display items", () => {
+    const config = buildConfig("JPY", 0, 0);
+    config.transaction.lineItems = undefined;
+
+    const { transactionInfo } = buildPaymentRequest(config, merchant);
+
+    expect(transactionInfo.totalPrice).toEqual("0");
+    expect(transactionInfo.displayItems).toBeUndefined();
+  });
+
   it("falls back to two decimal places for an unknown currency", () => {
     const { transactionInfo } = buildPaymentRequest(
       buildConfig("XYZ", 1000, 1000),

--- a/packages/ui-components/test/googlePayAmount.test.ts
+++ b/packages/ui-components/test/googlePayAmount.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { MerchantDetail } from "types";
+import { buildPaymentRequest } from "../src/GooglePay/utilities";
+import { GooglePayConfig } from "../src/GooglePay/types";
+
+const merchant = { id: "merchant_123", name: "Acme" } as MerchantDetail;
+
+function buildConfig(
+  currency: string,
+  amount: number,
+  lineItemAmount: number
+): GooglePayConfig {
+  return {
+    transaction: {
+      type: "payment",
+      amount,
+      currency,
+      country: "US",
+      merchantId: merchant.id,
+      domain: "acme.com",
+      lineItems: [{ label: "Widget", amount: lineItemAmount }],
+    },
+    type: "buy",
+    color: "black",
+    borderRadius: 0,
+  } as GooglePayConfig;
+}
+
+describe("buildPaymentRequest", () => {
+  it("converts minor units using the currency's exponent", () => {
+    const cases = [
+      { currency: "USD", amount: 1000, expected: "10.00" },
+      { currency: "EUR", amount: 1999, expected: "19.99" },
+      { currency: "JPY", amount: 1000, expected: "1000" },
+      { currency: "KRW", amount: 5, expected: "5" },
+      { currency: "KWD", amount: 1000, expected: "1.000" },
+      { currency: "USD", amount: 0, expected: "0.00" },
+      { currency: "USD", amount: 5, expected: "0.05" },
+    ];
+
+    for (const { currency, amount, expected } of cases) {
+      const { transactionInfo } = buildPaymentRequest(
+        buildConfig(currency, amount, amount),
+        merchant
+      );
+
+      expect(transactionInfo.totalPrice).toEqual(expected);
+      expect(transactionInfo.displayItems?.[0].price).toEqual(expected);
+    }
+  });
+
+  it("falls back to two decimal places for an unknown currency", () => {
+    const { transactionInfo } = buildPaymentRequest(
+      buildConfig("XYZ", 1000, 1000),
+      merchant
+    );
+
+    expect(transactionInfo.totalPrice).toEqual("10.00");
+  });
+});


### PR DESCRIPTION
`buildPaymentRequest` always divided minor-unit amounts by `100`, so Google Pay showed zero-decimal currencies at one hundredth of their value and three-decimal currencies at ten times their value.

It now formats totals and line items with each currency's exponent and **rejects Google Pay amounts that require a third fractional digit**, because **Google Pay accepts at most two**. This corrects the documented minor-unit contract, but merchants that compensated for the old formatting must remove that workaround, so this change is held for the next major release.
