### PR TITLE
fix(browser): share Apple Pay SDK load across instances

### DIFF
--- a/.changeset/apple-pay-credentials-error-handling.md
+++ b/.changeset/apple-pay-credentials-error-handling.md
@@ -1,5 +1,0 @@
----
-"@evervault/browser": patch
----
-
-Surface a failed Apple Pay credentials exchange on the `error` event instead of throwing an uncaught `TypeError` out of the click handler. `POST /frontend/apple-pay/credentials` responses are now checked for a non-2xx status and for missing card credentials, so an API failure reaches the merchant's error handler with the API's detail and status, and the Apple Pay sheet is completed as failed rather than left spinning until Apple times it out. Previously the error body was returned as if it were a successful exchange and the handler died on `card.displayName`, so no error event fired at all.

--- a/.changeset/apple-pay-credentials-error-handling.md
+++ b/.changeset/apple-pay-credentials-error-handling.md
@@ -1,0 +1,5 @@
+---
+"@evervault/browser": patch
+---
+
+Surface a failed Apple Pay credentials exchange on the `error` event instead of throwing an uncaught `TypeError` out of the click handler. `POST /frontend/apple-pay/credentials` responses are now checked for a non-2xx status and for missing card credentials, so an API failure reaches the merchant's error handler with the API's detail and status, and the Apple Pay sheet is completed as failed rather than left spinning until Apple times it out. Previously the error body was returned as if it were a successful exchange and the handler died on `card.displayName`, so no error event fired at all.

--- a/.changeset/apple-pay-shared-sdk-load.md
+++ b/.changeset/apple-pay-shared-sdk-load.md
@@ -1,0 +1,5 @@
+---
+"@evervault/browser": patch
+---
+
+Fix Apple Pay `availability()` permanently returning `"unsupported"` on every `ApplePayButton` after the first one on a page. The SDK script load is now shared across instances, so a later instance waits for Apple's script to execute instead of treating the first instance's `<script>` tag as already loaded, and a resolved `"unsupported"` is no longer memoized so a subsequent call re-probes. Affects pages that construct more than one button (an express-checkout button alongside the main one) on browsers where `ApplePaySession` is defined by Apple's injected SDK rather than natively — Chrome and Edge on macOS/iOS, in-app browsers, and older Safari.

--- a/.changeset/apple-pay-shared-sdk-load.md
+++ b/.changeset/apple-pay-shared-sdk-load.md
@@ -2,4 +2,4 @@
 "@evervault/browser": patch
 ---
 
-Fix Apple Pay `availability()` permanently returning `"unsupported"` on every `ApplePayButton` after the first one on a page. The SDK script load is now shared across instances, so a later instance waits for Apple's script to execute instead of treating the first instance's `<script>` tag as already loaded, and a resolved `"unsupported"` is no longer memoized so a subsequent call re-probes. Affects pages that construct more than one button (an express-checkout button alongside the main one) on browsers where `ApplePaySession` is defined by Apple's injected SDK rather than natively — Chrome and Edge on macOS/iOS, in-app browsers, and older Safari.
+Fix Apple Pay availability when multiple buttons are created before Apple's SDK loads. Also report failed Apple Pay credential exchanges through the `error` event and fail the payment sheet.

--- a/packages/browser/lib/ui/ApplePay/index.ts
+++ b/packages/browser/lib/ui/ApplePay/index.ts
@@ -31,6 +31,67 @@ import { Transaction } from "../../resources/transaction";
 const APPLE_PAY_SCRIPT_URL =
   "https://applepay.cdn-apple.com/jsapi/1.latest/apple-pay-sdk.js";
 
