### PR TITLE
feat(browser): expose Apple Pay payer details on process() payload

### DIFF
--- a/.changeset/apple-pay-payer-details.md
+++ b/.changeset/apple-pay-payer-details.md
@@ -1,0 +1,6 @@
+---
+"@evervault/browser": minor
+"types": minor
+---
+
+Expose `payerName`, `payerEmail` and `payerPhone` on the Apple Pay `process()` payload when `requestPayerDetails` is set. Safari returns these on the top-level `PaymentResponse`; they were previously only reachable through `shippingContact`, which Apple Pay uses to carry the requested payer fields.

--- a/.changeset/apple-pay-payer-details.md
+++ b/.changeset/apple-pay-payer-details.md
@@ -3,4 +3,4 @@
 "types": minor
 ---
 
-Expose `payerName`, `payerEmail` and `payerPhone` on the Apple Pay `process()` payload when `requestPayerDetails` is set. Safari returns these on the top-level `PaymentResponse`; they were previously only reachable through `shippingContact`, which Apple Pay uses to carry the requested payer fields.
+Add `payerName`, `payerEmail` and `payerPhone` to the Apple Pay `process()` payload when `requestPayerDetails` is set.

--- a/packages/browser/lib/ui/ApplePay/index.ts
+++ b/packages/browser/lib/ui/ApplePay/index.ts
@@ -280,10 +280,6 @@ export default class ApplePayButton {
         encrypted.shippingContact = response.details.shippingContact;
       }
 
-      // Safari fulfils requestPayerName/Email/Phone via the Apple Pay shipping
-      // contact and mirrors them onto the flat PaymentResponse payer fields.
-      // Forward those so callers using `requestPayerDetails` get the values
-      // under matching names, in addition to `shippingContact`.
       const { payerName, payerEmail, payerPhone } =
         response as PaymentResponse & {
           payerName?: string | null;

--- a/packages/browser/lib/ui/ApplePay/index.ts
+++ b/packages/browser/lib/ui/ApplePay/index.ts
@@ -280,6 +280,29 @@ export default class ApplePayButton {
         encrypted.shippingContact = response.details.shippingContact;
       }
 
+      // Safari fulfils requestPayerName/Email/Phone via the Apple Pay shipping
+      // contact and mirrors them onto the flat PaymentResponse payer fields.
+      // Forward those so callers using `requestPayerDetails` get the values
+      // under matching names, in addition to `shippingContact`.
+      const { payerName, payerEmail, payerPhone } =
+        response as PaymentResponse & {
+          payerName?: string | null;
+          payerEmail?: string | null;
+          payerPhone?: string | null;
+        };
+
+      if (payerName) {
+        encrypted.payerName = payerName;
+      }
+
+      if (payerEmail) {
+        encrypted.payerEmail = payerEmail;
+      }
+
+      if (payerPhone) {
+        encrypted.payerPhone = payerPhone;
+      }
+
       const shippingOptionId = (
         response as PaymentResponse & { shippingOption?: string | null }
       ).shippingOption;

--- a/packages/browser/test/applePay.test.ts
+++ b/packages/browser/test/applePay.test.ts
@@ -1581,6 +1581,105 @@ describe("ApplePayButton.abort", () => {
   });
 });
 
