### PR TITLE
Share the Apple Pay SDK load promise across ui.applePay() instances

### DIFF
--- a/.changeset/apple-pay-shared-sdk-load.md
+++ b/.changeset/apple-pay-shared-sdk-load.md
@@ -1,0 +1,5 @@
+---
+"@evervault/browser": patch
+---
+
+Fix `ApplePayButton.availability()` resolving to `"unsupported"` on a second `ui.applePay()` instance. Each instance kept its own SDK load promise and treated an already-present `<script>` tag as loaded, so an instance constructed after another saw the tag its sibling had just appended and probed before Apple's SDK had executed. The load promise is now shared across instances, an existing tag is only treated as ready once the SDK global is actually present, and a non-`"available"` result is no longer memoized so a later call can re-probe.

--- a/packages/browser/lib/ui/ApplePay/index.ts
+++ b/packages/browser/lib/ui/ApplePay/index.ts
@@ -31,6 +31,63 @@ import { Transaction } from "../../resources/transaction";
 const APPLE_PAY_SCRIPT_URL =
   "https://applepay.cdn-apple.com/jsapi/1.latest/apple-pay-sdk.js";
 
+const SCRIPT_LOAD_TIMEOUT = 10000;
+const EXISTING_SCRIPT_GRACE = 1000;
+
+const sdkLoadPromises = new WeakMap<HTMLScriptElement, Promise<void>>();
+
+function applePaySDKReady(): boolean {
+  return (
+    typeof ApplePaySession !== "undefined" &&
+    typeof ApplePaySession.applePayCapabilities === "function"
+  );
+}
+
+function waitForExistingScript(script: HTMLScriptElement): Promise<void> {
+  if (applePaySDKReady()) return Promise.resolve();
+
+  return new Promise((resolve) => {
+    // A tag that already executed never fires load again, so don't wait on it forever.
+    const grace = setTimeout(resolve, EXISTING_SCRIPT_GRACE);
+    script.addEventListener(
+      "load",
+      () => {
+        clearTimeout(grace);
+        resolve();
+      },
+      { once: true }
+    );
+  });
+}
+
+function loadApplePaySDK(): Promise<void> {
+  const existing = document.querySelector<HTMLScriptElement>(
+    `script[src="${APPLE_PAY_SCRIPT_URL}"]`
+  );
+
+  if (existing) {
+    const pending = sdkLoadPromises.get(existing);
+    if (pending) return pending;
+
+    const promise = waitForExistingScript(existing);
+    sdkLoadPromises.set(existing, promise);
+    return promise;
+  }
+
+  const script = document.createElement("script");
+  script.src = APPLE_PAY_SCRIPT_URL;
+  script.async = true;
+  script.crossOrigin = "anonymous";
+
+  const promise = new Promise<void>((resolve) => {
+    script.onload = () => resolve();
+  });
+
+  sdkLoadPromises.set(script, promise);
+  document.body.appendChild(script);
+  return promise;
+}
+
 export type ApplePayButtonOptions = {
   type?: ApplePayButtonType;
   style?: ApplePayButtonStyle;
@@ -146,9 +203,7 @@ export default class ApplePayButton {
   #button: HTMLElement | null = null;
   #options: ApplePayButtonOptions;
   #events = new EventManager<ApplePayEvents>();
-  #scriptLoaded = false;
   #scriptLoadPromise: Promise<void>;
-  #resolveScriptLoad!: () => void;
   #activeSession: PaymentRequest | null = null;
   #abortRequested = false;
   #sessionInProgress = false;
@@ -165,31 +220,7 @@ export default class ApplePayButton {
     this.client = client;
     this.#options = options;
     this.transaction = transaction;
-    this.#scriptLoadPromise = new Promise((resolve) => {
-      this.#resolveScriptLoad = resolve;
-    });
-    this.#injectScript();
-  }
-
-  #injectScript() {
-    const selector = `script[src="${APPLE_PAY_SCRIPT_URL}"]`;
-    const existing = document.querySelector(selector);
-    if (existing) {
-      this.#scriptLoaded = true;
-      this.#resolveScriptLoad();
-      return;
-    }
-
-    const script = document.createElement("script");
-    script.src = APPLE_PAY_SCRIPT_URL;
-    script.async = true;
-    script.crossOrigin = "anonymous";
-    script.onload = () => {
-      this.#scriptLoaded = true;
-      this.#resolveScriptLoad();
-    };
-
-    document.body.appendChild(script);
+    this.#scriptLoadPromise = loadApplePaySDK();
   }
 
   async #handleClick() {
@@ -428,14 +459,11 @@ export default class ApplePayButton {
   }
 
   async #waitForScript() {
