### PR TITLE
Add Google Pay golden request tests

### DIFF
--- a/packages/ui-components/.prettierignore
+++ b/packages/ui-components/.prettierignore
@@ -4,3 +4,6 @@ package.json
 tsconfig.json
 vite.config.mts.timestamp-*
 playwright-report
+
+# Shared with the Android SDK; keep the two copies byte-identical.
+test/fixtures/google-pay

--- a/packages/ui-components/test/fixtures/google-pay/billing-disabled.json
+++ b/packages/ui-components/test/fixtures/google-pay/billing-disabled.json
@@ -1,0 +1,39 @@
+{
+  "apiVersion": 2,
+  "apiVersionMinor": 0,
+  "emailRequired": false,
+  "allowedPaymentMethods": [
+    {
+      "type": "CARD",
+      "parameters": {
+        "allowedAuthMethods": ["PAN_ONLY", "CRYPTOGRAM_3DS"],
+        "allowedCardNetworks": ["AMEX", "DISCOVER", "INTERAC", "JCB", "MASTERCARD", "VISA"],
+        "billingAddressRequired": false
+      },
+      "tokenizationSpecification": {
+        "type": "PAYMENT_GATEWAY",
+        "parameters": {
+          "gateway": "evervault",
+          "gatewayMerchantId": "merchant_123"
+        }
+      }
+    }
+  ],
+  "merchantInfo": {
+    "merchantName": "Test Merchant"
+  },
+  "transactionInfo": {
+    "totalPriceStatus": "FINAL",
+    "totalPriceLabel": "Pay Test Merchant",
+    "totalPrice": "54.99",
+    "currencyCode": "EUR",
+    "countryCode": "IE",
+    "displayItems": [
+      {
+        "label": "Shell Jacket",
+        "type": "LINE_ITEM",
+        "price": "50.00"
+      }
+    ]
+  }
+}

--- a/packages/ui-components/test/fixtures/google-pay/billing-enabled.json
+++ b/packages/ui-components/test/fixtures/google-pay/billing-enabled.json
@@ -1,0 +1,43 @@
+{
+  "apiVersion": 2,
+  "apiVersionMinor": 0,
+  "emailRequired": false,
+  "allowedPaymentMethods": [
+    {
+      "type": "CARD",
+      "parameters": {
+        "allowedAuthMethods": ["PAN_ONLY", "CRYPTOGRAM_3DS"],
+        "allowedCardNetworks": ["AMEX", "DISCOVER", "INTERAC", "JCB", "MASTERCARD", "VISA"],
+        "billingAddressRequired": true,
+        "billingAddressParameters": {
+          "format": "FULL",
+          "phoneNumberRequired": false
+        }
+      },
+      "tokenizationSpecification": {
+        "type": "PAYMENT_GATEWAY",
+        "parameters": {
+          "gateway": "evervault",
+          "gatewayMerchantId": "merchant_123"
+        }
+      }
+    }
+  ],
+  "merchantInfo": {
+    "merchantName": "Test Merchant"
+  },
+  "transactionInfo": {
+    "totalPriceStatus": "FINAL",
+    "totalPriceLabel": "Pay Test Merchant",
+    "totalPrice": "54.99",
+    "currencyCode": "EUR",
+    "countryCode": "IE",
+    "displayItems": [
+      {
+        "label": "Shell Jacket",
+        "type": "LINE_ITEM",
+        "price": "50.00"
+      }
+    ]
+  }
+}

--- a/packages/ui-components/test/fixtures/google-pay/custom.json
+++ b/packages/ui-components/test/fixtures/google-pay/custom.json
@@ -1,0 +1,43 @@
+{
+  "apiVersion": 2,
+  "apiVersionMinor": 0,
+  "emailRequired": true,
+  "allowedPaymentMethods": [
+    {
+      "type": "CARD",
+      "parameters": {
+        "allowedAuthMethods": ["PAN_ONLY"],
+        "allowedCardNetworks": ["INTERAC"],
+        "billingAddressRequired": true,
+        "billingAddressParameters": {
+          "format": "MIN",
+          "phoneNumberRequired": true
+        }
+      },
+      "tokenizationSpecification": {
+        "type": "PAYMENT_GATEWAY",
+        "parameters": {
+          "gateway": "evervault",
+          "gatewayMerchantId": "merchant_123"
+        }
+      }
+    }
+  ],
+  "merchantInfo": {
+    "merchantName": "Test Merchant"
+  },
+  "transactionInfo": {
+    "totalPriceStatus": "FINAL",
+    "totalPriceLabel": "Subscription",
+    "totalPrice": "54.99",
+    "currencyCode": "EUR",
+    "countryCode": "IE",
+    "displayItems": [
+      {
+        "label": "Shell Jacket",
+        "type": "LINE_ITEM",
+        "price": "50.00"
+      }
+    ]
+  }
+}

