### PR TITLE
Convert Apple Pay amounts using the currency's exponent

### DIFF
--- a/.changeset/apple-pay-currency-exponent.md
+++ b/.changeset/apple-pay-currency-exponent.md
@@ -1,0 +1,9 @@
+---
+"@evervault/browser": patch
+---
+
+Fix Apple Pay amounts for currencies that do not have two minor units. Amounts
+were always divided by 100 and rendered with two decimal places, so a
+zero-decimal currency (JPY, KRW, VND) was authorised at 1/100th of the intended
+value and a three-decimal currency (KWD, BHD, OMR) at 10x. Totals, line items
+and shipping method amounts are now converted using the currency's own exponent.

--- a/packages/browser/lib/ui/ApplePay/utilities.ts
+++ b/packages/browser/lib/ui/ApplePay/utilities.ts
@@ -1,4 +1,5 @@
 import { getAppSDKConfig } from "shared/getAppSDKConfig";
+import { formatTransactionAmount } from "shared/currency";
 import {
   ApplePayMerchantCapability,
   ApplePayTransactionType,
@@ -156,7 +157,7 @@ function mapShippingMethodsToPaymentOptions(
       label: method.label,
       amount: {
         currency,
-        value: (method.amount / 100).toFixed(2),
+        value: formatTransactionAmount(method.amount, currency),
       },
       selected: index === selectedIndex,
     };
@@ -296,7 +297,7 @@ function mapLineItemsToDisplayItems(
   return (lineItems ?? []).map((item) => ({
     label: item.label,
     amount: {
-      value: (item.amount / 100).toFixed(2).toString(),
+      value: formatTransactionAmount(item.amount, currency),
       currency,
     },
     ...(item.type === "pending" ? { pending: true } : {}),
@@ -565,7 +566,10 @@ async function createPaymentUpdate(
     label: tx.priceLabel ?? merchant.name,
     amount: {
       currency: tx.currency,
-      value: (updatedTransactionConfig.amount / 100).toFixed(2),
+      value: formatTransactionAmount(
+        updatedTransactionConfig.amount,
+        tx.currency
+      ),
     },
   };
   return {
@@ -697,7 +701,10 @@ function buildPaymentSession(
   const paymentDetails: ApplePayPaymentDetailsInit = {
     total: {
       label: tx.priceLabel ?? merchant.name,
-      amount: { currency: tx.currency, value: (tx.amount / 100).toFixed(2) },
+      amount: {
+        currency: tx.currency,
+        value: formatTransactionAmount(tx.amount, tx.currency),
+      },
     },
     displayItems: lineItems,
     ...(shippingOptions ? { shippingOptions } : {}),
@@ -764,7 +771,10 @@ function buildRecurringSession(
   const paymentDetails: PaymentDetailsInit = {
     total: {
       label: tx.priceLabel ?? merchant.name,
-      amount: { currency: tx.currency, value: (tx.amount / 100).toFixed(2) },
+      amount: {
+        currency: tx.currency,
+        value: formatTransactionAmount(tx.amount, tx.currency),
+      },
     },
     displayItems: lineItems,
     modifiers: [
@@ -831,7 +841,7 @@ function buildDisbursementSession(
     tx.lineItems?.map((item) => ({
       label: item.label,
       amount: {
-        value: (item.amount / 100).toFixed(2).toString(),
+        value: formatTransactionAmount(item.amount, tx.currency),
         currency: tx.currency,
       },
       ...(item.type ? { type: item.type } : {}),

--- a/packages/browser/test/applePay.test.ts
+++ b/packages/browser/test/applePay.test.ts
@@ -1175,6 +1175,34 @@ describe("buildSession request-config passthrough", () => {
     ).rejects.toThrow("applicationData must be a Base64-encoded string");
   });
 
+  it.each([
+    { currency: "USD", amount: 1000, expected: "10.00" },
+    { currency: "JPY", amount: 1000, expected: "1000" },
+    { currency: "KWD", amount: 1000, expected: "1.000" },
+    { currency: "XYZ", amount: 1000, expected: "10.00" },
+  ])(
+    "converts $currency amounts using the currency's exponent",
+    async ({ currency, amount, expected }) => {
+      await buildSession(applePay, {
+        transaction: {
+          ...transaction,
+          currency,
+          amount,
+          lineItems: [{ label: "Item", amount }],
+        },
+      });
+
+      expect(paymentRequestCalls[0].total.amount).toEqual({
+        value: expected,
+        currency,
+      });
+      expect(paymentRequestCalls[0].displayItems?.[0].amount).toEqual({
+        value: expected,
+        currency,
+      });
+    }
+  );
+
   it("marks pending line items on displayItems", async () => {
     await buildSession(applePay, {
       transaction: {


### PR DESCRIPTION
Apple Pay request builders always divided minor-unit amounts by `100`, so zero-decimal currencies rendered at one hundredth of their value and three-decimal currencies at ten times their value. They now use `formatTransactionAmount` for payment and recurring totals, line items, shipping options, payment-method updates, and disbursement line items, using the currency exponent supplied by `Intl.NumberFormat`. This corrects the documented minor-unit contract, but merchants that compensated for the old formatting must remove that workaround, so this change is held for the next major `@evervault/browser` release.

Note: This PR is stacked on #977.