-    if (this.#scriptLoaded) return;
-    const TIMEOUT = 10000;
-
     let timeoutId: ReturnType<typeof setTimeout>;
     const timeout = new Promise<never>((_, reject) => {
       timeoutId = setTimeout(() => {
         reject(new Error("Apple Pay SDK script load timeout"));
-      }, TIMEOUT);
+      }, SCRIPT_LOAD_TIMEOUT);
     });
 
     try {
@@ -455,11 +483,17 @@ export default class ApplePayButton {
    */
   async availability(): Promise<"available" | "unavailable" | "unsupported"> {
     if (!this.#availabilityPromise) {
-      this.#availabilityPromise = this.#computeAvailability().catch((error) => {
-        // Don't cache a failed probe — allow a later call to retry.
-        this.#availabilityPromise = null;
-        throw error;
-      });
+      this.#availabilityPromise = this.#computeAvailability().then(
+        (result) => {
+          // Only "available" is durable; a negative may be a premature probe, so keep it retryable.
+          if (result !== "available") this.#availabilityPromise = null;
+          return result;
+        },
+        (error) => {
+          this.#availabilityPromise = null;
+          throw error;
+        }
+      );
     }
 
     return this.#availabilityPromise;
@@ -471,10 +505,7 @@ export default class ApplePayButton {
     if (typeof window.PaymentRequest === "undefined") return "unsupported";
     await this.#waitForScript();
 
-    if (
-      typeof ApplePaySession === "undefined" ||
-      typeof ApplePaySession.applePayCapabilities !== "function"
-    ) {
+    if (!applePaySDKReady()) {
       return "unsupported";
     }
 

--- a/packages/browser/test/applePay.test.ts
+++ b/packages/browser/test/applePay.test.ts
@@ -1850,3 +1850,93 @@ describe("ApplePayButton.availability", () => {
     expect(ApplePaySession.applePayCapabilities).toHaveBeenCalledOnce();
   });
 });
+
+describe("ApplePayButton multiple instances", () => {
+  const scriptSelector =
+    'script[src="https://applepay.cdn-apple.com/jsapi/1.latest/apple-pay-sdk.js"]';
+
+  function stubAvailableApplePaySession() {
+    vi.stubGlobal("ApplePaySession", {
+      applePayCapabilities: vi.fn().mockResolvedValue({
+        paymentCredentialStatus: "paymentCredentialsAvailable",
+      }),
+    });
+  }
+
+  beforeEach(() => {
+    vi.stubGlobal("PaymentRequest", class PaymentRequest {});
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("resolves availability() on a second instance sharing the first instance's script tag", async () => {
+    const first = new ApplePayButton(createMockClient(), createTransaction(), {
+      process: vi.fn(),
+    });
+    const second = new ApplePayButton(createMockClient(), createTransaction(), {
+      process: vi.fn(),
+    });
+
+    const scripts =
+      document.querySelectorAll<HTMLScriptElement>(scriptSelector);
+    expect(scripts).toHaveLength(1);
+
+    const firstAvailability = first.availability();
+    const secondAvailability = second.availability();
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    stubAvailableApplePaySession();
+    scripts[0].dispatchEvent(new Event("load"));
+
+    await expect(firstAvailability).resolves.toBe("available");
+    await expect(secondAvailability).resolves.toBe("available");
+  });
+
+  it("does not cache an unsupported result, allowing a later call to re-probe", async () => {
+    const apple = new ApplePayButton(createMockClient(), createTransaction(), {
+      process: vi.fn(),
+    });
+
+    document
+      .querySelector<HTMLScriptElement>(scriptSelector)!
+      .dispatchEvent(new Event("load"));
+
+    await expect(apple.availability()).resolves.toBe("unsupported");
+
+    stubAvailableApplePaySession();
+
+    await expect(apple.availability()).resolves.toBe("available");
+    expect(ApplePaySession.applePayCapabilities).toHaveBeenCalledOnce();
+  });
+
+  it("stops waiting on a pre-existing script tag that never signals load", async () => {
+    vi.useFakeTimers();
+    try {
+      const script = document.createElement("script");
+      script.src =
+        "https://applepay.cdn-apple.com/jsapi/1.latest/apple-pay-sdk.js";
+      document.body.appendChild(script);
+
+      const apple = new ApplePayButton(
+        createMockClient(),
+        createTransaction(),
+        {
+          process: vi.fn(),
+        }
+      );
+
+      const assertion = expect(apple.availability()).resolves.toBe(
+        "unsupported"
+      );
+      await vi.advanceTimersByTimeAsync(1000);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
Closes CARD-1239. A second `ui.applePay()` instance on the same page probed Apple's SDK before it had executed and then memoized the resulting `"unsupported"` forever, so the express-checkout button never mounted — the load promise is now shared across instances rather than per-instance, and only `"available"` is cached.

Reported by a customer via solutions-engineering; it reached CDN users on Sep 2 when `js.evervault.com/v2` finally served 2.63.0.