### PR TITLE
ci: accept main as well as master in workflow triggers

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -5,6 +5,7 @@ on:
     branches-ignore:
       - master
       - main
+      - main
 
 jobs:
   auto-format:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - "master"
       - "main"
+      - "main"
   merge_group:
 jobs:
   lint-and-test:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - "master"
       - "main"
+      - "main"
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   lint-and-test:


### PR DESCRIPTION
Preflight for the org-wide default branch rename to `main`.

Workflow triggers now match both `master` and `main`, so nothing stops
firing during the rename. The `master` entries are removed in the follow-up
cleanup PR after the default branch has been flipped.