+const SCRIPT_LOAD_TIMEOUT = 10000;
+
+let sdkLoadPromise: Promise<void> | null = null;
+
+function loadApplePaySDK(): Promise<void> {
+  if (sdkLoadPromise) return sdkLoadPromise;
+
+  sdkLoadPromise = new Promise<void>((resolve, reject) => {
+    const existing = document.querySelector<HTMLScriptElement>(
+      `script[src="${APPLE_PAY_SCRIPT_URL}"]`
+    );
+
+    if (
+      existing &&
+      typeof ApplePaySession !== "undefined" &&
+      typeof ApplePaySession.applePayCapabilities === "function"
+    ) {
+      resolve();
+      return;
+    }
+
+    const script = existing ?? document.createElement("script");
+
+    const timeoutId = setTimeout(() => {
+      // A tag we did not inject may have finished loading before we listened,
+      // so its `load` never fires again — resolve and let the capability check
+      // decide, rather than failing a page that already has the SDK.
+      if (existing) {
+        resolve();
+        return;
+      }
+
+      sdkLoadPromise = null;
+      reject(new Error("Apple Pay SDK script load timeout"));
+    }, SCRIPT_LOAD_TIMEOUT);
+
+    script.addEventListener(
+      "load",
+      () => {
+        clearTimeout(timeoutId);
+        resolve();
+      },
+      { once: true }
+    );
+
+    if (!existing) {
+      script.src = APPLE_PAY_SCRIPT_URL;
+      script.async = true;
+      script.crossOrigin = "anonymous";
+      document.body.appendChild(script);
+    }
+  });
+
+  return sdkLoadPromise;
+}
+
+/** Test-only: drops the shared SDK load so each test case starts clean. */
+export function resetApplePaySDKLoader() {
+  sdkLoadPromise = null;
+}
+
 type ApiErrorBody = { detail?: string; title?: string };
 
 async function credentialsFailureMessage(res: Response): Promise<string> {
@@ -157,9 +218,6 @@ export default class ApplePayButton {
   #button: HTMLElement | null = null;
   #options: ApplePayButtonOptions;
   #events = new EventManager<ApplePayEvents>();
-  #scriptLoaded = false;
-  #scriptLoadPromise: Promise<void>;
-  #resolveScriptLoad!: () => void;
   #activeSession: PaymentRequest | null = null;
   #abortRequested = false;
   #sessionInProgress = false;
@@ -176,31 +234,8 @@ export default class ApplePayButton {
     this.client = client;
     this.#options = options;
     this.transaction = transaction;
-    this.#scriptLoadPromise = new Promise((resolve) => {
-      this.#resolveScriptLoad = resolve;
-    });
-    this.#injectScript();
-  }
-
-  #injectScript() {
-    const selector = `script[src="${APPLE_PAY_SCRIPT_URL}"]`;
-    const existing = document.querySelector(selector);
-    if (existing) {
-      this.#scriptLoaded = true;
-      this.#resolveScriptLoad();
-      return;
-    }
-
-    const script = document.createElement("script");
-    script.src = APPLE_PAY_SCRIPT_URL;
-    script.async = true;
-    script.crossOrigin = "anonymous";
-    script.onload = () => {
-      this.#scriptLoaded = true;
-      this.#resolveScriptLoad();
-    };
-
-    document.body.appendChild(script);
+    // Start the shared load now; availability() awaits it and surfaces failures.
+    void loadApplePaySDK().catch(() => {});
   }
 
   async #handleClick() {
@@ -451,24 +486,6 @@ export default class ApplePayButton {
     this.#abortRequested = true;
   }
 