+describe("ApplePayButton payer details on process()", () => {
+  const payerName = "John Appleseed";
+  const payerEmail = "john@example.com";
+  const payerPhone = "+14085551234";
+
+  function createResolvedSession(payer: {
+    payerName?: string | null;
+    payerEmail?: string | null;
+    payerPhone?: string | null;
+  }) {
+    return {
+      show: vi.fn().mockResolvedValue({
+        details: {
+          token: {
+            paymentData: {},
+            paymentMethod: { displayName: "Visa 1234", type: "credit" },
+          },
+        },
+        ...payer,
+        complete: vi.fn().mockResolvedValue(undefined),
+      }),
+      abort: vi.fn(),
+    };
+  }
+
+  beforeEach(() => {
+    buildSessionMock.mockReset();
+    vi.spyOn(applePayUtilities, "buildSession").mockImplementation(
+      buildSessionMock
+    );
+
+    vi.stubGlobal("PaymentRequest", class PaymentRequest {});
+
+    vi.stubGlobal("ApplePaySession", {
+      applePayCapabilities: vi.fn().mockResolvedValue({
+        paymentCredentialStatus: "paymentCredentialsAvailable",
+      }),
+    });
+
+    const script = document.createElement("script");
+    script.src =
+      "https://applepay.cdn-apple.com/jsapi/1.latest/apple-pay-sdk.js";
+    document.body.appendChild(script);
+
+    server.use(
+      http.post(`${apiUrl}/frontend/apple-pay/credentials`, () =>
+        HttpResponse.json({ card: {} })
+      )
+    );
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("forwards payerName, payerEmail and payerPhone to the process() payload", async () => {
+    buildSessionMock.mockResolvedValue(
+      createResolvedSession({ payerName, payerEmail, payerPhone })
+    );
+    const process = vi.fn().mockResolvedValue(undefined);
+    const apple = new ApplePayButton(createMockClient(), createTransaction(), {
+      process,
+      requestPayerDetails: ["name", "email", "phone"],
+    });
+
+    await clickApplePayButton(apple);
+    await vi.waitFor(() => expect(process).toHaveBeenCalled());
+
+    const payload = process.mock.calls[0][0];
+    expect(payload.payerName).toBe(payerName);
+    expect(payload.payerEmail).toBe(payerEmail);
+    expect(payload.payerPhone).toBe(payerPhone);
+  });
+
+  it("omits payer fields when Safari returns them as null", async () => {
+    buildSessionMock.mockResolvedValue(
+      createResolvedSession({
+        payerName: null,
+        payerEmail: null,
+        payerPhone: null,
+      })
+    );
+    const process = vi.fn().mockResolvedValue(undefined);
+    const apple = new ApplePayButton(createMockClient(), createTransaction(), {
+      process,
+    });
+
+    await clickApplePayButton(apple);
+    await vi.waitFor(() => expect(process).toHaveBeenCalled());
+
+    const payload = process.mock.calls[0][0];
+    expect(payload).not.toHaveProperty("payerName");
+    expect(payload).not.toHaveProperty("payerEmail");
+    expect(payload).not.toHaveProperty("payerPhone");
+  });
+});
+
 describe("ApplePayButton shipping method on process()", () => {
   function createResolvedSession(shippingOption?: string | null) {
     return {

--- a/packages/browser/test/applePay.test.ts
+++ b/packages/browser/test/applePay.test.ts
@@ -1581,16 +1581,8 @@ describe("ApplePayButton.abort", () => {
   });
 });
 
-describe("ApplePayButton payer details on process()", () => {
-  const payerName = "John Appleseed";
-  const payerEmail = "john@example.com";
-  const payerPhone = "+14085551234";
-
-  function createResolvedSession(payer: {
-    payerName?: string | null;
-    payerEmail?: string | null;
-    payerPhone?: string | null;
-  }) {
+describe("ApplePayButton process() payload", () => {
+  function createResolvedSession(response: Record<string, unknown> = {}) {
     return {
       show: vi.fn().mockResolvedValue({
         details: {
@@ -1599,98 +1591,7 @@ describe("ApplePayButton payer details on process()", () => {
             paymentMethod: { displayName: "Visa 1234", type: "credit" },
           },
         },
-        ...payer,
-        complete: vi.fn().mockResolvedValue(undefined),
-      }),
-      abort: vi.fn(),
-    };
-  }
-
-  beforeEach(() => {
-    buildSessionMock.mockReset();
-    vi.spyOn(applePayUtilities, "buildSession").mockImplementation(
-      buildSessionMock
-    );
-
-    vi.stubGlobal("PaymentRequest", class PaymentRequest {});
-
-    vi.stubGlobal("ApplePaySession", {
-      applePayCapabilities: vi.fn().mockResolvedValue({
-        paymentCredentialStatus: "paymentCredentialsAvailable",
-      }),
-    });
-
-    const script = document.createElement("script");
-    script.src =
-      "https://applepay.cdn-apple.com/jsapi/1.latest/apple-pay-sdk.js";
-    document.body.appendChild(script);
-
-    server.use(
-      http.post(`${apiUrl}/frontend/apple-pay/credentials`, () =>
-        HttpResponse.json({ card: {} })
-      )
-    );
-  });
-
-  afterEach(() => {
-    document.body.innerHTML = "";
-    vi.restoreAllMocks();
-    vi.unstubAllGlobals();
-  });
-
-  it("forwards payerName, payerEmail and payerPhone to the process() payload", async () => {
-    buildSessionMock.mockResolvedValue(
-      createResolvedSession({ payerName, payerEmail, payerPhone })
-    );
-    const process = vi.fn().mockResolvedValue(undefined);
-    const apple = new ApplePayButton(createMockClient(), createTransaction(), {
-      process,
-      requestPayerDetails: ["name", "email", "phone"],
-    });
-
-    await clickApplePayButton(apple);
-    await vi.waitFor(() => expect(process).toHaveBeenCalled());
-
-    const payload = process.mock.calls[0][0];
-    expect(payload.payerName).toBe(payerName);
-    expect(payload.payerEmail).toBe(payerEmail);
-    expect(payload.payerPhone).toBe(payerPhone);
-  });
-
-  it("omits payer fields when Safari returns them as null", async () => {
-    buildSessionMock.mockResolvedValue(
-      createResolvedSession({
-        payerName: null,
-        payerEmail: null,
-        payerPhone: null,
-      })
-    );
-    const process = vi.fn().mockResolvedValue(undefined);
-    const apple = new ApplePayButton(createMockClient(), createTransaction(), {
-      process,
-    });
-
-    await clickApplePayButton(apple);
-    await vi.waitFor(() => expect(process).toHaveBeenCalled());
-
-    const payload = process.mock.calls[0][0];
-    expect(payload).not.toHaveProperty("payerName");
-    expect(payload).not.toHaveProperty("payerEmail");
-    expect(payload).not.toHaveProperty("payerPhone");
-  });
-});
-
-describe("ApplePayButton shipping method on process()", () => {
-  function createResolvedSession(shippingOption?: string | null) {
-    return {
-      show: vi.fn().mockResolvedValue({
-        details: {
-          token: {
-            paymentData: {},
-            paymentMethod: { displayName: "Visa 1234", type: "credit" },
-          },
-        },
-        shippingOption,
+        ...response,
         complete: vi.fn().mockResolvedValue(undefined),
       }),
       abort: vi.fn(),
@@ -1730,7 +1631,9 @@ describe("ApplePayButton shipping method on process()", () => {
   });
 
   it("attaches the matching shippingMethod to the process() payload", async () => {
-    buildSessionMock.mockResolvedValue(createResolvedSession("express"));
+    buildSessionMock.mockResolvedValue(
+      createResolvedSession({ shippingOption: "express" })
+    );
     const process = vi.fn().mockResolvedValue(undefined);
     const apple = new ApplePayButton(createMockClient(), createTransaction(), {
       process,
@@ -1758,7 +1661,9 @@ describe("ApplePayButton shipping method on process()", () => {
 
   it("falls back to a placeholder and warns when shippingOption matches nothing", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    buildSessionMock.mockResolvedValue(createResolvedSession("unknown-id"));
+    buildSessionMock.mockResolvedValue(
+      createResolvedSession({ shippingOption: "unknown-id" })
+    );
     const process = vi.fn().mockResolvedValue(undefined);
     const apple = new ApplePayButton(createMockClient(), createTransaction(), {
       process,
@@ -1782,7 +1687,7 @@ describe("ApplePayButton shipping method on process()", () => {
   });
 
   it("omits shippingMethod entirely when no shippingOption is returned", async () => {
-    buildSessionMock.mockResolvedValue(createResolvedSession(undefined));
+    buildSessionMock.mockResolvedValue(createResolvedSession());
     const process = vi.fn().mockResolvedValue(undefined);
     const apple = new ApplePayButton(createMockClient(), createTransaction(), {
       process,
@@ -1792,6 +1697,50 @@ describe("ApplePayButton shipping method on process()", () => {
     await vi.waitFor(() => expect(process).toHaveBeenCalled());
 
     expect(process.mock.calls[0][0].shippingMethod).toBeUndefined();
+  });
+
+  it("forwards payerName, payerEmail and payerPhone to the process() payload", async () => {
+    const payerName = "John Appleseed";
+    const payerEmail = "john@example.com";
+    const payerPhone = "+14085551234";
+    buildSessionMock.mockResolvedValue(
+      createResolvedSession({ payerName, payerEmail, payerPhone })
+    );
+    const process = vi.fn().mockResolvedValue(undefined);
+    const apple = new ApplePayButton(createMockClient(), createTransaction(), {
+      process,
+      requestPayerDetails: ["name", "email", "phone"],
+    });
+
+    await clickApplePayButton(apple);
+    await vi.waitFor(() => expect(process).toHaveBeenCalled());
+
+    const payload = process.mock.calls[0][0];
+    expect(payload.payerName).toBe(payerName);
+    expect(payload.payerEmail).toBe(payerEmail);
+    expect(payload.payerPhone).toBe(payerPhone);
+  });
+
+  it("omits payer fields when the response returns them as null", async () => {
+    buildSessionMock.mockResolvedValue(
+      createResolvedSession({
+        payerName: null,
+        payerEmail: null,
+        payerPhone: null,
+      })
+    );
+    const process = vi.fn().mockResolvedValue(undefined);
+    const apple = new ApplePayButton(createMockClient(), createTransaction(), {
+      process,
+    });
+
+    await clickApplePayButton(apple);
+    await vi.waitFor(() => expect(process).toHaveBeenCalled());
+
+    const payload = process.mock.calls[0][0];
+    expect(payload).not.toHaveProperty("payerName");
+    expect(payload).not.toHaveProperty("payerEmail");
+    expect(payload).not.toHaveProperty("payerPhone");
   });
 });
 

--- a/packages/types/uiComponents.ts
+++ b/packages/types/uiComponents.ts
@@ -359,20 +359,11 @@ export type EncryptedApplePayData = Omit<
     phoneNumber?: string;
   };
   /**
-   * The payer's full name, present when `requestPayerDetails` includes
-   * `"name"`. Apple Pay collects this on the shipping contact, so the same
-   * value is also available as `shippingContact.givenName` / `familyName`.
+   * Set when `requestPayerDetails` is used. Apple Pay collects these on the
+   * shipping contact, so they also appear on `shippingContact`.
    */
   payerName?: string;
-  /**
-   * The payer's email address, present when `requestPayerDetails` includes
-   * `"email"`. Also available as `shippingContact.emailAddress`.
-   */
   payerEmail?: string;
-  /**
-   * The payer's phone number, present when `requestPayerDetails` includes
-   * `"phone"`. Also available as `shippingContact.phoneNumber`.
-   */
   payerPhone?: string;
   /**
    * The shipping method the customer selected on the Apple Pay sheet.

--- a/packages/types/uiComponents.ts
+++ b/packages/types/uiComponents.ts
@@ -359,6 +359,22 @@ export type EncryptedApplePayData = Omit<
     phoneNumber?: string;
   };
   /**
+   * The payer's full name, present when `requestPayerDetails` includes
+   * `"name"`. Apple Pay collects this on the shipping contact, so the same
+   * value is also available as `shippingContact.givenName` / `familyName`.
+   */
+  payerName?: string;
+  /**
+   * The payer's email address, present when `requestPayerDetails` includes
+   * `"email"`. Also available as `shippingContact.emailAddress`.
+   */
+  payerEmail?: string;
+  /**
+   * The payer's phone number, present when `requestPayerDetails` includes
+   * `"phone"`. Also available as `shippingContact.phoneNumber`.
+   */
+  payerPhone?: string;
+  /**
    * The shipping method the customer selected on the Apple Pay sheet.
    * Present when `shippingMethods` were configured on the web Apple Pay button.
    */


### PR DESCRIPTION
# Why
A customer sets `requestPayerDetails: ["name", "email"]` on the web Apple Pay button and expects the payer name and email in `process()`. The SDK requests them from Safari but never reads `PaymentResponse.payerName` / `payerEmail` / `payerPhone`.

Safari collects these fields on the Apple Pay shipping contact, which the SDK already forwards as `shippingContact`. This change adds the flat fields too, so callers find the values under names that match the option they set.

# How
- Forward `payerName`, `payerEmail` and `payerPhone` from the `PaymentResponse` to the `process()` payload.
- Add the three optional fields to `EncryptedApplePayData`.
- Add tests for the forwarded fields and for the null case.
- Minor changeset for `@evervault/browser` and `types`.