### PR TITLE
Prevent production releases blocking master pushes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,6 +68,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           overwrite: false
+          retention-days: 30
           name: ${{ needs.get-artifact-name.outputs.artifact-name }}
           path: ${{ steps.get-path-to-package.outputs.path-to-package }}/dist
       - name: Upload Build Artifacts
@@ -75,5 +76,6 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           overwrite: false
+          retention-days: 30
           name: ${{ needs.get-artifact-name.outputs.artifact-name }}
           path: ${{ steps.get-path-to-package.outputs.path-to-package }}

--- a/.github/workflows/publish-static-bundle.yml
+++ b/.github/workflows/publish-static-bundle.yml
@@ -62,6 +62,16 @@ jobs:
     with:
       package-name: ${{ inputs.package-name }}
       environment: ${{ inputs.stage }}
+  notify-pending-approval:
+    runs-on: ubuntu-latest
+    if: ${{ inputs.stage == 'production' }}
+    steps:
+      - name: Notify slack that a release is waiting for approval
+        env:
+          WEBHOOK: ${{ secrets.PRODUCTION_SLACK_WEBHOOK }}
+          TEXT: "${{ inputs.tag_name }} is waiting for production approval: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        run: |-
+          curl -sf -X POST -H 'Content-type: application/json' --data "$(jq -cn --arg text "$TEXT" '{text: $text}')" "$WEBHOOK"
   # For packages which support preflight testing/deployment previews, we deploy the static bundle under a preview namespace and optionally run a preflight test against it.
   # This is to ensure that the preview deployment is working as expected before we promote to production.
   deploy-preview:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -5,7 +5,8 @@ on:
     branches:
       - "master"
       - "main"
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+# Concurrency is set per job, not per workflow. A release job waiting for
+# production approval must not block later pushes to master.
 jobs:
   lint-and-test:
     uses: ./.github/workflows/lint.yml
@@ -59,6 +60,7 @@ jobs:
     secrets: inherit
   deploy-browser:
     needs: [lint-and-test,e2e-test,build]
+    concurrency: staging-deploy-browser
     uses: ./.github/workflows/publish-static-bundle.yml
     with:
       stage: "staging"
@@ -75,6 +77,7 @@ jobs:
     secrets: inherit
   deploy-inputs:
     needs: [lint-and-test,e2e-test,build]
+    concurrency: staging-deploy-inputs
     uses: ./.github/workflows/publish-static-bundle.yml
     with:
       stage: "staging"
@@ -88,6 +91,7 @@ jobs:
     secrets: inherit
   deploy-ui-components:
     needs: [lint-and-test,e2e-test,build]
+    concurrency: staging-deploy-ui-components
     uses: ./.github/workflows/publish-static-bundle.yml
     with:
       stage: "staging"
@@ -104,6 +108,7 @@ jobs:
     secrets: inherit
   deploy-3ds:
     needs: [lint-and-test,e2e-test,build]
+    concurrency: staging-deploy-3ds
     uses: ./.github/workflows/publish-static-bundle.yml
     with:
       stage: "staging"
@@ -119,6 +124,7 @@ jobs:
     name: Create Tags
     runs-on: ubuntu-latest
     needs: [lint-and-test,e2e-test,build]
+    concurrency: create-tags
     outputs:
       has-changesets: ${{ steps.changesets.outputs.has-changesets }}
       tags-to-publish: ${{ steps.create-tags.outputs.tags-to-publish }}
@@ -172,6 +178,7 @@ jobs:
     strategy:
       matrix:
         tag: ${{ fromJson(needs.create-tags.outputs.tags-to-publish) }}
+    concurrency: release-${{ matrix.tag }}
     permissions:
       id-token: write
       contents: write


### PR DESCRIPTION
The workflow-wide `concurrency` group held later pushes while a production release waited for approval. Build artifacts also expired after seven days, which prevented delayed releases from deploying.

The workflow now sets job-level concurrency, retains build artifacts for 30 days, and posts a Slack notification when a production release awaits approval.