-  async #waitForScript() {
-    if (this.#scriptLoaded) return;
-    const TIMEOUT = 10000;
-
-    let timeoutId: ReturnType<typeof setTimeout>;
-    const timeout = new Promise<never>((_, reject) => {
-      timeoutId = setTimeout(() => {
-        reject(new Error("Apple Pay SDK script load timeout"));
-      }, TIMEOUT);
-    });
-
-    try {
-      await Promise.race([this.#scriptLoadPromise, timeout]);
-    } finally {
-      clearTimeout(timeoutId!);
-    }
-  }
-
   /**
    * Checks the availability of Apple Pay on the current device.
    *
@@ -479,11 +496,21 @@ export default class ApplePayButton {
    */
   async availability(): Promise<"available" | "unavailable" | "unsupported"> {
     if (!this.#availabilityPromise) {
-      this.#availabilityPromise = this.#computeAvailability().catch((error) => {
-        // Don't cache a failed probe — allow a later call to retry.
-        this.#availabilityPromise = null;
-        throw error;
-      });
+      this.#availabilityPromise = this.#computeAvailability()
+        .then((result) => {
+          // "unsupported" can just mean the SDK has not defined
+          // ApplePaySession yet — don't cache it, so a later call re-probes.
+          if (result === "unsupported") {
+            this.#availabilityPromise = null;
+          }
+
+          return result;
+        })
+        .catch((error) => {
+          // Don't cache a failed probe — allow a later call to retry.
+          this.#availabilityPromise = null;
+          throw error;
+        });
     }
 
     return this.#availabilityPromise;
@@ -493,7 +520,7 @@ export default class ApplePayButton {
     "available" | "unavailable" | "unsupported"
   > {
     if (typeof window.PaymentRequest === "undefined") return "unsupported";
-    await this.#waitForScript();
+    await loadApplePaySDK();
 
     if (
       typeof ApplePaySession === "undefined" ||

--- a/packages/browser/lib/ui/ApplePay/index.ts
+++ b/packages/browser/lib/ui/ApplePay/index.ts
@@ -31,6 +31,17 @@ import { Transaction } from "../../resources/transaction";
 const APPLE_PAY_SCRIPT_URL =
   "https://applepay.cdn-apple.com/jsapi/1.latest/apple-pay-sdk.js";
 
+type ApiErrorBody = { detail?: string; title?: string };
+
+async function credentialsFailureMessage(res: Response): Promise<string> {
+  const [body] = await tryCatch<ApiErrorBody>(res.json());
+  const detail = body?.detail ?? body?.title;
+
+  return detail
+    ? `Apple Pay credentials exchange failed (${res.status}): ${detail}`
+    : `Apple Pay credentials exchange failed (${res.status})`;
+}
+
 export type ApplePayButtonOptions = {
   type?: ApplePayButtonType;
   style?: ApplePayButtonStyle;
@@ -269,6 +280,7 @@ export default class ApplePayButton {
 
       if (encryptedError) {
         this.#events.dispatch("error", encryptedError.message);
+        await response.complete("fail");
         return;
       }
 
@@ -385,7 +397,19 @@ export default class ApplePayButton {
       body: JSON.stringify(requestBody),
     });
 
-    return res.json();
+    if (!res.ok) {
+      throw new Error(await credentialsFailureMessage(res));
+    }
+
+    const [encrypted] = await tryCatch<EncryptedApplePayData>(res.json());
+
+    if (!encrypted?.card) {
+      throw new Error(
+        "Apple Pay credentials exchange returned no card credentials"
+      );
+    }
+
+    return encrypted;
   }
 
   on(

--- a/packages/browser/lib/ui/ApplePay/index.ts
+++ b/packages/browser/lib/ui/ApplePay/index.ts
@@ -52,7 +52,7 @@ function isApplePayButtonDefined() {
 function loadApplePaySDK(): Promise<void> {
   if (sdkLoadPromise) return sdkLoadPromise;
 
-  sdkLoadPromise = new Promise<void>((resolve, reject) => {
+  const loadPromise = new Promise<void>((resolve, reject) => {
     const existing = document.querySelector<HTMLScriptElement>(
       `script[src="${APPLE_PAY_SCRIPT_URL}"]`
     );
@@ -63,36 +63,46 @@ function loadApplePaySDK(): Promise<void> {
     }
 
     const script = existing ?? document.createElement("script");
-
+    const fail = (error: Error) => {
+      clearTimeout(timeoutId);
+      script.removeEventListener("load", onLoad);
+      script.removeEventListener("error", onError);
+      if (!existing) script.remove();
+      reject(error);
+    };
+    const onLoad = () => {
+      clearTimeout(timeoutId);
+      script.removeEventListener("error", onError);
+      resolve();
+    };
+    const onError = () => fail(new Error("Apple Pay SDK script load failed"));
     const timeoutId = setTimeout(() => {
-      // An existing script may have loaded before this listener was attached.
-      if (existing) {
+      if (isApplePayButtonDefined()) {
         resolve();
         return;
       }
 
-      sdkLoadPromise = null;
-      reject(new Error("Apple Pay SDK script load timeout"));
+      fail(new Error("Apple Pay SDK script load timeout"));
     }, SCRIPT_LOAD_TIMEOUT);
 
-    script.addEventListener(
-      "load",
-      () => {
-        clearTimeout(timeoutId);
-        resolve();
-      },
-      { once: true }
-    );
+    script.addEventListener("load", onLoad, { once: true });
+    script.addEventListener("error", onError, { once: true });
 
     if (!existing) {
       script.src = APPLE_PAY_SCRIPT_URL;
       script.async = true;
       script.crossOrigin = "anonymous";
-      document.body.appendChild(script);
+      document.head.appendChild(script);
     }
   });
 
-  return sdkLoadPromise;
+  const sharedPromise = loadPromise.catch((error) => {
+    if (sdkLoadPromise === sharedPromise) sdkLoadPromise = null;
+    throw error;
+  });
+  sdkLoadPromise = sharedPromise;
+
+  return sharedPromise;
 }
 
 /** Test-only: drops the shared SDK load so each test is isolated */

--- a/packages/browser/lib/ui/ApplePay/index.ts
+++ b/packages/browser/lib/ui/ApplePay/index.ts
@@ -87,7 +87,7 @@ function loadApplePaySDK(): Promise<void> {
   return sdkLoadPromise;
 }
 
-/** Test-only: drops the shared SDK load so each test case starts clean. */
+/** Test-only: drops the shared SDK load so each test is isolated */
 export function resetApplePaySDKLoader() {
   sdkLoadPromise = null;
 }

--- a/packages/browser/lib/ui/ApplePay/index.ts
+++ b/packages/browser/lib/ui/ApplePay/index.ts
@@ -35,6 +35,20 @@ const SCRIPT_LOAD_TIMEOUT = 10000;
 
 let sdkLoadPromise: Promise<void> | null = null;
 
+function isApplePaySDKReady() {
+  return (
+    typeof ApplePaySession !== "undefined" &&
+    typeof ApplePaySession.applePayCapabilities === "function"
+  );
+}
+
+function isApplePayButtonDefined() {
+  return (
+    typeof customElements !== "undefined" &&
+    customElements.get("apple-pay-button") !== undefined
+  );
+}
+
 function loadApplePaySDK(): Promise<void> {
   if (sdkLoadPromise) return sdkLoadPromise;
 
@@ -43,11 +57,7 @@ function loadApplePaySDK(): Promise<void> {
       `script[src="${APPLE_PAY_SCRIPT_URL}"]`
     );
 
-    if (
-      existing &&
-      typeof ApplePaySession !== "undefined" &&
-      typeof ApplePaySession.applePayCapabilities === "function"
-    ) {
+    if (existing && isApplePayButtonDefined()) {
       resolve();
       return;
     }
@@ -498,9 +508,9 @@ export default class ApplePayButton {
     if (!this.#availabilityPromise) {
       this.#availabilityPromise = this.#computeAvailability()
         .then((result) => {
-          // "unsupported" can just mean the SDK has not defined
-          // ApplePaySession yet — don't cache it, so a later call re-probes.
-          if (result === "unsupported") {
+          // The SDK may not have defined ApplePaySession yet. Do not cache
+          // this ambiguous result, so a later call can re-probe.
+          if (result === "unsupported" && !isApplePaySDKReady()) {
             this.#availabilityPromise = null;
           }
 
@@ -520,7 +530,7 @@ export default class ApplePayButton {
     "available" | "unavailable" | "unsupported"
   > {
     if (typeof window.PaymentRequest === "undefined") return "unsupported";
-    await loadApplePaySDK();
+    if (!isApplePaySDKReady()) await loadApplePaySDK();
 
     if (
       typeof ApplePaySession === "undefined" ||
@@ -560,6 +570,8 @@ export default class ApplePayButton {
     if (availability === "unavailable") {
       console.info("Apple Pay may be unavailable on this device.");
     }
+
+    await loadApplePaySDK();
 
     const element = resolveSelector(selector);
     this.#button = document.createElement("apple-pay-button");

--- a/packages/browser/lib/ui/ApplePay/index.ts
+++ b/packages/browser/lib/ui/ApplePay/index.ts
@@ -65,9 +65,7 @@ function loadApplePaySDK(): Promise<void> {
     const script = existing ?? document.createElement("script");
 
     const timeoutId = setTimeout(() => {
-      // A tag we did not inject may have finished loading before we listened,
-      // so its `load` never fires again — resolve and let the capability check
-      // decide, rather than failing a page that already has the SDK.
+      // An existing script may have loaded before this listener was attached.
       if (existing) {
         resolve();
         return;
@@ -244,7 +242,6 @@ export default class ApplePayButton {
     this.client = client;
     this.#options = options;
     this.transaction = transaction;
-    // Start the shared load now; availability() awaits it and surfaces failures.
     void loadApplePaySDK().catch(() => {});
   }
 

--- a/packages/browser/test/applePay.test.ts
+++ b/packages/browser/test/applePay.test.ts
@@ -1744,6 +1744,148 @@ describe("ApplePayButton process() payload", () => {
   });
 });
 
+describe("ApplePayButton credentials exchange", () => {
+  function createSessionWithResponse() {
+    const response = {
+      details: {
+        token: {
+          paymentData: {},
+          paymentMethod: { displayName: "Visa 1234", type: "credit" },
+        },
+      },
+      complete: vi.fn().mockResolvedValue(undefined),
+    };
+
+    return {
+      response,
+      session: { show: vi.fn().mockResolvedValue(response), abort: vi.fn() },
+    };
+  }
+
+  function mountButton() {
+    const { response, session } = createSessionWithResponse();
+    buildSessionMock.mockResolvedValue(session);
+
+    const error = vi.fn();
+    const process = vi.fn().mockResolvedValue(undefined);
+    const apple = new ApplePayButton(createMockClient(), createTransaction(), {
+      process,
+    });
+    apple.on("error", error);
+
+    return { apple, error, process, response };
+  }
+
+  beforeEach(() => {
+    buildSessionMock.mockReset();
+    vi.spyOn(applePayUtilities, "buildSession").mockImplementation(
+      buildSessionMock
+    );
+
+    vi.stubGlobal("PaymentRequest", class PaymentRequest {});
+
+    vi.stubGlobal("ApplePaySession", {
+      applePayCapabilities: vi.fn().mockResolvedValue({
+        paymentCredentialStatus: "paymentCredentialsAvailable",
+      }),
+    });
+
+    const script = document.createElement("script");
+    script.src =
+      "https://applepay.cdn-apple.com/jsapi/1.latest/apple-pay-sdk.js";
+    document.body.appendChild(script);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("dispatches error and fails the sheet when the exchange returns a non-2xx", async () => {
+    server.use(
+      http.post(`${apiUrl}/frontend/apple-pay/credentials`, () =>
+        HttpResponse.json(
+          {
+            code: "internal-error",
+            title: "Internal Error",
+            detail: "Unable to decrypt the payment token",
+          },
+          { status: 500 }
+        )
+      )
+    );
+
+    const { apple, error, process, response } = mountButton();
+
+    await clickApplePayButton(apple);
+
+    await vi.waitFor(() => expect(error).toHaveBeenCalledOnce());
+    expect(error).toHaveBeenCalledWith(
+      "Apple Pay credentials exchange failed (500): Unable to decrypt the payment token"
+    );
+    expect(process).not.toHaveBeenCalled();
+    expect(response.complete).toHaveBeenCalledOnce();
+    expect(response.complete).toHaveBeenCalledWith("fail");
+  });
+
+  it("falls back to the status when the error body carries no detail", async () => {
+    server.use(
+      http.post(
+        `${apiUrl}/frontend/apple-pay/credentials`,
+        () => new HttpResponse(null, { status: 502 })
+      )
+    );
+
+    const { apple, error, process } = mountButton();
+
+    await clickApplePayButton(apple);
+
+    await vi.waitFor(() => expect(error).toHaveBeenCalledOnce());
+    expect(error).toHaveBeenCalledWith(
+      "Apple Pay credentials exchange failed (502)"
+    );
+    expect(process).not.toHaveBeenCalled();
+  });
+
+  it("dispatches error when a 200 response carries no card credentials", async () => {
+    server.use(
+      http.post(`${apiUrl}/frontend/apple-pay/credentials`, () =>
+        HttpResponse.json({})
+      )
+    );
+
+    const { apple, error, process, response } = mountButton();
+
+    await clickApplePayButton(apple);
+
+    await vi.waitFor(() => expect(error).toHaveBeenCalledOnce());
+    expect(error).toHaveBeenCalledWith(
+      "Apple Pay credentials exchange returned no card credentials"
+    );
+    expect(process).not.toHaveBeenCalled();
+    expect(response.complete).toHaveBeenCalledOnce();
+    expect(response.complete).toHaveBeenCalledWith("fail");
+  });
+
+  it("completes the sheet successfully when the exchange succeeds", async () => {
+    server.use(
+      http.post(`${apiUrl}/frontend/apple-pay/credentials`, () =>
+        HttpResponse.json({ card: {} })
+      )
+    );
+
+    const { apple, error, process, response } = mountButton();
+
+    await clickApplePayButton(apple);
+
+    await vi.waitFor(() => expect(process).toHaveBeenCalledOnce());
+    expect(error).not.toHaveBeenCalled();
+    expect(response.complete).toHaveBeenCalledOnce();
+    expect(response.complete).toHaveBeenCalledWith("success");
+  });
+});
+
 describe("ApplePayButton.availability", () => {
   function stubApplePaySession(
     capabilities:

--- a/packages/browser/test/applePay.test.ts
+++ b/packages/browser/test/applePay.test.ts
@@ -1393,6 +1393,11 @@ function createMockSession() {
 async function clickApplePayButton(apple: ApplePayButton) {
   const container = document.createElement("div");
   document.body.appendChild(container);
+  document
+    .querySelector<HTMLScriptElement>(
+      'script[src="https://applepay.cdn-apple.com/jsapi/1.latest/apple-pay-sdk.js"]'
+    )
+    ?.dispatchEvent(new Event("load"));
   await apple.mount(container);
   const button = container.querySelector("apple-pay-button");
   button?.dispatchEvent(new Event("click"));
@@ -1414,32 +1419,60 @@ describe("ApplePayButton script loading", () => {
     vi.unstubAllGlobals();
   });
 
-  it("resolves availability() as soon as the SDK script's onload fires, without polling", async () => {
+  it("resolves availability() before the SDK loads when its capability API is ready", async () => {
     const apple = new ApplePayButton(createMockClient(), createTransaction(), {
       process: vi.fn(),
     });
 
+    await expect(apple.availability()).resolves.toBe("available");
     const script = document.querySelector<HTMLScriptElement>(
       'script[src="https://applepay.cdn-apple.com/jsapi/1.latest/apple-pay-sdk.js"]'
     );
     expect(script).not.toBeNull();
+    script!.dispatchEvent(new Event("load"));
+  });
 
-    let resolved = false;
-    const availabilityPromise = apple.availability().then((result) => {
-      resolved = true;
-      return result;
+  it("waits for the SDK before mounting a button when its capability API is ready", async () => {
+    const apple = new ApplePayButton(createMockClient(), createTransaction(), {
+      process: vi.fn(),
     });
+    const container = document.createElement("div");
+    document.body.appendChild(container);
 
+    const mountPromise = apple.mount(container);
     await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(resolved).toBe(false);
+    expect(container.querySelector("apple-pay-button")).toBeNull();
 
+    const script = document.querySelector<HTMLScriptElement>(
+      'script[src="https://applepay.cdn-apple.com/jsapi/1.latest/apple-pay-sdk.js"]'
+    );
     script!.dispatchEvent(new Event("load"));
 
-    await expect(availabilityPromise).resolves.toBe("available");
-    expect(resolved).toBe(true);
+    await mountPromise;
+    expect(container.querySelector("apple-pay-button")).not.toBeNull();
+  });
+
+  it("mounts without waiting when a merchant-loaded SDK defined the button", async () => {
+    const script = document.createElement("script");
+    script.src =
+      "https://applepay.cdn-apple.com/jsapi/1.latest/apple-pay-sdk.js";
+    document.body.appendChild(script);
+    vi.stubGlobal("customElements", {
+      get: vi.fn().mockReturnValue(class ApplePayButtonElement {}),
+    });
+
+    const apple = new ApplePayButton(createMockClient(), createTransaction(), {
+      process: vi.fn(),
+    });
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+
+    await apple.mount(container);
+    expect(container.querySelector("apple-pay-button")).not.toBeNull();
   });
 
   it("rejects with a timeout error if the SDK script never loads", async () => {
+    vi.stubGlobal("ApplePaySession", undefined);
     vi.useFakeTimers();
     try {
       const apple = new ApplePayButton(
@@ -1988,6 +2021,18 @@ describe("ApplePayButton.availability", () => {
     expect(ApplePaySession.applePayCapabilities).toHaveBeenCalledOnce();
   });
 
+  it("caches a genuine unsupported capability result", async () => {
+    stubApplePaySession({ paymentCredentialStatus: "applePayUnsupported" });
+
+    const apple = new ApplePayButton(createMockClient(), createTransaction(), {
+      process: vi.fn(),
+    });
+
+    await expect(apple.availability()).resolves.toBe("unsupported");
+    await expect(apple.availability()).resolves.toBe("unsupported");
+    expect(ApplePaySession.applePayCapabilities).toHaveBeenCalledOnce();
+  });
+
   it("only calls applePayCapabilities once when availability() is followed by mount()", async () => {
     const apple = new ApplePayButton(createMockClient(), createTransaction(), {
       process: vi.fn(),
@@ -1997,6 +2042,11 @@ describe("ApplePayButton.availability", () => {
 
     const container = document.createElement("div");
     document.body.appendChild(container);
+    document
+      .querySelector<HTMLScriptElement>(
+        'script[src="https://applepay.cdn-apple.com/jsapi/1.latest/apple-pay-sdk.js"]'
+      )
+      ?.dispatchEvent(new Event("load"));
     await apple.mount(container);
 
     expect(ApplePaySession.applePayCapabilities).toHaveBeenCalledOnce();

--- a/packages/browser/test/applePay.test.ts
+++ b/packages/browser/test/applePay.test.ts
@@ -33,6 +33,8 @@ const apiUrl = "https://api.test.evervault.com";
 const app = "app_test123";
 const merchantId = "merchant_abc";
 const merchantName = "Acme Co";
+const applePaySDKSelector =
+  'script[src="https://applepay.cdn-apple.com/jsapi/1.latest/apple-pay-sdk.js"]';
 
 const paymentRequestCalls: ApplePayPaymentDetailsInit[] = [];
 const paymentMethodDataCalls: Array<{
@@ -1390,14 +1392,16 @@ function createMockSession() {
   };
 }
 
+function dispatchApplePaySDKLoad() {
+  document
+    .querySelector<HTMLScriptElement>(applePaySDKSelector)
+    ?.dispatchEvent(new Event("load"));
+}
+
 async function clickApplePayButton(apple: ApplePayButton) {
   const container = document.createElement("div");
   document.body.appendChild(container);
-  document
-    .querySelector<HTMLScriptElement>(
-      'script[src="https://applepay.cdn-apple.com/jsapi/1.latest/apple-pay-sdk.js"]'
-    )
-    ?.dispatchEvent(new Event("load"));
+  dispatchApplePaySDKLoad();
   await apple.mount(container);
   const button = container.querySelector("apple-pay-button");
   button?.dispatchEvent(new Event("click"));
@@ -1426,10 +1430,10 @@ describe("ApplePayButton script loading", () => {
 
     await expect(apple.availability()).resolves.toBe("available");
     const script = document.querySelector<HTMLScriptElement>(
-      'script[src="https://applepay.cdn-apple.com/jsapi/1.latest/apple-pay-sdk.js"]'
+      applePaySDKSelector
     );
     expect(script).not.toBeNull();
-    script!.dispatchEvent(new Event("load"));
+    dispatchApplePaySDKLoad();
   });
 
   it("waits for the SDK before mounting a button when its capability API is ready", async () => {
@@ -1443,10 +1447,7 @@ describe("ApplePayButton script loading", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(container.querySelector("apple-pay-button")).toBeNull();
 
-    const script = document.querySelector<HTMLScriptElement>(
-      'script[src="https://applepay.cdn-apple.com/jsapi/1.latest/apple-pay-sdk.js"]'
-    );
-    script!.dispatchEvent(new Event("load"));
+    dispatchApplePaySDKLoad();
 
     await mountPromise;
     expect(container.querySelector("apple-pay-button")).not.toBeNull();
@@ -1514,7 +1515,7 @@ describe("ApplePayButton script loading", () => {
     expect(resolved).toBe(false);
 
     const script = document.querySelector<HTMLScriptElement>(
-      'script[src="https://applepay.cdn-apple.com/jsapi/1.latest/apple-pay-sdk.js"]'
+      applePaySDKSelector
     );
     expect(script).not.toBeNull();
 
@@ -1523,7 +1524,7 @@ describe("ApplePayButton script loading", () => {
         paymentCredentialStatus: "paymentCredentialsAvailable",
       }),
     });
-    script!.dispatchEvent(new Event("load"));
+    dispatchApplePaySDKLoad();
 
     await expect(availabilityPromise).resolves.toBe("available");
   });
@@ -2042,11 +2043,7 @@ describe("ApplePayButton.availability", () => {
 
     const container = document.createElement("div");
     document.body.appendChild(container);
-    document
-      .querySelector<HTMLScriptElement>(
-        'script[src="https://applepay.cdn-apple.com/jsapi/1.latest/apple-pay-sdk.js"]'
-      )
-      ?.dispatchEvent(new Event("load"));
+    dispatchApplePaySDKLoad();
     await apple.mount(container);
 
     expect(ApplePaySession.applePayCapabilities).toHaveBeenCalledOnce();

--- a/packages/browser/test/applePay.test.ts
+++ b/packages/browser/test/applePay.test.ts
@@ -1429,9 +1429,8 @@ describe("ApplePayButton script loading", () => {
     });
 
     await expect(apple.availability()).resolves.toBe("available");
-    const script = document.querySelector<HTMLScriptElement>(
-      applePaySDKSelector
-    );
+    const script =
+      document.querySelector<HTMLScriptElement>(applePaySDKSelector);
     expect(script).not.toBeNull();
     dispatchApplePaySDKLoad();
   });
@@ -1514,9 +1513,8 @@ describe("ApplePayButton script loading", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(resolved).toBe(false);
 
-    const script = document.querySelector<HTMLScriptElement>(
-      applePaySDKSelector
-    );
+    const script =
+      document.querySelector<HTMLScriptElement>(applePaySDKSelector);
     expect(script).not.toBeNull();
 
     vi.stubGlobal("ApplePaySession", {

--- a/packages/browser/test/applePay.test.ts
+++ b/packages/browser/test/applePay.test.ts
@@ -165,6 +165,9 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  document.querySelectorAll(applePaySDKSelector).forEach((script) => {
+    script.remove();
+  });
   server.resetHandlers();
 });
 
@@ -1469,6 +1472,80 @@ describe("ApplePayButton script loading", () => {
 
     await apple.mount(container);
     expect(container.querySelector("apple-pay-button")).not.toBeNull();
+  });
+
+  it("rejects after an existing SDK script fails to load", async () => {
+    vi.stubGlobal("ApplePaySession", undefined);
+    vi.useFakeTimers();
+    try {
+      const script = document.createElement("script");
+      script.src =
+        "https://applepay.cdn-apple.com/jsapi/1.latest/apple-pay-sdk.js";
+      document.head.appendChild(script);
+      const apple = new ApplePayButton(
+        createMockClient(),
+        createTransaction(),
+        { process: vi.fn() }
+      );
+
+      const assertion = expect(apple.availability()).rejects.toThrow(
+        "Apple Pay SDK script load timeout"
+      );
+
+      await vi.advanceTimersByTimeAsync(10000);
+      await assertion;
+      expect(script.isConnected).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("removes a failed SDK script and allows a later retry", async () => {
+    vi.stubGlobal("ApplePaySession", undefined);
+    const first = new ApplePayButton(createMockClient(), createTransaction(), {
+      process: vi.fn(),
+    });
+
+    const firstScript = document.querySelector<HTMLScriptElement>(
+      applePaySDKSelector
+    );
+    firstScript!.dispatchEvent(new Event("error"));
+
+    await expect(first.availability()).rejects.toThrow(
+      "Apple Pay SDK script load failed"
+    );
+    expect(document.querySelector(applePaySDKSelector)).toBeNull();
+
+    vi.stubGlobal("ApplePaySession", {
+      applePayCapabilities: vi.fn().mockResolvedValue({
+        paymentCredentialStatus: "paymentCredentialsAvailable",
+      }),
+    });
+    const second = new ApplePayButton(
+      createMockClient(),
+      createTransaction(),
+      { process: vi.fn() }
+    );
+
+    await expect(second.availability()).resolves.toBe("available");
+    dispatchApplePaySDKLoad();
+  });
+
+  it("loads the SDK when constructed before document.body exists", () => {
+    vi.stubGlobal("ApplePaySession", undefined);
+    const body = document.body;
+    body.remove();
+
+    try {
+      new ApplePayButton(createMockClient(), createTransaction(), {
+        process: vi.fn(),
+      });
+
+      expect(document.head.querySelector(applePaySDKSelector)).not.toBeNull();
+    } finally {
+      document.documentElement.appendChild(body);
+      dispatchApplePaySDKLoad();
+    }
   });
 
   it("rejects with a timeout error if the SDK script never loads", async () => {

--- a/packages/browser/test/applePay.test.ts
+++ b/packages/browser/test/applePay.test.ts
@@ -1506,9 +1506,8 @@ describe("ApplePayButton script loading", () => {
       process: vi.fn(),
     });
 
-    const firstScript = document.querySelector<HTMLScriptElement>(
-      applePaySDKSelector
-    );
+    const firstScript =
+      document.querySelector<HTMLScriptElement>(applePaySDKSelector);
     firstScript!.dispatchEvent(new Event("error"));
 
     await expect(first.availability()).rejects.toThrow(
@@ -1521,11 +1520,9 @@ describe("ApplePayButton script loading", () => {
         paymentCredentialStatus: "paymentCredentialsAvailable",
       }),
     });
-    const second = new ApplePayButton(
-      createMockClient(),
-      createTransaction(),
-      { process: vi.fn() }
-    );
+    const second = new ApplePayButton(createMockClient(), createTransaction(), {
+      process: vi.fn(),
+    });
 
     await expect(second.availability()).resolves.toBe("available");
     dispatchApplePaySDKLoad();

--- a/packages/browser/test/applePay.test.ts
+++ b/packages/browser/test/applePay.test.ts
@@ -13,7 +13,7 @@ import {
 } from "vitest";
 import * as applePayUtilities from "../lib/ui/ApplePay/utilities";
 import type { ApplePayMerchantCapability } from "types";
-import ApplePayButton from "../lib/ui/ApplePay";
+import ApplePayButton, { resetApplePaySDKLoader } from "../lib/ui/ApplePay";
 import { Transaction } from "../lib/resources/transaction";
 import type EvervaultClient from "../lib/main";
 import { setupCrypto } from "./setup";
@@ -150,6 +150,7 @@ beforeAll(() => {
 });
 
 beforeEach(() => {
+  resetApplePaySDKLoader();
   paymentRequestCalls.length = 0;
   paymentMethodDataCalls.length = 0;
   paymentOptionsCalls.length = 0;
@@ -1456,6 +1457,62 @@ describe("ApplePayButton script loading", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("resolves availability() on a second instance once the shared script loads", async () => {
+    vi.stubGlobal("ApplePaySession", undefined);
+
+    const buttons = [
+      new ApplePayButton(createMockClient(), createTransaction(), {
+        process: vi.fn(),
+      }),
+      new ApplePayButton(createMockClient(), createTransaction(), {
+        process: vi.fn(),
+      }),
+    ];
+
+    let resolved = false;
+    const availabilityPromise = buttons[1].availability().then((result) => {
+      resolved = true;
+      return result;
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(resolved).toBe(false);
+
+    const script = document.querySelector<HTMLScriptElement>(
+      'script[src="https://applepay.cdn-apple.com/jsapi/1.latest/apple-pay-sdk.js"]'
+    );
+    expect(script).not.toBeNull();
+
+    vi.stubGlobal("ApplePaySession", {
+      applePayCapabilities: vi.fn().mockResolvedValue({
+        paymentCredentialStatus: "paymentCredentialsAvailable",
+      }),
+    });
+    script!.dispatchEvent(new Event("load"));
+
+    await expect(availabilityPromise).resolves.toBe("available");
+  });
+
+  it("injects a single SDK script tag for multiple instances", () => {
+    vi.stubGlobal("ApplePaySession", undefined);
+
+    const buttons = [
+      new ApplePayButton(createMockClient(), createTransaction(), {
+        process: vi.fn(),
+      }),
+      new ApplePayButton(createMockClient(), createTransaction(), {
+        process: vi.fn(),
+      }),
+    ];
+
+    expect(buttons).toHaveLength(2);
+    expect(
+      document.querySelectorAll(
+        'script[src="https://applepay.cdn-apple.com/jsapi/1.latest/apple-pay-sdk.js"]'
+      )
+    ).toHaveLength(1);
   });
 });
 


### PR DESCRIPTION

# Why

**Before:** Creating two `ui.applePay()` buttons on the same page could stop the second button from appearing. It could check availability before Apple’s SDK had loaded, return `"unsupported"`, and cache that result.

This change shares the Apple SDK load between buttons. It also waits for the SDK before rendering the Apple Pay button, handles script-load failures, and allows a later button to retry after an Evervault-injected script fails.

It also improves failed Apple Pay credential exchanges. Failed responses now call the configured `error` handler and close the Apple Pay sheet as failed, rather than causing an uncaught error and leaving the sheet open.