### PR TITLE
Collect a Google Pay shipping address and option on web

### DIFF
--- a/.changeset/google-pay-web-shipping.md
+++ b/.changeset/google-pay-web-shipping.md
@@ -3,4 +3,4 @@
 "@evervault/js": minor
 ---
 
-Add Google Pay shipping address and shipping option collection on web. `shippingAddress` and `shippingOptions` configure the sheet, `onShippingAddressChange` and `onShippingOptionChange` update the total, line items and options while the sheet is open, and the buyer's choice is surfaced on the `process()` payload as `shippingAddress` and `shippingOptionId`.
+Add Google Pay shipping collection on web. `shippingAddress` configures address collection, while `shippingOptions` adds options and enables address collection automatically. Shipping callbacks can update the open sheet, and `process()` receives the buyer's shipping address and option ID.

--- a/.changeset/google-pay-web-shipping.md
+++ b/.changeset/google-pay-web-shipping.md
@@ -1,0 +1,6 @@
+---
+"@evervault/browser": minor
+"@evervault/js": minor
+---
+
+Add Google Pay shipping address and shipping option collection on web. `shippingAddress` and `shippingOptions` configure the sheet, `onShippingAddressChange` and `onShippingOptionChange` update the total, line items and options while the sheet is open, and the buyer's choice is surfaced on the `process()` payload as `shippingAddress` and `shippingOptionId`.

--- a/.changeset/google-pay-web-shipping.md
+++ b/.changeset/google-pay-web-shipping.md
@@ -3,4 +3,4 @@
 "@evervault/js": minor
 ---
 
-Add Google Pay shipping collection on web. `shippingAddress` configures address collection, while `shippingOptions` adds options and enables address collection automatically. Shipping callbacks can update the open sheet, and `process()` receives the buyer's shipping address and option ID.
+Add Google Pay shipping collection on web. `shippingAddress` configures address collection, while `shippingOptions` adds options and enables address collection automatically. Shipping callbacks receive the current checkout state and can update the open sheet. `process()` receives the buyer's shipping address and selected option.

--- a/packages/browser/lib/ui/googlePay.ts
+++ b/packages/browser/lib/ui/googlePay.ts
@@ -13,42 +13,6 @@ import type {
 import { Transaction } from "../resources/transaction";
 import { getStringDimensionOrDefault } from "../utils";
 
-/**
- * Google rejects a request that asks for a shipping option without an address,
- * or with an empty option list, at sheet-present time. Fail at construction so
- * the merchant sees the cause rather than a sheet that will not open.
- */
-function assertShippingConfigValid(options: GooglePayOptions) {
-  const { shippingAddress, shippingOptions } = options;
-  if (!shippingOptions) return;
-
-  if (!shippingAddress) {
-    throw new Error(
-      "[Evervault Google Pay] shippingOptions requires shippingAddress; " +
-        "Google only offers shipping options once it has an address"
-    );
-  }
-
-  if (!shippingOptions.options.length) {
-    throw new Error(
-      "[Evervault Google Pay] shippingOptions.options must not be empty"
-    );
-  }
-
-  const { defaultSelectedOptionId } = shippingOptions;
-  if (
-    defaultSelectedOptionId &&
-    !shippingOptions.options.some(
-      (option) => option.id === defaultSelectedOptionId
-    )
-  ) {
-    throw new Error(
-      "[Evervault Google Pay] shippingOptions.defaultSelectedOptionId " +
-        `"${defaultSelectedOptionId}" does not match any configured option`
-    );
-  }
-}
-
 interface GooglePayEvents {
   ready: () => void;
   success: () => void;
@@ -67,8 +31,6 @@ export default class GooglePay {
     transaction: Transaction,
     options: GooglePayOptions
   ) {
-    assertShippingConfigValid(options);
-
     this.#options = options;
     this.#transaction = transaction;
     this.#frame = new EvervaultFrame(client, "GooglePay", {

--- a/packages/browser/lib/ui/googlePay.ts
+++ b/packages/browser/lib/ui/googlePay.ts
@@ -5,11 +5,49 @@ import type {
   SelectorType,
   GooglePayOptions,
   GooglePayClientMessages,
+  GooglePayDataChangeRequest,
+  GooglePayDataChangeUpdate,
   GooglePayHostMessages,
   GooglePayErrorMessage,
 } from "types";
 import { Transaction } from "../resources/transaction";
 import { getStringDimensionOrDefault } from "../utils";
+
+/**
+ * Google rejects a request that asks for a shipping option without an address,
+ * or with an empty option list, at sheet-present time. Fail at construction so
+ * the merchant sees the cause rather than a sheet that will not open.
+ */
+function assertShippingConfigValid(options: GooglePayOptions) {
+  const { shippingAddress, shippingOptions } = options;
+  if (!shippingOptions) return;
+
+  if (!shippingAddress) {
+    throw new Error(
+      "[Evervault Google Pay] shippingOptions requires shippingAddress; " +
+        "Google only offers shipping options once it has an address"
+    );
+  }
+
+  if (!shippingOptions.options.length) {
+    throw new Error(
+      "[Evervault Google Pay] shippingOptions.options must not be empty"
+    );
+  }
+
+  const { defaultSelectedOptionId } = shippingOptions;
+  if (
+    defaultSelectedOptionId &&
+    !shippingOptions.options.some(
+      (option) => option.id === defaultSelectedOptionId
+    )
+  ) {
+    throw new Error(
+      "[Evervault Google Pay] shippingOptions.defaultSelectedOptionId " +
+        `"${defaultSelectedOptionId}" does not match any configured option`
+    );
+  }
+}
 
 interface GooglePayEvents {
   ready: () => void;
@@ -29,6 +67,8 @@ export default class GooglePay {
     transaction: Transaction,
     options: GooglePayOptions
   ) {
+    assertShippingConfigValid(options);
+
     this.#options = options;
     this.#transaction = transaction;
     this.#frame = new EvervaultFrame(client, "GooglePay", {
@@ -65,6 +105,13 @@ export default class GooglePay {
       }
     });
 
+    this.#frame.on("EV_GOOGLE_PAY_DATA_CHANGE", async (payload) => {
+      this.#frame.send(
+        "EV_GOOGLE_PAY_DATA_CHANGE_RESULT",
+        await this.#handleDataChange(payload)
+      );
+    });
+
     this.#frame.on("EV_GOOGLE_PAY_CANCELLED", () => {
       this.#events.dispatch("cancel");
     });
@@ -78,6 +125,38 @@ export default class GooglePay {
     });
   }
 