--- a/packages/ui-components/test/googlePayGoldenRequest.test.ts
+++ b/packages/ui-components/test/googlePayGoldenRequest.test.ts
@@ -1,0 +1,129 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { MerchantDetail } from "types";
+import { buildPaymentRequest } from "../src/GooglePay/utilities";
+import { GooglePayConfig } from "../src/GooglePay/types";
+import { apiConfig } from "../src/utilities/config";
+
+/**
+ * Fixture tests for the whole Google Pay payment request.
+ *
+ * The fixtures are shared with the Android SDK's
+ * `android/googlepay/src/test/resources/google-pay` in evervault/evervault-pay.
+ * Keep the two copies identical so a default that drifts on one platform fails
+ * here.
+ */
+
+type PaymentRequest = ReturnType<typeof buildPaymentRequest>;
+
+/**
+ * The request fields web and Android share.
+ *
+ * `merchantId`, `merchantOrigin`, and `callbackIntents` are required by the
+ * Google Pay web client and have no Android equivalent, so they are covered by
+ * their own test rather than by the shared fixtures.
+ */
+type GoldenRequest = Pick<
+  PaymentRequest,
+  | "apiVersion"
+  | "apiVersionMinor"
+  | "emailRequired"
+  | "allowedPaymentMethods"
+  | "transactionInfo"
+> & {
+  merchantInfo: Pick<PaymentRequest["merchantInfo"], "merchantName">;
+};
+
+const merchant: MerchantDetail = {
+  id: "merchant_123",
+  name: "Test Merchant",
+};
+
+const transaction = {
+  type: "payment" as const,
+  amount: 5499,
+  currency: "EUR",
+  country: "IE",
+  merchantId: merchant.id,
+  domain: "shop.example.com",
+  lineItems: [{ label: "Shell Jacket", amount: 5000 }],
+};
+
+const baseConfig: GooglePayConfig = {
+  transaction,
+  type: "buy",
+  color: "black",
+  borderRadius: 12,
+};
+
+function loadFixture(name: string): unknown {
+  return JSON.parse(
+    readFileSync(
+      new URL(`./fixtures/google-pay/${name}.json`, import.meta.url),
+      "utf8"
+    )
+  );
+}
+
+function comparableRequest(config: GooglePayConfig): GoldenRequest {
+  const {
+    apiVersion,
+    apiVersionMinor,
+    emailRequired,
+    allowedPaymentMethods,
+    merchantInfo,
+    transactionInfo,
+  } = buildPaymentRequest(config, merchant);
+
+  return {
+    apiVersion,
+    apiVersionMinor,
+    emailRequired,
+    allowedPaymentMethods,
+    merchantInfo: { merchantName: merchantInfo.merchantName },
+    transactionInfo,
+  };
+}
+
+describe("Google Pay golden requests", () => {
+  it("matches the disabled-billing fixture by default", () => {
+    expect(comparableRequest(baseConfig)).toEqual(
+      loadFixture("billing-disabled")
+    );
+  });
+
+  it("matches the disabled-billing fixture when billing is explicitly disabled", () => {
+    expect(comparableRequest({ ...baseConfig, billingAddress: false })).toEqual(
+      loadFixture("billing-disabled")
+    );
+  });
+
+  it("matches the enabled-billing fixture when billing is enabled", () => {
+    expect(comparableRequest({ ...baseConfig, billingAddress: true })).toEqual(
+      loadFixture("billing-enabled")
+    );
+  });
+
+  it("matches the custom fixture when every option is set", () => {
+    expect(
+      comparableRequest({
+        ...baseConfig,
+        transaction: { ...transaction, priceLabel: "Subscription" },
+        emailRequired: true,
+        allowedAuthMethods: ["PAN_ONLY"],
+        allowedCardNetworks: ["INTERAC"],
+        billingAddress: { format: "MIN", phoneNumber: true },
+      })
+    ).toEqual(loadFixture("custom"));
+  });
+
+  it("includes the web-only request fields", () => {
+    const request = buildPaymentRequest(baseConfig, merchant);
+
+    expect(request.merchantInfo).toMatchObject({
+      merchantId: apiConfig.googlePayMerchantId,
+      merchantOrigin: transaction.domain,
+    });
+    expect(request.callbackIntents).toEqual(["PAYMENT_AUTHORIZATION"]);
+  });
+});


### PR DESCRIPTION
The web Google Pay request had no whole-request test, so defaults and configured fields could change without a focused failure. `googlePayGoldenRequest.test.ts` now compares billing-disabled, billing-enabled, and custom requests with JSON fixtures.

The fixture type derives from `buildPaymentRequest`, so the projection stays tied to the production return type. A separate test covers web-only `merchantId`, `merchantOrigin`, and `callbackIntents` fields.

The fixtures match the Android SDK copies byte-for-byte, but no CI check enforces that yet.

Stacked on #987.
