### PR TITLE
chore: set Dependabot update intervals to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,16 +3,16 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "swift"
     directory: "packages/react-native-v2"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gradle"
     directory: "packages/react-native-v2/android"
     schedule:
-      interval: "weekly"
+      interval: "monthly"


### PR DESCRIPTION
# Why
Reduce Dependabot PR noise by moving all update schedules from weekly to monthly.

# How
Changed `interval:` from `"weekly"` to `"monthly"` for all four entries in `.github/dependabot.yml` (github-actions `/`, npm `/`, swift `packages/react-native-v2`, gradle `packages/react-native-v2/android`). No other config values were touched.

## Ecosystem check
- **swift** (`packages/react-native-v2`): confirmed `Package.swift` exists at that directory.
- **gradle** (`packages/react-native-v2/android`): confirmed `build.gradle` exists at that directory.
- **npm** (`/`): this is a **pnpm** monorepo. The root `package.json` has no `workspaces` field (that's an npm/yarn convention) — workspace membership is instead declared in `pnpm-workspace.yaml`, which globs `packages/*`, `actions/*`, `examples/*`, and `e2e-tests/**`. Dependabot's `npm` ecosystem does support pnpm workspaces and reads `pnpm-workspace.yaml` from the root manifest directory, so `directory: "/"` should still pick up all workspace packages under `packages/*` (and the other listed globs) via `pnpm-lock.yaml`. Not changed in this PR — flagging for awareness since the workspace declaration lives in a pnpm-specific file rather than `package.json`.
- **github-actions** (`/`): workflows live under `.github/workflows/`, the standard location Dependabot scans for this ecosystem — representative.
- **Other manifests found but not currently configured**: `examples/react-native-example/ios/Podfile` (CocoaPods) and `packages/react-native-v2/native-evervault.podspec` — no `cocoapods` ecosystem entry exists for these. No `Cargo.toml`, `go.mod`, `pyproject.toml`, or `Dockerfile` were found anywhere in the repo. Not changed in this PR — flagging only.
