### PR TITLE
Omit Google Pay billingAddressParameters when billing is not required

### DIFF
--- a/.changeset/google-pay-button-radius-default.md
+++ b/.changeset/google-pay-button-radius-default.md
@@ -1,0 +1,5 @@
+---
+"@evervault/ui-components": minor
+---
+
+Default the Google Pay button corner radius to 12 to match pay.js and the Android SDK, which previously rendered 4 on web and 100 on Android. The fallback now uses `??`, so `borderRadius: 0` gives square corners instead of being treated as unset.

--- a/.changeset/omit-google-pay-billing-address-parameters.md
+++ b/.changeset/omit-google-pay-billing-address-parameters.md
@@ -1,0 +1,5 @@
+---
+"@evervault/ui-components": patch
+---
+
+Omit `billingAddressParameters` from the Google Pay request when `billingAddressRequired` is false. Google ignores the field in that case, so no merchant behaviour changes, and the request now matches what the Android SDK emits.

--- a/packages/ui-components/src/GooglePay/utilities.ts
+++ b/packages/ui-components/src/GooglePay/utilities.ts
@@ -30,10 +30,17 @@ export function buildPaymentRequest(
               "VISA",
             ],
           billingAddressRequired: isBillingRequired(config),
-          billingAddressParameters: {
-            format: billingAddressFormat(config),
-            phoneNumberRequired: phoneNumberRequired(config),
-          },
+          // Google ignores these when billingAddressRequired is false. Omit
+          // them so the request says only what it means, and so it matches the
+          // Android SDK.
+          ...(isBillingRequired(config)
+            ? {
+                billingAddressParameters: {
+                  format: billingAddressFormat(config),
+                  phoneNumberRequired: phoneNumberRequired(config),
+                },
+              }
+            : {}),
         },
         tokenizationSpecification: {
           type: "PAYMENT_GATEWAY",


### PR DESCRIPTION
`buildPaymentRequest` sent `billingAddressParameters` even when `billingAddressRequired` was `false`. Google ignores those parameters, but the request still claimed a `FULL` billing address format that the merchant did not request.

The request now omits `billingAddressParameters` unless billing collection is enabled. This does not change the Google Pay sheet, and it matches the Android request for the disabled case.

Stack: #985 adds golden request tests on top of this PR.
