### PR TITLE
Default the Google Pay button radius to Google's own 12

### DIFF
--- a/packages/ui-components/src/GooglePay/index.tsx
+++ b/packages/ui-components/src/GooglePay/index.tsx
@@ -14,6 +14,10 @@ import { getMerchant } from "../utilities/useMerchant";
 import { getAppSDKConfig } from "shared";
 import { apiConfig } from "../utilities/config";
 
+// Google's own default when buttonRadius is unset. The Android SDK uses the same
+// value, so a merchant who sets nothing gets the same button on both platforms.
+const DEFAULT_BUTTON_RADIUS = 12;
+
 const FUNDING_SOURCE_MAP: Partial<
   Record<google.payments.api.CardFundingSource, PaymentMethodType>
 > = {
@@ -144,7 +148,7 @@ export function GooglePay({ config }: GooglePayProps) {
           buttonLocale: config.locale || "en",
           buttonType: config.type || "plain",
           buttonColor: config.color || "black",
-          buttonRadius: config.borderRadius || 4,
+          buttonRadius: config.borderRadius ?? DEFAULT_BUTTON_RADIUS,
           buttonSizeMode: "fill",
           onClick: async () => {
             try {

--- a/packages/ui-components/src/GooglePay/types.ts
+++ b/packages/ui-components/src/GooglePay/types.ts
@@ -10,7 +10,7 @@ export interface GooglePayConfig {
   type: GooglePayButtonType;
   color: GooglePayButtonColor;
   locale?: string;
-  borderRadius: number;
+  borderRadius?: number;
   allowedAuthMethods?: string[];
   allowedCardNetworks?: string[];
   billingAddress?: GooglePayBillingAddressConfig;

--- a/packages/ui-components/test/GooglePay.test.tsx
+++ b/packages/ui-components/test/GooglePay.test.tsx
@@ -22,9 +22,14 @@ vi.mock("../src/utilities/useSearchParams", () => ({
   useSearchParams: () => ({ app: "app_test123", id: "frame1" }),
 }));
 
+const createButtonMock = vi.fn();
+
 class MockPaymentsClient {
   isReadyToPay = vi.fn().mockResolvedValue({ result: true });
-  createButton = vi.fn().mockReturnValue(document.createElement("div"));
+  createButton = (...args: unknown[]) => {
+    createButtonMock(...args);
+    return document.createElement("div");
+  };
   loadPaymentData = vi.fn();
 }
 
@@ -39,7 +44,6 @@ const config: GooglePayConfig = {
   },
   type: "plain",
   color: "black",
-  borderRadius: 4,
 };
 
 function getInjectedScript() {
@@ -93,5 +97,43 @@ describe("GooglePay onLoad GET concurrency", () => {
         expect.any(String)
       );
     });
+  });
+});
+
+describe("GooglePay button radius", () => {
+  beforeEach(() => {
+    createButtonMock.mockReset();
+    getMerchantMock.mockReset();
+    getAppSDKConfigMock.mockReset();
+    getMerchantMock.mockResolvedValue({ id: "merchant_abc", name: "Acme Co" });
+    getAppSDKConfigMock.mockResolvedValue({ is_sandbox: false });
+    (globalThis as unknown as { google: unknown }).google = {
+      payments: { api: { PaymentsClient: MockPaymentsClient } },
+    };
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    delete (globalThis as { google?: unknown }).google;
+  });
+
+  async function renderAndGetRadius(borderRadius?: number) {
+    render(<GooglePay config={{ ...config, borderRadius }} />);
+    getInjectedScript()!.dispatchEvent(new Event("load"));
+    await waitFor(() => expect(createButtonMock).toHaveBeenCalled());
+    return (createButtonMock.mock.calls[0][0] as { buttonRadius: number })
+      .buttonRadius;
+  }
+
+  it("defaults to 12, matching the Android SDK", async () => {
+    expect(await renderAndGetRadius(undefined)).toBe(12);
+  });
+
+  it("uses the configured radius", async () => {
+    expect(await renderAndGetRadius(20)).toBe(20);
+  });
+
+  it("honours a radius of 0 rather than falling back to the default", async () => {
+    expect(await renderAndGetRadius(0)).toBe(0);
   });
 });


### PR DESCRIPTION
If a merchant didn't set `borderRadius`, the Google Pay button fell back to `4`px on web and `100` on Android, so the same checkout got a nearly square button in one place and a pill in the other. Both now default to `12`, which is what pay.js renders when `buttonRadius` is unset. The fallback also moves from `||` to `??`, so `borderRadius: 0` now gives you square corners instead of being treated as unset.