+  /**
+   * Runs the merchant's shipping callback for one sheet selection. The reply
+   * always carries the request's id, so the frame can match it even when the
+   * buyer changes their mind mid-sheet and several are in flight.
+   */
+  async #handleDataChange(payload: GooglePayDataChangeRequest) {
+    try {
+      const update = await this.#runDataChangeCallback(payload);
+      return { id: payload.id, ...(update ?? {}) };
+    } catch {
+      return {
+        id: payload.id,
+        error: {
+          reason: "OTHER_ERROR" as const,
+          message: "Something went wrong, please try again",
+        },
+      };
+    }
+  }
+
+  #runDataChangeCallback(
+    payload: GooglePayDataChangeRequest
+  ): Promise<GooglePayDataChangeUpdate | void> | undefined {
+    if (payload.trigger === "SHIPPING_OPTION") {
+      if (!payload.shippingOptionId) return undefined;
+      return this.#options.onShippingOptionChange?.(payload.shippingOptionId);
+    }
+
+    if (!payload.shippingAddress) return undefined;
+    return this.#options.onShippingAddressChange?.(payload.shippingAddress);
+  }
+
   get config() {
     return {
       config: {
@@ -89,6 +168,8 @@ export default class GooglePay {
         allowedAuthMethods: this.#options.allowedAuthMethods,
         allowedCardNetworks: this.#options.allowedCardNetworks,
         billingAddress: this.#options.billingAddress,
+        shippingAddress: this.#options.shippingAddress,
+        shippingOptions: this.#options.shippingOptions,
         emailRequired: this.#options.emailRequired,
       },
     };

--- a/packages/browser/lib/ui/googlePay.ts
+++ b/packages/browser/lib/ui/googlePay.ts
@@ -31,6 +31,7 @@ export default class GooglePay {
     transaction: Transaction,
     options: GooglePayOptions
   ) {
+    validateShippingOptions(options.shippingOptions);
     this.#options = options;
     this.#transaction = transaction;
     this.#frame = new EvervaultFrame(client, "GooglePay", {
@@ -95,7 +96,8 @@ export default class GooglePay {
   async #handleDataChange(payload: GooglePayDataChangeRequest) {
     try {
       const update = await this.#runDataChangeCallback(payload);
-      return { id: payload.id, ...(update ?? {}) };
+      validateShippingOptions(update?.shippingOptions);
+      return { ...(update ?? {}), id: payload.id };
     } catch {
       return {
         id: payload.id,
@@ -155,5 +157,15 @@ export default class GooglePay {
 
   on<T extends keyof GooglePayEvents>(event: T, callback: GooglePayEvents[T]) {
     return this.#events.on(event, callback);
+  }
+}
+
+function validateShippingOptions(
+  shippingOptions: GooglePayOptions["shippingOptions"]
+) {
+  if (shippingOptions?.options.length === 0) {
+    throw new Error(
+      "Google Pay shippingOptions must contain at least one option"
+    );
   }
 }

--- a/packages/browser/lib/ui/googlePay.ts
+++ b/packages/browser/lib/ui/googlePay.ts
@@ -13,6 +13,8 @@ import type {
 import { Transaction } from "../resources/transaction";
 import { getStringDimensionOrDefault } from "../utils";
 
+const SHIPPING_CALLBACK_TIMEOUT_MS = 10_000;
+
 interface GooglePayEvents {
   ready: () => void;
   success: () => void;
@@ -95,7 +97,11 @@ export default class GooglePay {
    */
   async #handleDataChange(payload: GooglePayDataChangeRequest) {
     try {
-      const update = await this.#runDataChangeCallback(payload);
+      const callbackResult = this.#runDataChangeCallback(payload);
+      const update = await resolveWithin(
+        callbackResult,
+        SHIPPING_CALLBACK_TIMEOUT_MS
+      );
       validateShippingOptions(update?.shippingOptions);
       return { ...(update ?? {}), id: payload.id };
     } catch {
@@ -111,14 +117,32 @@ export default class GooglePay {
 
   #runDataChangeCallback(
     payload: GooglePayDataChangeRequest
-  ): Promise<GooglePayDataChangeUpdate | void> | undefined {
+  ):
+    | GooglePayDataChangeUpdate
+    | void
+    | Promise<GooglePayDataChangeUpdate | void> {
+    const context = {
+      trigger: payload.trigger,
+      shippingAddress: payload.shippingAddress,
+      selectedShippingOption: payload.selectedShippingOption,
+      amount: payload.amount,
+      lineItems: payload.lineItems,
+      shippingOptions: payload.shippingOptions,
+    };
+
     if (payload.trigger === "SHIPPING_OPTION") {
-      if (!payload.shippingOptionId) return undefined;
-      return this.#options.onShippingOptionChange?.(payload.shippingOptionId);
+      if (!payload.selectedShippingOption) return undefined;
+      return this.#options.onShippingOptionChange?.(
+        payload.selectedShippingOption,
+        context
+      );
     }
 
     if (!payload.shippingAddress) return undefined;
-    return this.#options.onShippingAddressChange?.(payload.shippingAddress);
+    return this.#options.onShippingAddressChange?.(
+      payload.shippingAddress,
+      context
+    );
   }
 
   get config() {
@@ -160,12 +184,55 @@ export default class GooglePay {
   }
 }
 
+async function resolveWithin<T>(
+  value: T | Promise<T>,
+  timeoutMs: number
+): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const expired = new Promise<never>((_, reject) => {
+    timeout = setTimeout(
+      () => reject(new Error("Google Pay shipping callback timed out")),
+      timeoutMs
+    );
+  });
+
+  try {
+    return await Promise.race([Promise.resolve(value), expired]);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
 function validateShippingOptions(
   shippingOptions: GooglePayOptions["shippingOptions"]
 ) {
-  if (shippingOptions?.options.length === 0) {
+  if (!shippingOptions) return;
+  if (shippingOptions.options.length === 0) {
     throw new Error(
       "Google Pay shippingOptions must contain at least one option"
+    );
+  }
+
+  const ids = new Set<string>();
+  for (const option of shippingOptions.options) {
+    if (!option.id.trim()) {
+      throw new Error("Google Pay shipping option ids must not be empty");
+    }
+    if (!option.label.trim()) {
+      throw new Error("Google Pay shipping option labels must not be empty");
+    }
+    if (ids.has(option.id)) {
+      throw new Error("Google Pay shipping option ids must be unique");
+    }
+    ids.add(option.id);
+  }
+
+  if (
+    shippingOptions.defaultSelectedOptionId !== undefined &&
+    !ids.has(shippingOptions.defaultSelectedOptionId)
+  ) {
+    throw new Error(
+      "Google Pay defaultSelectedOptionId must match a shipping option id"
     );
   }
 }

--- a/packages/browser/test/googlePay.test.ts
+++ b/packages/browser/test/googlePay.test.ts
@@ -1,0 +1,232 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { GooglePayOptions } from "types";
+import GooglePay from "../lib/ui/googlePay";
+import { Transaction } from "../lib/resources/transaction";
+import type EvervaultClient from "../lib/main";
+
+type Handler = (payload: unknown) => unknown;
+
+const handlers = new Map<string, Handler>();
+const sent: Array<{ type: string; payload: unknown }> = [];
+
+vi.mock("../lib/ui/evervaultFrame", () => ({
+  EvervaultFrame: class {
+    on(type: string, handler: Handler) {
+      handlers.set(type, handler);
+    }
+
+    send(type: string, payload: unknown) {
+      sent.push({ type, payload });
+    }
+
+    mount() {
+      return this;
+    }
+
+    unmount() {
+      return this;
+    }
+  },
+}));
+
+const client = {} as EvervaultClient;
+const transaction = new Transaction({
+  amount: 1000,
+  currency: "USD",
+  country: "US",
+  merchantId: "merchant_abc",
+});
+
+const SHIPPING_OPTIONS = {
+  options: [{ id: "standard", label: "Standard" }],
+};
+
+const ADDRESS = {
+  countryCode: "US",
+  postalCode: "94043",
+  administrativeArea: "CA",
+  locality: "Mountain View",
+};
+
+function mount(options: Partial<GooglePayOptions> = {}) {
+  return new GooglePay(client, transaction, {
+    process: vi.fn(),
+    ...options,
+  } as GooglePayOptions);
+}
+
+/** Drives one data change the way the frame does, and returns the reply. */
+async function raiseDataChange(payload: Record<string, unknown>) {
+  await handlers.get("EV_GOOGLE_PAY_DATA_CHANGE")!({
+    id: "gpay-data-change-1",
+    ...payload,
+  });
+  return sent.at(-1);
+}
+
+describe("GooglePay shipping configuration", () => {
+  it("rejects shipping options without a shipping address", () => {
+    expect(() => mount({ shippingOptions: SHIPPING_OPTIONS })).toThrow(
+      /shippingOptions requires shippingAddress/
+    );
+  });
+
+  it("rejects an empty option list", () => {
+    expect(() =>
+      mount({ shippingAddress: true, shippingOptions: { options: [] } })
+    ).toThrow(/must not be empty/);
+  });
+
+  it("rejects a default selection that matches no option", () => {
+    expect(() =>
+      mount({
+        shippingAddress: true,
+        shippingOptions: {
+          ...SHIPPING_OPTIONS,
+          defaultSelectedOptionId: "express",
+        },
+      })
+    ).toThrow(/does not match any configured option/);
+  });
+
+  it("accepts a default selection that matches an option", () => {
+    expect(() =>
+      mount({
+        shippingAddress: true,
+        shippingOptions: {
+          ...SHIPPING_OPTIONS,
+          defaultSelectedOptionId: "standard",
+        },
+      })
+    ).not.toThrow();
+  });
+
+  it("passes the shipping config to the frame", () => {
+    const button = mount({
+      shippingAddress: { allowedCountryCodes: ["US"] },
+      shippingOptions: SHIPPING_OPTIONS,
+    });
+
+    expect(button.config.config).toMatchObject({
+      shippingAddress: { allowedCountryCodes: ["US"] },
+      shippingOptions: SHIPPING_OPTIONS,
+    });
+  });
+});
+
+describe("GooglePay data change callbacks", () => {
+  beforeEach(() => {
+    handlers.clear();
+    sent.length = 0;
+  });
+
+  it("calls onShippingAddressChange and returns its update", async () => {
+    const onShippingAddressChange = vi.fn().mockResolvedValue({ amount: 1500 });
+    mount({ shippingAddress: true, onShippingAddressChange });
+
+    const reply = await raiseDataChange({
+      trigger: "SHIPPING_ADDRESS",
+      shippingAddress: ADDRESS,
+    });
+
+    expect(onShippingAddressChange).toHaveBeenCalledOnce();
+    expect(onShippingAddressChange).toHaveBeenCalledWith(ADDRESS);
+    expect(reply).toEqual({
+      type: "EV_GOOGLE_PAY_DATA_CHANGE_RESULT",
+      payload: { id: "gpay-data-change-1", amount: 1500 },
+    });
+  });
+
+  it("calls onShippingOptionChange with the chosen option id", async () => {
+    const onShippingOptionChange = vi.fn().mockResolvedValue({ amount: 1200 });
+    mount({
+      shippingAddress: true,
+      shippingOptions: SHIPPING_OPTIONS,
+      onShippingOptionChange,
+    });
+
+    await raiseDataChange({
+      trigger: "SHIPPING_OPTION",
+      shippingOptionId: "express",
+    });
+
+    expect(onShippingOptionChange).toHaveBeenCalledOnce();
+    expect(onShippingOptionChange).toHaveBeenCalledWith("express");
+  });
+
+  it("does not call the address callback for an option change", async () => {
+    const onShippingAddressChange = vi.fn().mockResolvedValue({});
+    mount({
+      shippingAddress: true,
+      shippingOptions: SHIPPING_OPTIONS,
+      onShippingAddressChange,
+    });
+
+    await raiseDataChange({
+      trigger: "SHIPPING_OPTION",
+      shippingOptionId: "standard",
+    });
+
+    expect(onShippingAddressChange).not.toHaveBeenCalled();
+  });
+
+  it("replies with only the id when no callback is configured", async () => {
+    mount({ shippingAddress: true });
+
+    const reply = await raiseDataChange({
+      trigger: "SHIPPING_ADDRESS",
+      shippingAddress: ADDRESS,
+    });
+
+    expect(reply?.payload).toEqual({ id: "gpay-data-change-1" });
+  });
+
+  it("replies with only the id for an INITIALIZE trigger with no address", async () => {
+    const onShippingAddressChange = vi.fn().mockResolvedValue({ amount: 1500 });
+    mount({ shippingAddress: true, onShippingAddressChange });
+
+    const reply = await raiseDataChange({ trigger: "INITIALIZE" });
+
+    expect(onShippingAddressChange).not.toHaveBeenCalled();
+    expect(reply?.payload).toEqual({ id: "gpay-data-change-1" });
+  });
+
+  it("turns a thrown callback into an inline sheet error", async () => {
+    mount({
+      shippingAddress: true,
+      onShippingAddressChange: vi.fn().mockRejectedValue(new Error("boom")),
+    });
+
+    const reply = await raiseDataChange({
+      trigger: "SHIPPING_ADDRESS",
+      shippingAddress: ADDRESS,
+    });
+
+    expect(reply?.payload).toEqual({
+      id: "gpay-data-change-1",
+      error: {
+        reason: "OTHER_ERROR",
+        message: "Something went wrong, please try again",
+      },
+    });
+  });
+
+  it("passes a merchant error through untouched", async () => {
+    mount({
+      shippingAddress: true,
+      onShippingAddressChange: vi.fn().mockResolvedValue({
+        error: { message: "We do not ship there" },
+      }),
+    });
+
+    const reply = await raiseDataChange({
+      trigger: "SHIPPING_ADDRESS",
+      shippingAddress: ADDRESS,
+    });
+
+    expect(reply?.payload).toEqual({
+      id: "gpay-data-change-1",
+      error: { message: "We do not ship there" },
+    });
+  });
+});

--- a/packages/browser/test/googlePay.test.ts
+++ b/packages/browser/test/googlePay.test.ts
@@ -71,14 +71,23 @@ it("passes shipping configuration to the frame", () => {
   ).toMatchObject({ shippingAddress, shippingOptions: SHIPPING_OPTIONS });
 });
 
+it("rejects an empty shipping option list", () => {
+  expect(() => mount({ shippingOptions: { options: [] } })).toThrow(
+    "Google Pay shippingOptions must contain at least one option"
+  );
+});
+
 describe("GooglePay data change callbacks", () => {
   beforeEach(() => {
     handlers.clear();
     sent.length = 0;
   });
 
-  it("calls onShippingAddressChange and returns its update", async () => {
-    const onShippingAddressChange = vi.fn().mockResolvedValue({ amount: 1500 });
+  it("calls onShippingAddressChange and preserves the request id", async () => {
+    const onShippingAddressChange = vi.fn().mockResolvedValue({
+      id: "merchant-supplied-id",
+      amount: 1500,
+    });
     mount({ shippingAddress: true, onShippingAddressChange });
 
     const reply = await raiseDataChange({
@@ -146,6 +155,25 @@ describe("GooglePay data change callbacks", () => {
         reason: "OTHER_ERROR",
         message: "Something went wrong, please try again",
       },
+    });
+  });
+
+  it("rejects an empty shipping option update", async () => {
+    mount({
+      shippingAddress: true,
+      onShippingAddressChange: vi.fn().mockResolvedValue({
+        shippingOptions: { options: [] },
+      }),
+    });
+
+    const reply = await raiseDataChange({
+      trigger: "SHIPPING_ADDRESS",
+      shippingAddress: ADDRESS,
+    });
+
+    expect(reply?.payload).toMatchObject({
+      id: "gpay-data-change-1",
+      error: { reason: "OTHER_ERROR" },
     });
   });
 

--- a/packages/browser/test/googlePay.test.ts
+++ b/packages/browser/test/googlePay.test.ts
@@ -64,54 +64,11 @@ async function raiseDataChange(payload: Record<string, unknown>) {
   return sent.at(-1);
 }
 
-describe("GooglePay shipping configuration", () => {
-  it("rejects shipping options without a shipping address", () => {
-    expect(() => mount({ shippingOptions: SHIPPING_OPTIONS })).toThrow(
-      /shippingOptions requires shippingAddress/
-    );
-  });
-
-  it("rejects an empty option list", () => {
-    expect(() =>
-      mount({ shippingAddress: true, shippingOptions: { options: [] } })
-    ).toThrow(/must not be empty/);
-  });
-
-  it("rejects a default selection that matches no option", () => {
-    expect(() =>
-      mount({
-        shippingAddress: true,
-        shippingOptions: {
-          ...SHIPPING_OPTIONS,
-          defaultSelectedOptionId: "express",
-        },
-      })
-    ).toThrow(/does not match any configured option/);
-  });
-
-  it("accepts a default selection that matches an option", () => {
-    expect(() =>
-      mount({
-        shippingAddress: true,
-        shippingOptions: {
-          ...SHIPPING_OPTIONS,
-          defaultSelectedOptionId: "standard",
-        },
-      })
-    ).not.toThrow();
-  });
-
-  it("passes the shipping config to the frame", () => {
-    const button = mount({
-      shippingAddress: { allowedCountryCodes: ["US"] },
-      shippingOptions: SHIPPING_OPTIONS,
-    });
-
-    expect(button.config.config).toMatchObject({
-      shippingAddress: { allowedCountryCodes: ["US"] },
-      shippingOptions: SHIPPING_OPTIONS,
-    });
-  });
+it("passes shipping configuration to the frame", () => {
+  const shippingAddress = { allowedCountryCodes: ["US"] };
+  expect(
+    mount({ shippingAddress, shippingOptions: SHIPPING_OPTIONS }).config.config
+  ).toMatchObject({ shippingAddress, shippingOptions: SHIPPING_OPTIONS });
 });
 
 describe("GooglePay data change callbacks", () => {
@@ -137,36 +94,17 @@ describe("GooglePay data change callbacks", () => {
     });
   });
 
-  it("calls onShippingOptionChange with the chosen option id", async () => {
+  it("routes option changes only to the option callback", async () => {
+    const onShippingAddressChange = vi.fn();
     const onShippingOptionChange = vi.fn().mockResolvedValue({ amount: 1200 });
-    mount({
-      shippingAddress: true,
-      shippingOptions: SHIPPING_OPTIONS,
-      onShippingOptionChange,
-    });
+    mount({ onShippingAddressChange, onShippingOptionChange });
 
     await raiseDataChange({
       trigger: "SHIPPING_OPTION",
       shippingOptionId: "express",
     });
 
-    expect(onShippingOptionChange).toHaveBeenCalledOnce();
     expect(onShippingOptionChange).toHaveBeenCalledWith("express");
-  });
-
-  it("does not call the address callback for an option change", async () => {
-    const onShippingAddressChange = vi.fn().mockResolvedValue({});
-    mount({
-      shippingAddress: true,
-      shippingOptions: SHIPPING_OPTIONS,
-      onShippingAddressChange,
-    });
-
-    await raiseDataChange({
-      trigger: "SHIPPING_OPTION",
-      shippingOptionId: "standard",
-    });
-
     expect(onShippingAddressChange).not.toHaveBeenCalled();
   });
 

--- a/packages/browser/test/googlePay.test.ts
+++ b/packages/browser/test/googlePay.test.ts
@@ -38,7 +38,11 @@ const transaction = new Transaction({
 });
 
 const SHIPPING_OPTIONS = {
-  options: [{ id: "standard", label: "Standard" }],
+  options: [
+    { id: "standard", label: "Standard", amount: 500 },
+    { id: "express", label: "Express", amount: 800 },
+  ],
+  defaultSelectedOptionId: "standard",
 };
 
 const ADDRESS = {
@@ -59,6 +63,11 @@ function mount(options: Partial<GooglePayOptions> = {}) {
 async function raiseDataChange(payload: Record<string, unknown>) {
   await handlers.get("EV_GOOGLE_PAY_DATA_CHANGE")!({
     id: "gpay-data-change-1",
+    amount: 1000,
+    lineItems: undefined,
+    shippingOptions: SHIPPING_OPTIONS,
+    shippingAddress: null,
+    selectedShippingOption: SHIPPING_OPTIONS.options[0],
     ...payload,
   });
   return sent.at(-1);
@@ -71,10 +80,34 @@ it("passes shipping configuration to the frame", () => {
   ).toMatchObject({ shippingAddress, shippingOptions: SHIPPING_OPTIONS });
 });
 
-it("rejects an empty shipping option list", () => {
-  expect(() => mount({ shippingOptions: { options: [] } })).toThrow(
-    "Google Pay shippingOptions must contain at least one option"
-  );
+it.each([
+  [{ options: [] }, "must contain at least one option"],
+  [
+    { options: [{ id: "", label: "Standard" }] },
+    "option ids must not be empty",
+  ],
+  [
+    { options: [{ id: "standard", label: "" }] },
+    "option labels must not be empty",
+  ],
+  [
+    {
+      options: [
+        { id: "standard", label: "Standard" },
+        { id: "standard", label: "Standard again" },
+      ],
+    },
+    "option ids must be unique",
+  ],
+  [
+    {
+      options: [{ id: "standard", label: "Standard" }],
+      defaultSelectedOptionId: "express",
+    },
+    "defaultSelectedOptionId must match a shipping option id",
+  ],
+])("rejects invalid shipping options: %s", (shippingOptions, message) => {
+  expect(() => mount({ shippingOptions })).toThrow(message);
 });
 
 describe("GooglePay data change callbacks", () => {
@@ -83,8 +116,8 @@ describe("GooglePay data change callbacks", () => {
     sent.length = 0;
   });
 
-  it("calls onShippingAddressChange and preserves the request id", async () => {
-    const onShippingAddressChange = vi.fn().mockResolvedValue({
+  it("passes context to a synchronous address callback and preserves the request id", async () => {
+    const onShippingAddressChange = vi.fn().mockReturnValue({
       id: "merchant-supplied-id",
       amount: 1500,
     });
@@ -96,7 +129,16 @@ describe("GooglePay data change callbacks", () => {
     });
 
     expect(onShippingAddressChange).toHaveBeenCalledOnce();
-    expect(onShippingAddressChange).toHaveBeenCalledWith(ADDRESS);
+    expect(onShippingAddressChange).toHaveBeenCalledWith(
+      ADDRESS,
+      expect.objectContaining({
+        trigger: "SHIPPING_ADDRESS",
+        shippingAddress: ADDRESS,
+        selectedShippingOption: SHIPPING_OPTIONS.options[0],
+        amount: 1000,
+        shippingOptions: SHIPPING_OPTIONS,
+      })
+    );
     expect(reply).toEqual({
       type: "EV_GOOGLE_PAY_DATA_CHANGE_RESULT",
       payload: { id: "gpay-data-change-1", amount: 1500 },
@@ -110,10 +152,17 @@ describe("GooglePay data change callbacks", () => {
 
     await raiseDataChange({
       trigger: "SHIPPING_OPTION",
-      shippingOptionId: "express",
+      selectedShippingOption: SHIPPING_OPTIONS.options[1],
     });
 
-    expect(onShippingOptionChange).toHaveBeenCalledWith("express");
+    expect(onShippingOptionChange).toHaveBeenCalledWith(
+      SHIPPING_OPTIONS.options[1],
+      expect.objectContaining({
+        trigger: "SHIPPING_OPTION",
+        selectedShippingOption: SHIPPING_OPTIONS.options[1],
+        amount: 1000,
+      })
+    );
     expect(onShippingAddressChange).not.toHaveBeenCalled();
   });
 
@@ -136,6 +185,29 @@ describe("GooglePay data change callbacks", () => {
 
     expect(onShippingAddressChange).not.toHaveBeenCalled();
     expect(reply?.payload).toEqual({ id: "gpay-data-change-1" });
+  });
+
+  it("turns a callback timeout into an inline sheet error", async () => {
+    vi.useFakeTimers();
+    try {
+      mount({
+        shippingAddress: true,
+        onShippingAddressChange: vi.fn().mockReturnValue(new Promise(() => {})),
+      });
+
+      const replyPromise = raiseDataChange({
+        trigger: "SHIPPING_ADDRESS",
+        shippingAddress: ADDRESS,
+      });
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      expect((await replyPromise)?.payload).toMatchObject({
+        id: "gpay-data-change-1",
+        error: { reason: "OTHER_ERROR" },
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("turns a thrown callback into an inline sheet error", async () => {

--- a/packages/types/uiComponents.ts
+++ b/packages/types/uiComponents.ts
@@ -581,8 +581,8 @@ export interface GooglePayOptions {
    */
   shippingAddress?: GooglePayShippingAddressConfig;
   /**
-   * Offer shipping options in the sheet. Requires `shippingAddress`, because
-   * Google only raises option callbacks once it has an address.
+   * Offer shipping options in the sheet. This also enables shipping-address
+   * collection when `shippingAddress` is omitted.
    */
   shippingOptions?: GooglePayShippingOptionsConfig;
   /**

--- a/packages/types/uiComponents.ts
+++ b/packages/types/uiComponents.ts
@@ -497,11 +497,8 @@ export interface GooglePayErrorMessage {
   intent?: google.payments.api.CallbackIntent;
 }
 
-export interface GooglePayShippingAddressParameters {
-  /** ISO 3166-1 alpha-2 codes the buyer may ship to, e.g. `["US", "CA"]`. */
-  allowedCountryCodes?: string[];
-  phoneNumberRequired?: boolean;
-}
+export type GooglePayShippingAddressParameters =
+  google.payments.api.ShippingAddressParameters;
 
 export type GooglePayShippingAddressConfig =
   | boolean

--- a/packages/types/uiComponents.ts
+++ b/packages/types/uiComponents.ts
@@ -480,8 +480,8 @@ export type EncryptedGooglePayData = (
   email?: string | null;
   billingAddress?: google.payments.api.Address | null;
   /**
-   * The address the buyer chose in the sheet. Present only when
-   * `shippingAddress` was configured on the Google Pay button.
+   * The address the buyer chose in the sheet. Present when shipping-address
+   * collection was enabled directly or through `shippingOptions`.
    */
   shippingAddress?: google.payments.api.Address | null;
   /**
@@ -504,11 +504,7 @@ export type GooglePayShippingAddressConfig =
   | boolean
   | GooglePayShippingAddressParameters;
 
-export interface GooglePayShippingOption {
-  id: string;
-  label: string;
-  description?: string;
-}
+export type GooglePayShippingOption = google.payments.api.SelectionOption;
 
 export interface GooglePayShippingOptionsConfig {
   options: GooglePayShippingOption[];

--- a/packages/types/uiComponents.ts
+++ b/packages/types/uiComponents.ts
@@ -307,12 +307,14 @@ export interface GooglePayClientMessages extends EvervaultFrameClientMessages {
   EV_GOOGLE_PAY_CANCELLED: undefined;
   EV_GOOGLE_PAY_ERROR: string;
   EV_GOOGLE_PAY_SUCCESS: undefined;
+  EV_GOOGLE_PAY_DATA_CHANGE: GooglePayDataChangeRequest;
 }
 
 export interface GooglePayHostMessages extends EvervaultFrameHostMessages {
   EV_GOOGLE_PAY_AUTH_COMPLETE: undefined;
   EV_GOOGLE_PAY_AUTH_ERROR: GooglePayErrorMessage;
   EV_GOOGLE_PAY_SUCCESS: undefined;
+  EV_GOOGLE_PAY_DATA_CHANGE_RESULT: GooglePayDataChangeResponse;
 }
 
 export interface ApplePayHostMessages extends EvervaultFrameHostMessages {
@@ -477,12 +479,76 @@ export type EncryptedGooglePayData = (
 ) & {
   email?: string | null;
   billingAddress?: google.payments.api.Address | null;
+  /**
+   * The address the buyer chose in the sheet. Present only when
+   * `shippingAddress` was configured on the Google Pay button.
+   */
+  shippingAddress?: google.payments.api.Address | null;
+  /**
+   * The id of the shipping option the buyer chose in the sheet. Present only
+   * when `shippingOptions` were configured on the Google Pay button.
+   */
+  shippingOptionId?: string | null;
 };
 
 export interface GooglePayErrorMessage {
   message: string;
   reason?: google.payments.api.ErrorReason;
   intent?: google.payments.api.CallbackIntent;
+}
+
+export interface GooglePayShippingAddressParameters {
+  /** ISO 3166-1 alpha-2 codes the buyer may ship to, e.g. `["US", "CA"]`. */
+  allowedCountryCodes?: string[];
+  phoneNumberRequired?: boolean;
+}
+
+export type GooglePayShippingAddressConfig =
+  | boolean
+  | GooglePayShippingAddressParameters;
+
+export interface GooglePayShippingOption {
+  id: string;
+  label: string;
+  description?: string;
+}
+
+export interface GooglePayShippingOptionsConfig {
+  options: GooglePayShippingOption[];
+  /** Defaults to the first option when omitted, matching Google's own default. */
+  defaultSelectedOptionId?: string;
+}
+
+/**
+ * What a merchant returns from `onShippingAddressChange` /
+ * `onShippingOptionChange` to update the open sheet. Every field is optional:
+ * returning nothing leaves the sheet as it is.
+ *
+ * `amount` and `lineItems[].amount` are in the currency's minor units, the same
+ * as `transaction.amount`.
+ */
+export interface GooglePayDataChangeUpdate {
+  amount?: number;
+  lineItems?: TransactionLineItem[];
+  shippingOptions?: GooglePayShippingOptionsConfig;
+  /** Rejects the buyer's selection and shows this error inside the sheet. */
+  error?: GooglePayErrorMessage;
+}
+
+/**
+ * A shipping selection the buyer made while the sheet is open. Carries an `id`
+ * because, unlike authorization, the sheet can raise several of these in one
+ * session and each needs to be matched to its own reply.
+ */
+export interface GooglePayDataChangeRequest {
+  id: string;
+  trigger: google.payments.api.CallbackTrigger;
+  shippingAddress?: google.payments.api.IntermediateAddress | null;
+  shippingOptionId?: string | null;
+}
+
+export interface GooglePayDataChangeResponse extends GooglePayDataChangeUpdate {
+  id: string;
 }
 
 export type GooglePayBillingAddressConfig =
@@ -509,6 +575,27 @@ export interface GooglePayOptions {
   allowedAuthMethods?: google.payments.api.CardAuthMethod[];
   allowedCardNetworks?: google.payments.api.CardNetwork[];
   billingAddress?: GooglePayBillingAddressConfig;
+  /**
+   * Collect a shipping address in the sheet. Pass `true` for any supported
+   * country, or parameters to restrict countries / request a phone number.
+   */
+  shippingAddress?: GooglePayShippingAddressConfig;
+  /**
+   * Offer shipping options in the sheet. Requires `shippingAddress`, because
+   * Google only raises option callbacks once it has an address.
+   */
+  shippingOptions?: GooglePayShippingOptionsConfig;
+  /**
+   * Called when the buyer picks or changes their shipping address, while the
+   * sheet is still open. Return updated totals, line items or options.
+   */
+  onShippingAddressChange?: (
+    address: google.payments.api.IntermediateAddress
+  ) => Promise<GooglePayDataChangeUpdate | void>;
+  /** Called when the buyer picks a different shipping option. */
+  onShippingOptionChange?: (
+    optionId: string
+  ) => Promise<GooglePayDataChangeUpdate | void>;
   theme?: ThemeDefinition;
 }
 

--- a/packages/types/uiComponents.ts
+++ b/packages/types/uiComponents.ts
@@ -485,10 +485,10 @@ export type EncryptedGooglePayData = (
    */
   shippingAddress?: google.payments.api.Address | null;
   /**
-   * The id of the shipping option the buyer chose in the sheet. Present only
-   * when `shippingOptions` were configured on the Google Pay button.
+   * The shipping option the buyer chose in the sheet. Present only when
+   * `shippingOptions` were configured on the Google Pay button.
    */
-  shippingOptionId?: string | null;
+  shippingOption?: GooglePayShippingOption | null;
 };
 
 export interface GooglePayErrorMessage {
@@ -504,7 +504,13 @@ export type GooglePayShippingAddressConfig =
   | boolean
   | GooglePayShippingAddressParameters;
 
-export type GooglePayShippingOption = google.payments.api.SelectionOption;
+export type GooglePayShippingOption = google.payments.api.SelectionOption & {
+  /**
+   * Optional shipping cost in minor units. Google Pay does not display this
+   * field automatically. Include it in `label` when buyers must see the price.
+   */
+  amount?: number;
+};
 
 export interface GooglePayShippingOptionsConfig {
   options: GooglePayShippingOption[];
@@ -512,37 +518,49 @@ export interface GooglePayShippingOptionsConfig {
   defaultSelectedOptionId?: string;
 }
 
+/** The current shipping state when Google Pay asks for an update. */
+export interface GooglePayShippingContext {
+  trigger: google.payments.api.CallbackTrigger;
+  shippingAddress?: google.payments.api.IntermediateAddress | null;
+  selectedShippingOption?: GooglePayShippingOption | null;
+  /** The current total in the currency's minor units. */
+  amount: number;
+  lineItems?: TransactionLineItem[];
+  shippingOptions?: GooglePayShippingOptionsConfig;
+}
+
 /**
- * What a merchant returns from `onShippingAddressChange` /
- * `onShippingOptionChange` to update the open sheet. Every field is optional:
- * returning nothing leaves the sheet as it is.
- *
- * `amount` and `lineItems[].amount` are in the currency's minor units, the same
- * as `transaction.amount`.
+ * A successful patch for the open sheet. Omitted fields retain their current
+ * values. Amounts use the currency's minor units, like `transaction.amount`.
  */
-export interface GooglePayDataChangeUpdate {
+export interface GooglePayDataChangeSuccess {
   amount?: number;
   lineItems?: TransactionLineItem[];
   shippingOptions?: GooglePayShippingOptionsConfig;
-  /** Rejects the buyer's selection and shows this error inside the sheet. */
-  error?: GooglePayErrorMessage;
+  error?: never;
 }
 
-/**
- * A shipping selection the buyer made while the sheet is open. Carries an `id`
- * because, unlike authorization, the sheet can raise several of these in one
- * session and each needs to be matched to its own reply.
- */
-export interface GooglePayDataChangeRequest {
-  id: string;
-  trigger: google.payments.api.CallbackTrigger;
-  shippingAddress?: google.payments.api.IntermediateAddress | null;
-  shippingOptionId?: string | null;
+/** Rejects the buyer's current selection and shows an error in the sheet. */
+export interface GooglePayDataChangeFailure {
+  error: GooglePayErrorMessage;
+  amount?: never;
+  lineItems?: never;
+  shippingOptions?: never;
 }
 
-export interface GooglePayDataChangeResponse extends GooglePayDataChangeUpdate {
+export type GooglePayDataChangeUpdate =
+  | GooglePayDataChangeSuccess
+  | GooglePayDataChangeFailure;
+
+/** Internal message used to run a merchant callback outside the payment frame. */
+export interface GooglePayDataChangeRequest extends GooglePayShippingContext {
+  /** Correlates this request with its asynchronous response. */
   id: string;
 }
+
+export type GooglePayDataChangeResponse = GooglePayDataChangeUpdate & {
+  id: string;
+};
 
 export type GooglePayBillingAddressConfig =
   | boolean
@@ -580,15 +598,27 @@ export interface GooglePayOptions {
   shippingOptions?: GooglePayShippingOptionsConfig;
   /**
    * Called when the buyer picks or changes their shipping address, while the
-   * sheet is still open. Return updated totals, line items or options.
+   * sheet is still open. Return updated totals, line items or options. The
+   * callback has 10 seconds to complete.
    */
   onShippingAddressChange?: (
-    address: google.payments.api.IntermediateAddress
-  ) => Promise<GooglePayDataChangeUpdate | void>;
-  /** Called when the buyer picks a different shipping option. */
+    address: google.payments.api.IntermediateAddress,
+    context: GooglePayShippingContext
+  ) =>
+    | GooglePayDataChangeUpdate
+    | void
+    | Promise<GooglePayDataChangeUpdate | void>;
+  /**
+   * Called when the buyer picks a different shipping option. The callback has
+   * 10 seconds to complete.
+   */
   onShippingOptionChange?: (
-    optionId: string
-  ) => Promise<GooglePayDataChangeUpdate | void>;
+    option: GooglePayShippingOption,
+    context: GooglePayShippingContext
+  ) =>
+    | GooglePayDataChangeUpdate
+    | void
+    | Promise<GooglePayDataChangeUpdate | void>;
   theme?: ThemeDefinition;
 }
 

--- a/packages/ui-components/src/GooglePay/index.tsx
+++ b/packages/ui-components/src/GooglePay/index.tsx
@@ -246,6 +246,9 @@ export function GooglePay({ config }: GooglePayProps) {
           buttonRadius: config.borderRadius ?? DEFAULT_BUTTON_RADIUS,
           buttonSizeMode: "fill",
           onClick: async () => {
+            currentAmount = config.transaction.amount;
+            currentLineItems = config.transaction.lineItems;
+
             try {
               await paymentsClient.loadPaymentData(paymentRequest);
             } catch (err) {

--- a/packages/ui-components/src/GooglePay/index.tsx
+++ b/packages/ui-components/src/GooglePay/index.tsx
@@ -46,20 +46,18 @@ function isPaymentError(
  * `CallbackTrigger` and `CallbackIntent` overlap but are not the same union, so
  * an error raised from a data change has to name an intent Google accepts.
  */
-function errorIntent(
+function defaultShippingError(
   data: google.payments.api.IntermediatePaymentData
-): google.payments.api.CallbackIntent {
+): Pick<google.payments.api.PaymentDataError, "reason" | "intent"> {
   return data.callbackTrigger === "SHIPPING_OPTION"
-    ? "SHIPPING_OPTION"
-    : "SHIPPING_ADDRESS";
+    ? { reason: "SHIPPING_OPTION_INVALID", intent: "SHIPPING_OPTION" }
+    : {
+        reason: "SHIPPING_ADDRESS_UNSERVICEABLE",
+        intent: "SHIPPING_ADDRESS",
+      };
 }
 
 let dataChangeSequence = 0;
-
-function nextDataChangeId(): string {
-  dataChangeSequence += 1;
-  return `gpay-data-change-${dataChangeSequence}`;
-}
 
 export function GooglePay({ config }: GooglePayProps) {
   const { app } = useSearchParams();
@@ -84,6 +82,11 @@ export function GooglePay({ config }: GooglePayProps) {
       const merchantPromise = getMerchant(app, config.transaction.merchantId);
 
       const appConfig = await appConfigPromise;
+      // Each response patches the open sheet. Keep prior values when a later
+      // merchant response updates only the amount or only the line items.
+      let currentAmount = config.transaction.amount;
+      let currentLineItems = config.transaction.lineItems;
+
       const paymentsClient = new google.payments.api.PaymentsClient({
         // Always use 'test' in staging, but use the resolved environment in production
         environment:
@@ -97,7 +100,7 @@ export function GooglePay({ config }: GooglePayProps) {
           // than once per session, so each request is matched to its reply by
           // id rather than by message type alone.
           onPaymentDataChanged: async (data) => {
-            const id = nextDataChangeId();
+            const id = `gpay-data-change-${++dataChangeSequence}`;
 
             const update = await new Promise<GooglePayDataChangeResponse>(
               (resolve) => {
@@ -120,11 +123,11 @@ export function GooglePay({ config }: GooglePayProps) {
             );
 
             if (update.error) {
+              const defaultError = defaultShippingError(data);
               return {
                 error: {
-                  reason:
-                    update.error.reason || "SHIPPING_ADDRESS_UNSERVICEABLE",
-                  intent: update.error.intent || errorIntent(data),
+                  reason: update.error.reason ?? defaultError.reason,
+                  intent: update.error.intent ?? defaultError.intent,
                   message: update.error.message,
                 },
               };
@@ -133,11 +136,14 @@ export function GooglePay({ config }: GooglePayProps) {
             const result: google.payments.api.PaymentDataRequestUpdate = {};
 
             if (update.amount !== undefined || update.lineItems !== undefined) {
+              currentAmount = update.amount ?? currentAmount;
+              currentLineItems = update.lineItems ?? currentLineItems;
+
               const merchant = await merchantPromise;
               result.newTransactionInfo = buildTransactionInfo(
                 config,
                 merchant?.name ?? "",
-                { amount: update.amount, lineItems: update.lineItems }
+                { amount: currentAmount, lineItems: currentLineItems }
               );
             }
 

--- a/packages/ui-components/src/GooglePay/index.tsx
+++ b/packages/ui-components/src/GooglePay/index.tsx
@@ -59,6 +59,16 @@ function defaultShippingError(
 
 let dataChangeSequence = 0;
 
+function initialShippingOptionId(
+  shippingOptions: GooglePayConfig["shippingOptions"]
+): string | null {
+  return (
+    shippingOptions?.defaultSelectedOptionId ??
+    shippingOptions?.options[0]?.id ??
+    null
+  );
+}
+
 export function GooglePay({ config }: GooglePayProps) {
   const { app } = useSearchParams();
   const container = useRef<HTMLDivElement>(null);
@@ -86,6 +96,12 @@ export function GooglePay({ config }: GooglePayProps) {
       // merchant response updates only the amount or only the line items.
       let currentAmount = config.transaction.amount;
       let currentLineItems = config.transaction.lineItems;
+      let currentShippingOptions = config.shippingOptions;
+      let currentShippingAddress: google.payments.api.IntermediateAddress | null =
+        null;
+      let currentShippingOptionId = initialShippingOptionId(
+        config.shippingOptions
+      );
 
       const paymentsClient = new google.payments.api.PaymentsClient({
         // Always use 'test' in staging, but use the resolved environment in production
@@ -102,6 +118,18 @@ export function GooglePay({ config }: GooglePayProps) {
           onPaymentDataChanged: async (data) => {
             const id = `gpay-data-change-${++dataChangeSequence}`;
 
+            if (data.shippingAddress !== undefined) {
+              currentShippingAddress = data.shippingAddress;
+            }
+            if (data.shippingOptionData?.id) {
+              currentShippingOptionId = data.shippingOptionData.id;
+            }
+
+            const currentShippingOption =
+              currentShippingOptions?.options.find(
+                (option) => option.id === currentShippingOptionId
+              ) ?? null;
+
             const update = await new Promise<GooglePayDataChangeResponse>(
               (resolve) => {
                 const off = on(
@@ -116,8 +144,11 @@ export function GooglePay({ config }: GooglePayProps) {
                 send("EV_GOOGLE_PAY_DATA_CHANGE", {
                   id,
                   trigger: data.callbackTrigger,
-                  shippingAddress: data.shippingAddress ?? null,
-                  shippingOptionId: data.shippingOptionData?.id ?? null,
+                  shippingAddress: currentShippingAddress,
+                  selectedShippingOption: currentShippingOption,
+                  amount: currentAmount,
+                  lineItems: currentLineItems,
+                  shippingOptions: currentShippingOptions,
                 });
               }
             );
@@ -148,8 +179,12 @@ export function GooglePay({ config }: GooglePayProps) {
             }
 
             if (update.shippingOptions) {
+              currentShippingOptions = update.shippingOptions;
+              currentShippingOptionId = initialShippingOptionId(
+                currentShippingOptions
+              );
               result.newShippingOptionParameters = shippingOptionParameters(
-                update.shippingOptions
+                currentShippingOptions
               );
             }
 
@@ -188,7 +223,9 @@ export function GooglePay({ config }: GooglePayProps) {
             }
 
             if (data.shippingOptionData) {
-              payload.shippingOptionId = data.shippingOptionData.id;
+              payload.shippingOption = currentShippingOptions?.options.find(
+                (option) => option.id === data.shippingOptionData?.id
+              );
             }
 
             const cardDetails = paymentMethodInfo?.cardDetails;
@@ -248,6 +285,11 @@ export function GooglePay({ config }: GooglePayProps) {
           onClick: async () => {
             currentAmount = config.transaction.amount;
             currentLineItems = config.transaction.lineItems;
+            currentShippingOptions = config.shippingOptions;
+            currentShippingAddress = null;
+            currentShippingOptionId = initialShippingOptionId(
+              config.shippingOptions
+            );
 
             try {
               await paymentsClient.loadPaymentData(paymentRequest);

--- a/packages/ui-components/src/GooglePay/index.tsx
+++ b/packages/ui-components/src/GooglePay/index.tsx
@@ -1,11 +1,17 @@
 import css from "./styles.module.css";
 import { CSSProperties, useLayoutEffect, useRef } from "react";
-import { buildPaymentRequest, exchangePaymentData } from "./utilities";
+import {
+  buildPaymentRequest,
+  buildTransactionInfo,
+  exchangePaymentData,
+  shippingOptionParameters,
+} from "./utilities";
 import { setSize } from "../utilities/resize";
 import { GooglePayConfig } from "./types";
 import { useMessaging } from "../utilities/useMessaging";
 import {
   GooglePayClientMessages,
+  GooglePayDataChangeResponse,
   GooglePayHostMessages,
   PaymentMethodType,
 } from "types";
@@ -34,6 +40,25 @@ function isPaymentError(
   err: unknown
 ): err is google.payments.api.PaymentsError {
   return Boolean((err as google.payments.api.PaymentsError).statusCode);
+}
+
+/**
+ * `CallbackTrigger` and `CallbackIntent` overlap but are not the same union, so
+ * an error raised from a data change has to name an intent Google accepts.
+ */
+function errorIntent(
+  data: google.payments.api.IntermediatePaymentData
+): google.payments.api.CallbackIntent {
+  return data.callbackTrigger === "SHIPPING_OPTION"
+    ? "SHIPPING_OPTION"
+    : "SHIPPING_ADDRESS";
+}
+
+let dataChangeSequence = 0;
+
+function nextDataChangeId(): string {
+  dataChangeSequence += 1;
+  return `gpay-data-change-${dataChangeSequence}`;
 }
 
 export function GooglePay({ config }: GooglePayProps) {
@@ -68,6 +93,62 @@ export function GooglePay({ config }: GooglePayProps) {
             ? "TEST"
             : "PRODUCTION",
         paymentDataCallbacks: {
+          // Google raises this while the sheet is open, and can raise it more
+          // than once per session, so each request is matched to its reply by
+          // id rather than by message type alone.
+          onPaymentDataChanged: async (data) => {
+            const id = nextDataChangeId();
+
+            const update = await new Promise<GooglePayDataChangeResponse>(
+              (resolve) => {
+                const off = on(
+                  "EV_GOOGLE_PAY_DATA_CHANGE_RESULT",
+                  (response) => {
+                    if (response.id !== id) return;
+                    off();
+                    resolve(response);
+                  }
+                );
+
+                send("EV_GOOGLE_PAY_DATA_CHANGE", {
+                  id,
+                  trigger: data.callbackTrigger,
+                  shippingAddress: data.shippingAddress ?? null,
+                  shippingOptionId: data.shippingOptionData?.id ?? null,
+                });
+              }
+            );
+
+            if (update.error) {
+              return {
+                error: {
+                  reason:
+                    update.error.reason || "SHIPPING_ADDRESS_UNSERVICEABLE",
+                  intent: update.error.intent || errorIntent(data),
+                  message: update.error.message,
+                },
+              };
+            }
+
+            const result: google.payments.api.PaymentDataRequestUpdate = {};
+
+            if (update.amount !== undefined || update.lineItems !== undefined) {
+              const merchant = await merchantPromise;
+              result.newTransactionInfo = buildTransactionInfo(
+                config,
+                merchant?.name ?? "",
+                { amount: update.amount, lineItems: update.lineItems }
+              );
+            }
+
+            if (update.shippingOptions) {
+              result.newShippingOptionParameters = shippingOptionParameters(
+                update.shippingOptions
+              );
+            }
+
+            return result;
+          },
           onPaymentAuthorized: async (data) => {
             const payload = await exchangePaymentData(
               app,
@@ -94,6 +175,14 @@ export function GooglePay({ config }: GooglePayProps) {
             const billingAddress = paymentMethodInfo?.billingAddress || null;
             if (billingAddress) {
               payload.billingAddress = billingAddress;
+            }
+
+            if (data.shippingAddress) {
+              payload.shippingAddress = data.shippingAddress;
+            }
+
+            if (data.shippingOptionData) {
+              payload.shippingOptionId = data.shippingOptionData.id;
             }
 
             const cardDetails = paymentMethodInfo?.cardDetails;

--- a/packages/ui-components/src/GooglePay/types.ts
+++ b/packages/ui-components/src/GooglePay/types.ts
@@ -2,6 +2,8 @@ import {
   GooglePayBillingAddressConfig,
   GooglePayButtonColor,
   GooglePayButtonType,
+  GooglePayShippingAddressConfig,
+  GooglePayShippingOptionsConfig,
   TransactionDetailsWithDomain,
 } from "types";
 
@@ -14,5 +16,7 @@ export interface GooglePayConfig {
   allowedAuthMethods?: string[];
   allowedCardNetworks?: string[];
   billingAddress?: GooglePayBillingAddressConfig;
+  shippingAddress?: GooglePayShippingAddressConfig;
+  shippingOptions?: GooglePayShippingOptionsConfig;
   emailRequired?: boolean;
 }

--- a/packages/ui-components/src/GooglePay/utilities.ts
+++ b/packages/ui-components/src/GooglePay/utilities.ts
@@ -190,14 +190,7 @@ function isShippingRequired(config: GooglePayConfig): boolean {
 function shippingAddressParameters(
   config: GooglePayConfig
 ): google.payments.api.ShippingAddressParameters {
-  const shippingConfig = config.shippingAddress;
-  if (typeof shippingConfig !== "object" || shippingConfig === null) return {};
-  return {
-    ...(shippingConfig.allowedCountryCodes
-      ? { allowedCountryCodes: shippingConfig.allowedCountryCodes }
-      : {}),
-    ...(shippingConfig.phoneNumberRequired
-      ? { phoneNumberRequired: true }
-      : {}),
-  };
+  return typeof config.shippingAddress === "object"
+    ? config.shippingAddress
+    : {};
 }

--- a/packages/ui-components/src/GooglePay/utilities.ts
+++ b/packages/ui-components/src/GooglePay/utilities.ts
@@ -1,4 +1,9 @@
-import { EncryptedGooglePayData, MerchantDetail } from "types";
+import {
+  EncryptedGooglePayData,
+  GooglePayShippingOptionsConfig,
+  MerchantDetail,
+  TransactionLineItem,
+} from "types";
 import { GooglePayConfig } from "./types";
 import { apiConfig } from "../utilities/config";
 
@@ -56,20 +61,79 @@ export function buildPaymentRequest(
       merchantName: merchant.name,
       merchantOrigin: tx.domain, // merchantOrigin is not present in the GooglePayConfig type but is noted as required by the GooglePay API
     } as unknown as google.payments.api.MerchantInfo,
-    transactionInfo: {
-      totalPriceStatus: "FINAL",
-      totalPriceLabel: tx.priceLabel ?? `Pay ${merchant.name}`,
-      totalPrice: (tx.amount / 100).toFixed(2).toString(),
-      currencyCode: tx.currency,
-      countryCode: tx.country,
-      displayItems: tx.lineItems?.map((item) => ({
-        label: item.label,
-        type: "LINE_ITEM",
-        price: (item.amount / 100).toFixed(2).toString(),
-      })),
-    },
-    callbackIntents: ["PAYMENT_AUTHORIZATION"],
+    ...(isShippingRequired(config)
+      ? {
+          shippingAddressRequired: true,
+          shippingAddressParameters: shippingAddressParameters(config),
+        }
+      : {}),
+    ...(config.shippingOptions
+      ? {
+          shippingOptionRequired: true,
+          shippingOptionParameters: shippingOptionParameters(
+            config.shippingOptions
+          ),
+        }
+      : {}),
+    transactionInfo: buildTransactionInfo(config, merchant.name),
+    callbackIntents: callbackIntents(config),
   };
+}
+
+/**
+ * Google raises shipping callbacks only for the intents the request declares,
+ * so the intent list has to follow the config rather than be hardcoded.
+ */
+export function callbackIntents(
+  config: GooglePayConfig
+): google.payments.api.CallbackIntent[] {
+  const intents: google.payments.api.CallbackIntent[] = [];
+  if (isShippingRequired(config)) intents.push("SHIPPING_ADDRESS");
+  if (config.shippingOptions) intents.push("SHIPPING_OPTION");
+  intents.push("PAYMENT_AUTHORIZATION");
+  return intents;
+}
+
+export function buildTransactionInfo(
+  config: GooglePayConfig,
+  merchantName: string,
+  overrides: { amount?: number; lineItems?: TransactionLineItem[] } = {}
+): google.payments.api.TransactionInfo {
+  const tx = config.transaction;
+  const amount = overrides.amount ?? tx.amount;
+  const lineItems = overrides.lineItems ?? tx.lineItems;
+
+  return {
+    totalPriceStatus: "FINAL",
+    totalPriceLabel: tx.priceLabel ?? `Pay ${merchantName}`,
+    totalPrice: formatAmount(amount),
+    currencyCode: tx.currency,
+    countryCode: tx.country,
+    displayItems: lineItems?.map((item) => ({
+      label: item.label,
+      type: "LINE_ITEM",
+      price: formatAmount(item.amount),
+    })),
+  };
+}
+
+export function shippingOptionParameters(
+  shippingOptions: GooglePayShippingOptionsConfig
+): google.payments.api.ShippingOptionParameters {
+  return {
+    shippingOptions: shippingOptions.options.map((option) => ({
+      id: option.id,
+      label: option.label,
+      description: option.description ?? "",
+    })),
+    ...(shippingOptions.defaultSelectedOptionId
+      ? { defaultSelectedOptionId: shippingOptions.defaultSelectedOptionId }
+      : {}),
+  };
+}
+
+function formatAmount(amount: number): string {
+  return (amount / 100).toFixed(2).toString();
 }
 
 const API = import.meta.env.VITE_API_URL as string;
@@ -117,4 +181,25 @@ function phoneNumberRequired(config: GooglePayConfig): boolean {
   const billingConfig = config.billingAddress;
   if (typeof billingConfig === "boolean") return false;
   return billingConfig?.phoneNumber || false;
+}
+
+function isShippingRequired(config: GooglePayConfig): boolean {
+  const shippingConfig = config.shippingAddress;
+  if (typeof shippingConfig === "boolean") return shippingConfig;
+  return !!shippingConfig;
+}
+
+function shippingAddressParameters(
+  config: GooglePayConfig
+): google.payments.api.ShippingAddressParameters {
+  const shippingConfig = config.shippingAddress;
+  if (typeof shippingConfig !== "object" || shippingConfig === null) return {};
+  return {
+    ...(shippingConfig.allowedCountryCodes
+      ? { allowedCountryCodes: shippingConfig.allowedCountryCodes }
+      : {}),
+    ...(shippingConfig.phoneNumberRequired
+      ? { phoneNumberRequired: true }
+      : {}),
+  };
 }

--- a/packages/ui-components/src/GooglePay/utilities.ts
+++ b/packages/ui-components/src/GooglePay/utilities.ts
@@ -184,9 +184,7 @@ function phoneNumberRequired(config: GooglePayConfig): boolean {
 }
 
 function isShippingRequired(config: GooglePayConfig): boolean {
-  const shippingConfig = config.shippingAddress;
-  if (typeof shippingConfig === "boolean") return shippingConfig;
-  return !!shippingConfig;
+  return !!config.shippingAddress || !!config.shippingOptions;
 }
 
 function shippingAddressParameters(

--- a/packages/ui-components/test/GooglePay.test.tsx
+++ b/packages/ui-components/test/GooglePay.test.tsx
@@ -139,6 +139,13 @@ describe("GooglePay shipping data changes", () => {
     administrativeArea: "CA",
     locality: "Mountain View",
   } as google.payments.api.IntermediateAddress;
+  const SHIPPING_OPTIONS = {
+    options: [
+      { id: "standard", label: "Standard", amount: 500 },
+      { id: "express", label: "Express", amount: 800 },
+    ],
+    defaultSelectedOptionId: "standard",
+  };
 
   beforeEach(() => {
     (globalThis as unknown as { google: unknown }).google = {
@@ -152,7 +159,7 @@ describe("GooglePay shipping data changes", () => {
         config={{
           ...config,
           shippingAddress: true,
-          shippingOptions: { options: [{ id: "standard", label: "Standard" }] },
+          shippingOptions: SHIPPING_OPTIONS,
         }}
       />
     );
@@ -209,6 +216,9 @@ describe("GooglePay shipping data changes", () => {
         payload: expect.objectContaining({
           trigger: "SHIPPING_ADDRESS",
           shippingAddress: ADDRESS,
+          selectedShippingOption: SHIPPING_OPTIONS.options[0],
+          amount: 1000,
+          shippingOptions: SHIPPING_OPTIONS,
         }),
       }),
       "*"
@@ -216,7 +226,7 @@ describe("GooglePay shipping data changes", () => {
     expect(result.newTransactionInfo?.totalPrice).toBe("15.00");
   });
 
-  it("reports the chosen option id when the buyer changes option", async () => {
+  it("reports the chosen option and current state when it changes", async () => {
     await mountWithShipping();
     const postMessage = replyToDataChange({ amount: 1200 });
 
@@ -229,7 +239,9 @@ describe("GooglePay shipping data changes", () => {
       expect.objectContaining({
         payload: expect.objectContaining({
           trigger: "SHIPPING_OPTION",
-          shippingOptionId: "express",
+          selectedShippingOption: SHIPPING_OPTIONS.options[1],
+          amount: 1000,
+          shippingOptions: SHIPPING_OPTIONS,
         }),
       }),
       "*"
@@ -238,7 +250,7 @@ describe("GooglePay shipping data changes", () => {
 
   it("preserves prior values across partial transaction updates", async () => {
     await mountWithShipping();
-    replyToDataChange([
+    const postMessage = replyToDataChange([
       {
         amount: 1500,
         lineItems: [{ label: "Shipping", amount: 500 }],
@@ -261,6 +273,15 @@ describe("GooglePay shipping data changes", () => {
       totalPrice: "18.00",
       displayItems: [{ label: "Express", price: "8.00" }],
     });
+    expect(postMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          amount: 1800,
+          lineItems: [{ label: "Shipping", amount: 500 }],
+        }),
+      }),
+      "*"
+    );
   });
 
   it("resets partial transaction state when the sheet reopens", async () => {
@@ -334,9 +355,9 @@ describe("GooglePay shipping data changes", () => {
     }
   );
 
-  it("replaces the sheet's options when the merchant returns new ones", async () => {
+  it("replaces the sheet's options and uses them in later context", async () => {
     await mountWithShipping();
-    replyToDataChange({
+    const postMessage = replyToDataChange({
       shippingOptions: { options: [{ id: "next-day", label: "Next day" }] },
     });
 
@@ -348,6 +369,22 @@ describe("GooglePay shipping data changes", () => {
     expect(result.newShippingOptionParameters).toEqual({
       shippingOptions: [{ id: "next-day", label: "Next day", description: "" }],
     });
+
+    await callbacks.onPaymentDataChanged!({
+      callbackTrigger: "SHIPPING_OPTION",
+      shippingOptionData: { id: "next-day" },
+    } as google.payments.api.IntermediatePaymentData);
+    expect(postMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          selectedShippingOption: { id: "next-day", label: "Next day" },
+          shippingOptions: {
+            options: [{ id: "next-day", label: "Next day" }],
+          },
+        }),
+      }),
+      "*"
+    );
   });
 
   it("surfaces the buyer's shipping choice on the authorized payload", async () => {
@@ -375,7 +412,7 @@ describe("GooglePay shipping data changes", () => {
           type: "EV_GOOGLE_PAY_AUTH",
           payload: expect.objectContaining({
             shippingAddress,
-            shippingOptionId: "standard",
+            shippingOption: SHIPPING_OPTIONS.options[0],
           }),
         }),
         "*"

--- a/packages/ui-components/test/GooglePay.test.tsx
+++ b/packages/ui-components/test/GooglePay.test.tsx
@@ -52,20 +52,25 @@ function getInjectedScript() {
   );
 }
 
+beforeEach(() => {
+  createButtonMock.mockReset();
+  getMerchantMock.mockReset();
+  getAppSDKConfigMock.mockReset();
+  getMerchantMock.mockResolvedValue({ id: "merchant_abc", name: "Acme Co" });
+  getAppSDKConfigMock.mockResolvedValue({ is_sandbox: false });
+  (globalThis as unknown as { google: unknown }).google = {
+    payments: { api: { PaymentsClient: MockPaymentsClient } },
+  };
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  delete (globalThis as { google?: unknown }).google;
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
 describe("GooglePay onLoad GET concurrency", () => {
-  beforeEach(() => {
-    getMerchantMock.mockReset();
-    getAppSDKConfigMock.mockReset();
-    (globalThis as unknown as { google: unknown }).google = {
-      payments: { api: { PaymentsClient: MockPaymentsClient } },
-    };
-  });
-
-  afterEach(() => {
-    document.body.innerHTML = "";
-    delete (globalThis as { google?: unknown }).google;
-  });
-
   it("issues getAppSDKConfig and getMerchant concurrently, not sequentially", async () => {
     let resolveAppConfig: (value: { is_sandbox: boolean }) => void = () => {};
     const appConfigGate = new Promise<{ is_sandbox: boolean }>((resolve) => {
@@ -101,22 +106,6 @@ describe("GooglePay onLoad GET concurrency", () => {
 });
 
 describe("GooglePay button radius", () => {
-  beforeEach(() => {
-    createButtonMock.mockReset();
-    getMerchantMock.mockReset();
-    getAppSDKConfigMock.mockReset();
-    getMerchantMock.mockResolvedValue({ id: "merchant_abc", name: "Acme Co" });
-    getAppSDKConfigMock.mockResolvedValue({ is_sandbox: false });
-    (globalThis as unknown as { google: unknown }).google = {
-      payments: { api: { PaymentsClient: MockPaymentsClient } },
-    };
-  });
-
-  afterEach(() => {
-    document.body.innerHTML = "";
-    delete (globalThis as { google?: unknown }).google;
-  });
-
   async function renderAndGetRadius(borderRadius?: number) {
     render(<GooglePay config={{ ...config, borderRadius }} />);
     getInjectedScript()!.dispatchEvent(new Event("load"));
@@ -125,16 +114,12 @@ describe("GooglePay button radius", () => {
       .buttonRadius;
   }
 
-  it("defaults to 12, matching the Android SDK", async () => {
-    expect(await renderAndGetRadius(undefined)).toBe(12);
-  });
-
-  it("uses the configured radius", async () => {
-    expect(await renderAndGetRadius(20)).toBe(20);
-  });
-
-  it("honours a radius of 0 rather than falling back to the default", async () => {
-    expect(await renderAndGetRadius(0)).toBe(0);
+  it.each([
+    [undefined, 12],
+    [20, 20],
+    [0, 0],
+  ])("maps a radius of %s to %s", async (configured, expected) => {
+    expect(await renderAndGetRadius(configured)).toBe(expected);
   });
 });
 
@@ -156,20 +141,9 @@ describe("GooglePay shipping data changes", () => {
   } as google.payments.api.IntermediateAddress;
 
   beforeEach(() => {
-    getMerchantMock.mockReset();
-    getAppSDKConfigMock.mockReset();
-    getMerchantMock.mockResolvedValue({ id: "merchant_abc", name: "Acme Co" });
-    getAppSDKConfigMock.mockResolvedValue({ is_sandbox: false });
     (globalThis as unknown as { google: unknown }).google = {
       payments: { api: { PaymentsClient: CapturingPaymentsClient } },
     };
-  });
-
-  afterEach(() => {
-    document.body.innerHTML = "";
-    delete (globalThis as { google?: unknown }).google;
-    vi.unstubAllGlobals();
-    vi.restoreAllMocks();
   });
 
   async function mountWithShipping() {
@@ -184,6 +158,13 @@ describe("GooglePay shipping data changes", () => {
     );
     getInjectedScript()!.dispatchEvent(new Event("load"));
     await waitFor(() => expect(callbacks.onPaymentDataChanged).toBeDefined());
+  }
+
+  async function openPaymentSheet() {
+    const options = createButtonMock.mock.calls.at(-1)?.[0] as {
+      onClick: () => Promise<void>;
+    };
+    await options.onClick();
   }
 
   /**
@@ -282,6 +263,31 @@ describe("GooglePay shipping data changes", () => {
     });
   });
 
+  it("resets partial transaction state when the sheet reopens", async () => {
+    await mountWithShipping();
+    replyToDataChange([
+      {
+        amount: 1500,
+        lineItems: [{ label: "Shipping", amount: 500 }],
+      },
+      { lineItems: [{ label: "Express", amount: 800 }] },
+    ]);
+    const change = () =>
+      callbacks.onPaymentDataChanged!({
+        callbackTrigger: "SHIPPING_OPTION",
+        shippingOptionData: { id: "express" },
+      } as google.payments.api.IntermediatePaymentData);
+
+    await openPaymentSheet();
+    await change();
+    await openPaymentSheet();
+
+    expect((await change()).newTransactionInfo).toMatchObject({
+      totalPrice: "10.00",
+      displayItems: [{ label: "Express", price: "8.00" }],
+    });
+  });
+
   it("returns no update when the merchant returns nothing", async () => {
     await mountWithShipping();
     replyToDataChange({});
@@ -294,41 +300,39 @@ describe("GooglePay shipping data changes", () => {
     expect(result).toEqual({});
   });
 
-  it("surfaces an address error as an inline sheet error", async () => {
-    await mountWithShipping();
-    replyToDataChange({
-      error: { message: "We do not ship there" },
-    });
-
-    const result = await callbacks.onPaymentDataChanged!({
-      callbackTrigger: "SHIPPING_ADDRESS",
-      shippingAddress: ADDRESS,
-    } as google.payments.api.IntermediatePaymentData);
-
-    expect(result.error).toEqual({
+  it.each([
+    {
+      data: { callbackTrigger: "SHIPPING_ADDRESS", shippingAddress: ADDRESS },
+      message: "We do not ship there",
       reason: "SHIPPING_ADDRESS_UNSERVICEABLE",
       intent: "SHIPPING_ADDRESS",
-      message: "We do not ship there",
-    });
-  });
-
-  it("uses a shipping-option error for an invalid option", async () => {
-    await mountWithShipping();
-    replyToDataChange({
-      error: { message: "That option is no longer available" },
-    });
-
-    const result = await callbacks.onPaymentDataChanged!({
-      callbackTrigger: "SHIPPING_OPTION",
-      shippingOptionData: { id: "express" },
-    } as google.payments.api.IntermediatePaymentData);
-
-    expect(result.error).toEqual({
+    },
+    {
+      data: {
+        callbackTrigger: "SHIPPING_OPTION",
+        shippingOptionData: { id: "express" },
+      },
+      message: "That option is no longer available",
       reason: "SHIPPING_OPTION_INVALID",
       intent: "SHIPPING_OPTION",
-      message: "That option is no longer available",
-    });
-  });
+    },
+  ] as const)(
+    "uses a $intent error for an invalid selection",
+    async (testCase) => {
+      await mountWithShipping();
+      replyToDataChange({ error: { message: testCase.message } });
+
+      const result = await callbacks.onPaymentDataChanged!(
+        testCase.data as google.payments.api.IntermediatePaymentData
+      );
+
+      expect(result.error).toEqual({
+        reason: testCase.reason,
+        intent: testCase.intent,
+        message: testCase.message,
+      });
+    }
+  );
 
   it("replaces the sheet's options when the merchant returns new ones", async () => {
     await mountWithShipping();

--- a/packages/ui-components/test/GooglePay.test.tsx
+++ b/packages/ui-components/test/GooglePay.test.tsx
@@ -137,3 +137,226 @@ describe("GooglePay button radius", () => {
     expect(await renderAndGetRadius(0)).toBe(0);
   });
 });
+
+describe("GooglePay shipping data changes", () => {
+  let callbacks: google.payments.api.PaymentDataCallbacks;
+
+  class CapturingPaymentsClient extends MockPaymentsClient {
+    constructor(options: google.payments.api.PaymentOptions) {
+      super();
+      callbacks = options.paymentDataCallbacks ?? {};
+    }
+  }
+
+  const ADDRESS = {
+    countryCode: "US",
+    postalCode: "94043",
+    administrativeArea: "CA",
+    locality: "Mountain View",
+  } as google.payments.api.IntermediateAddress;
+
+  beforeEach(() => {
+    getMerchantMock.mockReset();
+    getAppSDKConfigMock.mockReset();
+    getMerchantMock.mockResolvedValue({ id: "merchant_abc", name: "Acme Co" });
+    getAppSDKConfigMock.mockResolvedValue({ is_sandbox: false });
+    (globalThis as unknown as { google: unknown }).google = {
+      payments: { api: { PaymentsClient: CapturingPaymentsClient } },
+    };
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    delete (globalThis as { google?: unknown }).google;
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  async function mountWithShipping() {
+    render(
+      <GooglePay
+        config={{
+          ...config,
+          shippingAddress: true,
+          shippingOptions: { options: [{ id: "standard", label: "Standard" }] },
+        }}
+      />
+    );
+    getInjectedScript()!.dispatchEvent(new Event("load"));
+    await waitFor(() => expect(callbacks.onPaymentDataChanged).toBeDefined());
+  }
+
+  /**
+   * Answers the frame's outgoing data-change message the way the host SDK
+   * would, echoing back the id it was sent.
+   */
+  function replyToDataChange(update: Record<string, unknown>) {
+    const postMessage = vi
+      .spyOn(window.parent, "postMessage")
+      .mockImplementation((message: unknown) => {
+        const { type, payload } = message as {
+          type: string;
+          payload: { id: string };
+        };
+        if (type !== "EV_GOOGLE_PAY_DATA_CHANGE") return;
+        window.dispatchEvent(
+          new MessageEvent("message", {
+            data: {
+              type: "EV_GOOGLE_PAY_DATA_CHANGE_RESULT",
+              payload: { id: payload.id, ...update },
+            },
+          })
+        );
+      });
+    return postMessage;
+  }
+
+  it("sends the buyer's address to the host and applies the new total", async () => {
+    await mountWithShipping();
+    const postMessage = replyToDataChange({ amount: 1500 });
+
+    const result = await callbacks.onPaymentDataChanged!({
+      callbackTrigger: "SHIPPING_ADDRESS",
+      shippingAddress: ADDRESS,
+    } as google.payments.api.IntermediatePaymentData);
+
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "EV_GOOGLE_PAY_DATA_CHANGE",
+        payload: expect.objectContaining({
+          trigger: "SHIPPING_ADDRESS",
+          shippingAddress: ADDRESS,
+        }),
+      }),
+      "*"
+    );
+    expect(result.newTransactionInfo?.totalPrice).toBe("15.00");
+  });
+
+  it("reports the chosen option id when the buyer changes option", async () => {
+    await mountWithShipping();
+    const postMessage = replyToDataChange({ amount: 1200 });
+
+    await callbacks.onPaymentDataChanged!({
+      callbackTrigger: "SHIPPING_OPTION",
+      shippingOptionData: { id: "express" },
+    } as google.payments.api.IntermediatePaymentData);
+
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          trigger: "SHIPPING_OPTION",
+          shippingOptionId: "express",
+        }),
+      }),
+      "*"
+    );
+  });
+
+  it("returns no update when the merchant returns nothing", async () => {
+    await mountWithShipping();
+    replyToDataChange({});
+
+    const result = await callbacks.onPaymentDataChanged!({
+      callbackTrigger: "SHIPPING_ADDRESS",
+      shippingAddress: ADDRESS,
+    } as google.payments.api.IntermediatePaymentData);
+
+    expect(result).toEqual({});
+  });
+
+  it("surfaces a merchant error as an inline sheet error", async () => {
+    await mountWithShipping();
+    replyToDataChange({
+      error: { message: "We do not ship there" },
+    });
+
+    const result = await callbacks.onPaymentDataChanged!({
+      callbackTrigger: "SHIPPING_ADDRESS",
+      shippingAddress: ADDRESS,
+    } as google.payments.api.IntermediatePaymentData);
+
+    expect(result.error).toEqual({
+      reason: "SHIPPING_ADDRESS_UNSERVICEABLE",
+      intent: "SHIPPING_ADDRESS",
+      message: "We do not ship there",
+    });
+  });
+
+  it("replaces the sheet's options when the merchant returns new ones", async () => {
+    await mountWithShipping();
+    replyToDataChange({
+      shippingOptions: { options: [{ id: "next-day", label: "Next day" }] },
+    });
+
+    const result = await callbacks.onPaymentDataChanged!({
+      callbackTrigger: "SHIPPING_ADDRESS",
+      shippingAddress: ADDRESS,
+    } as google.payments.api.IntermediatePaymentData);
+
+    expect(result.newShippingOptionParameters).toEqual({
+      shippingOptions: [{ id: "next-day", label: "Next day", description: "" }],
+    });
+  });
+
+  it("surfaces the buyer's shipping choice on the authorized payload", async () => {
+    await mountWithShipping();
+    const postMessage = vi
+      .spyOn(window.parent, "postMessage")
+      .mockImplementation(() => {});
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ json: async () => ({ card: {} }) })
+    );
+    const shippingAddress = { ...ADDRESS, name: "Ada Lovelace" };
+
+    void callbacks.onPaymentAuthorized!({
+      paymentMethodData: {
+        tokenizationData: { token: JSON.stringify({}) },
+      },
+      shippingAddress,
+      shippingOptionData: { id: "standard" },
+    } as unknown as google.payments.api.PaymentData);
+
+    await waitFor(() =>
+      expect(postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "EV_GOOGLE_PAY_AUTH",
+          payload: expect.objectContaining({
+            shippingAddress,
+            shippingOptionId: "standard",
+          }),
+        }),
+        "*"
+      )
+    );
+  });
+
+  it("ignores a reply meant for a different data change", async () => {
+    await mountWithShipping();
+    vi.spyOn(window.parent, "postMessage").mockImplementation(() => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          data: {
+            type: "EV_GOOGLE_PAY_DATA_CHANGE_RESULT",
+            payload: { id: "gpay-data-change-does-not-exist", amount: 9999 },
+          },
+        })
+      );
+    });
+
+    const pending = Promise.resolve(
+      callbacks.onPaymentDataChanged!({
+        callbackTrigger: "SHIPPING_ADDRESS",
+        shippingAddress: ADDRESS,
+      } as google.payments.api.IntermediatePaymentData)
+    );
+
+    const settled = await Promise.race([
+      pending.then(() => "resolved"),
+      new Promise((resolve) => setTimeout(() => resolve("pending"), 20)),
+    ]);
+
+    expect(settled).toBe("pending");
+  });
+});

--- a/packages/ui-components/test/GooglePay.test.tsx
+++ b/packages/ui-components/test/GooglePay.test.tsx
@@ -190,8 +190,11 @@ describe("GooglePay shipping data changes", () => {
    * Answers the frame's outgoing data-change message the way the host SDK
    * would, echoing back the id it was sent.
    */
-  function replyToDataChange(update: Record<string, unknown>) {
-    const postMessage = vi
+  function replyToDataChange(
+    update: Record<string, unknown> | Record<string, unknown>[]
+  ) {
+    const updates = Array.isArray(update) ? [...update] : [update];
+    return vi
       .spyOn(window.parent, "postMessage")
       .mockImplementation((message: unknown) => {
         const { type, payload } = message as {
@@ -203,12 +206,11 @@ describe("GooglePay shipping data changes", () => {
           new MessageEvent("message", {
             data: {
               type: "EV_GOOGLE_PAY_DATA_CHANGE_RESULT",
-              payload: { id: payload.id, ...update },
+              payload: { id: payload.id, ...(updates.shift() ?? {}) },
             },
           })
         );
       });
-    return postMessage;
   }
 
   it("sends the buyer's address to the host and applies the new total", async () => {
@@ -253,6 +255,33 @@ describe("GooglePay shipping data changes", () => {
     );
   });
 
+  it("preserves prior values across partial transaction updates", async () => {
+    await mountWithShipping();
+    replyToDataChange([
+      {
+        amount: 1500,
+        lineItems: [{ label: "Shipping", amount: 500 }],
+      },
+      { amount: 1800 },
+      { lineItems: [{ label: "Express", amount: 800 }] },
+    ]);
+    const change = () =>
+      callbacks.onPaymentDataChanged!({
+        callbackTrigger: "SHIPPING_OPTION",
+        shippingOptionData: { id: "express" },
+      } as google.payments.api.IntermediatePaymentData);
+
+    await change();
+    expect((await change()).newTransactionInfo).toMatchObject({
+      totalPrice: "18.00",
+      displayItems: [{ label: "Shipping", price: "5.00" }],
+    });
+    expect((await change()).newTransactionInfo).toMatchObject({
+      totalPrice: "18.00",
+      displayItems: [{ label: "Express", price: "8.00" }],
+    });
+  });
+
   it("returns no update when the merchant returns nothing", async () => {
     await mountWithShipping();
     replyToDataChange({});
@@ -265,7 +294,7 @@ describe("GooglePay shipping data changes", () => {
     expect(result).toEqual({});
   });
 
-  it("surfaces a merchant error as an inline sheet error", async () => {
+  it("surfaces an address error as an inline sheet error", async () => {
     await mountWithShipping();
     replyToDataChange({
       error: { message: "We do not ship there" },
@@ -280,6 +309,24 @@ describe("GooglePay shipping data changes", () => {
       reason: "SHIPPING_ADDRESS_UNSERVICEABLE",
       intent: "SHIPPING_ADDRESS",
       message: "We do not ship there",
+    });
+  });
+
+  it("uses a shipping-option error for an invalid option", async () => {
+    await mountWithShipping();
+    replyToDataChange({
+      error: { message: "That option is no longer available" },
+    });
+
+    const result = await callbacks.onPaymentDataChanged!({
+      callbackTrigger: "SHIPPING_OPTION",
+      shippingOptionData: { id: "express" },
+    } as google.payments.api.IntermediatePaymentData);
+
+    expect(result.error).toEqual({
+      reason: "SHIPPING_OPTION_INVALID",
+      intent: "SHIPPING_OPTION",
+      message: "That option is no longer available",
     });
   });
 

--- a/packages/ui-components/test/GooglePayRequest.test.ts
+++ b/packages/ui-components/test/GooglePayRequest.test.ts
@@ -42,17 +42,15 @@ describe("buildPaymentRequest shipping fields", () => {
   });
 
   it("passes address parameters through", () => {
-    expect(
-      build({
-        shippingAddress: {
-          allowedCountryCodes: ["US", "CA"],
-          phoneNumberRequired: true,
-        },
-      }).shippingAddressParameters
-    ).toEqual({
+    const shippingAddress = {
       allowedCountryCodes: ["US", "CA"],
       phoneNumberRequired: true,
-    });
+      format: "FULL-ISO3166" as const,
+    };
+
+    expect(build({ shippingAddress }).shippingAddressParameters).toEqual(
+      shippingAddress
+    );
   });
 
   it("makes options imply address collection", () => {

--- a/packages/ui-components/test/GooglePayRequest.test.ts
+++ b/packages/ui-components/test/GooglePayRequest.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildPaymentRequest,
+  callbackIntents,
+  shippingOptionParameters,
+} from "../src/GooglePay/utilities";
+import type { GooglePayConfig } from "../src/GooglePay/types";
+import type { MerchantDetail } from "types";
+
+const MERCHANT = { id: "merchant_abc", name: "Acme Co" } as MerchantDetail;
+
+const BASE_CONFIG: GooglePayConfig = {
+  transaction: {
+    type: "payment",
+    amount: 1000,
+    currency: "USD",
+    country: "US",
+    merchantId: "merchant_abc",
+    domain: "shop.example.com",
+  },
+  type: "plain",
+  color: "black",
+};
+
+const SHIPPING_OPTIONS = {
+  options: [
+    { id: "standard", label: "Standard", description: "3-5 days" },
+    { id: "express", label: "Express" },
+  ],
+};
+
+function build(config: Partial<GooglePayConfig> = {}) {
+  return buildPaymentRequest({ ...BASE_CONFIG, ...config }, MERCHANT);
+}
+
+describe("buildPaymentRequest shipping fields", () => {
+  it("omits every shipping field when shipping is not configured", () => {
+    const request = build();
+
+    expect(request).not.toHaveProperty("shippingAddressRequired");
+    expect(request).not.toHaveProperty("shippingAddressParameters");
+    expect(request).not.toHaveProperty("shippingOptionRequired");
+    expect(request).not.toHaveProperty("shippingOptionParameters");
+  });
+
+  it("requests an address with no restrictions for shippingAddress: true", () => {
+    const request = build({ shippingAddress: true });
+
+    expect(request.shippingAddressRequired).toBe(true);
+    expect(request.shippingAddressParameters).toEqual({});
+  });
+
+  it("passes allowedCountryCodes and phoneNumberRequired through", () => {
+    const request = build({
+      shippingAddress: {
+        allowedCountryCodes: ["US", "CA"],
+        phoneNumberRequired: true,
+      },
+    });
+
+    expect(request.shippingAddressParameters).toEqual({
+      allowedCountryCodes: ["US", "CA"],
+      phoneNumberRequired: true,
+    });
+  });
+
+  it("treats shippingAddress: false as no shipping", () => {
+    const request = build({ shippingAddress: false });
+
+    expect(request).not.toHaveProperty("shippingAddressRequired");
+  });
+
+  it("declares shipping options when they are configured", () => {
+    const request = build({
+      shippingAddress: true,
+      shippingOptions: SHIPPING_OPTIONS,
+    });
+
+    expect(request.shippingOptionRequired).toBe(true);
+    expect(request.shippingOptionParameters).toEqual({
+      shippingOptions: [
+        { id: "standard", label: "Standard", description: "3-5 days" },
+        { id: "express", label: "Express", description: "" },
+      ],
+    });
+  });
+
+  it("keeps a default selection when one is given", () => {
+    expect(
+      shippingOptionParameters({
+        ...SHIPPING_OPTIONS,
+        defaultSelectedOptionId: "express",
+      }).defaultSelectedOptionId
+    ).toBe("express");
+  });
+
+  it("omits defaultSelectedOptionId so Google's own default applies", () => {
+    expect(shippingOptionParameters(SHIPPING_OPTIONS)).not.toHaveProperty(
+      "defaultSelectedOptionId"
+    );
+  });
+});
+
+describe("callbackIntents", () => {
+  it("asks only for authorization when shipping is not configured", () => {
+    expect(callbackIntents(BASE_CONFIG)).toEqual(["PAYMENT_AUTHORIZATION"]);
+  });
+
+  it("adds SHIPPING_ADDRESS when an address is collected", () => {
+    expect(callbackIntents({ ...BASE_CONFIG, shippingAddress: true })).toEqual([
+      "SHIPPING_ADDRESS",
+      "PAYMENT_AUTHORIZATION",
+    ]);
+  });
+
+  it("adds SHIPPING_OPTION when options are offered", () => {
+    expect(
+      callbackIntents({
+        ...BASE_CONFIG,
+        shippingAddress: true,
+        shippingOptions: SHIPPING_OPTIONS,
+      })
+    ).toEqual(["SHIPPING_ADDRESS", "SHIPPING_OPTION", "PAYMENT_AUTHORIZATION"]);
+  });
+});

--- a/packages/ui-components/test/GooglePayRequest.test.ts
+++ b/packages/ui-components/test/GooglePayRequest.test.ts
@@ -2,13 +2,11 @@ import { describe, expect, it } from "vitest";
 import {
   buildPaymentRequest,
   callbackIntents,
-  shippingOptionParameters,
 } from "../src/GooglePay/utilities";
 import type { GooglePayConfig } from "../src/GooglePay/types";
 import type { MerchantDetail } from "types";
 
 const MERCHANT = { id: "merchant_abc", name: "Acme Co" } as MerchantDetail;
-
 const BASE_CONFIG: GooglePayConfig = {
   transaction: {
     type: "payment",
@@ -21,12 +19,12 @@ const BASE_CONFIG: GooglePayConfig = {
   type: "plain",
   color: "black",
 };
-
 const SHIPPING_OPTIONS = {
   options: [
     { id: "standard", label: "Standard", description: "3-5 days" },
     { id: "express", label: "Express" },
   ],
+  defaultSelectedOptionId: "express",
 };
 
 function build(config: Partial<GooglePayConfig> = {}) {
@@ -34,92 +32,54 @@ function build(config: Partial<GooglePayConfig> = {}) {
 }
 
 describe("buildPaymentRequest shipping fields", () => {
-  it("omits every shipping field when shipping is not configured", () => {
-    const request = build();
-
-    expect(request).not.toHaveProperty("shippingAddressRequired");
-    expect(request).not.toHaveProperty("shippingAddressParameters");
-    expect(request).not.toHaveProperty("shippingOptionRequired");
-    expect(request).not.toHaveProperty("shippingOptionParameters");
+  it("omits shipping when it is not configured", () => {
+    expect(build()).not.toEqual(
+      expect.objectContaining({
+        shippingAddressRequired: expect.anything(),
+        shippingOptionRequired: expect.anything(),
+      })
+    );
   });
 
-  it("requests an address with no restrictions for shippingAddress: true", () => {
-    const request = build({ shippingAddress: true });
-
-    expect(request.shippingAddressRequired).toBe(true);
-    expect(request.shippingAddressParameters).toEqual({});
-  });
-
-  it("passes allowedCountryCodes and phoneNumberRequired through", () => {
-    const request = build({
-      shippingAddress: {
-        allowedCountryCodes: ["US", "CA"],
-        phoneNumberRequired: true,
-      },
-    });
-
-    expect(request.shippingAddressParameters).toEqual({
+  it("passes address parameters through", () => {
+    expect(
+      build({
+        shippingAddress: {
+          allowedCountryCodes: ["US", "CA"],
+          phoneNumberRequired: true,
+        },
+      }).shippingAddressParameters
+    ).toEqual({
       allowedCountryCodes: ["US", "CA"],
       phoneNumberRequired: true,
     });
   });
 
-  it("treats shippingAddress: false as no shipping", () => {
-    const request = build({ shippingAddress: false });
-
-    expect(request).not.toHaveProperty("shippingAddressRequired");
-  });
-
-  it("declares shipping options when they are configured", () => {
-    const request = build({
-      shippingAddress: true,
-      shippingOptions: SHIPPING_OPTIONS,
-    });
-
-    expect(request.shippingOptionRequired).toBe(true);
-    expect(request.shippingOptionParameters).toEqual({
-      shippingOptions: [
-        { id: "standard", label: "Standard", description: "3-5 days" },
-        { id: "express", label: "Express", description: "" },
-      ],
-    });
-  });
-
-  it("keeps a default selection when one is given", () => {
-    expect(
-      shippingOptionParameters({
-        ...SHIPPING_OPTIONS,
+  it("makes options imply address collection", () => {
+    expect(build({ shippingOptions: SHIPPING_OPTIONS })).toMatchObject({
+      shippingAddressRequired: true,
+      shippingAddressParameters: {},
+      shippingOptionRequired: true,
+      shippingOptionParameters: {
+        shippingOptions: [
+          { id: "standard", label: "Standard", description: "3-5 days" },
+          { id: "express", label: "Express", description: "" },
+        ],
         defaultSelectedOptionId: "express",
-      }).defaultSelectedOptionId
-    ).toBe("express");
-  });
-
-  it("omits defaultSelectedOptionId so Google's own default applies", () => {
-    expect(shippingOptionParameters(SHIPPING_OPTIONS)).not.toHaveProperty(
-      "defaultSelectedOptionId"
-    );
+      },
+    });
   });
 });
 
 describe("callbackIntents", () => {
-  it("asks only for authorization when shipping is not configured", () => {
-    expect(callbackIntents(BASE_CONFIG)).toEqual(["PAYMENT_AUTHORIZATION"]);
-  });
-
-  it("adds SHIPPING_ADDRESS when an address is collected", () => {
-    expect(callbackIntents({ ...BASE_CONFIG, shippingAddress: true })).toEqual([
-      "SHIPPING_ADDRESS",
-      "PAYMENT_AUTHORIZATION",
-    ]);
-  });
-
-  it("adds SHIPPING_OPTION when options are offered", () => {
-    expect(
-      callbackIntents({
-        ...BASE_CONFIG,
-        shippingAddress: true,
-        shippingOptions: SHIPPING_OPTIONS,
-      })
-    ).toEqual(["SHIPPING_ADDRESS", "SHIPPING_OPTION", "PAYMENT_AUTHORIZATION"]);
+  it.each([
+    [{}, ["PAYMENT_AUTHORIZATION"]],
+    [{ shippingAddress: true }, ["SHIPPING_ADDRESS", "PAYMENT_AUTHORIZATION"]],
+    [
+      { shippingOptions: SHIPPING_OPTIONS },
+      ["SHIPPING_ADDRESS", "SHIPPING_OPTION", "PAYMENT_AUTHORIZATION"],
+    ],
+  ] as const)("derives intents from %o", (config, expected) => {
+    expect(callbackIntents({ ...BASE_CONFIG, ...config })).toEqual(expected);
   });
 });


### PR DESCRIPTION
Google Pay on web did not expose shipping fields and hardcoded `callbackIntents` to `["PAYMENT_AUTHORIZATION"]`. Merchants could not collect a shipping address, offer shipping options, or update an open payment sheet.

This adds `shippingAddress` and `shippingOptions` to the button configuration. Shipping options also enable address collection. Address and option callbacks receive the current shipping state and can return a synchronous or asynchronous partial update for the total, line items, or available options. A callback can instead return a typed Google Pay error.

Callbacks have a 10-second timeout. The SDK validates option IDs and defaults, correlates concurrent iframe replies, preserves partial updates within one sheet session, and resets them before the next session. `process()` receives the final `shippingAddress` and full `shippingOption`.

[CARD-1057](https://linear.app/evervault/issue/CARD-1057/b-google-pay-web-shipping-address-option-dynamic-price-updates)