### PR TITLE
fix(browser): surface a failed Apple Pay credentials exchange on the error event

### DIFF
--- a/.changeset/apple-pay-credentials-error-handling.md
+++ b/.changeset/apple-pay-credentials-error-handling.md
@@ -1,0 +1,5 @@
+---
+"@evervault/browser": patch
+---
+
+Surface a failed Apple Pay credentials exchange on the `error` event instead of throwing an uncaught `TypeError` out of the click handler. `POST /frontend/apple-pay/credentials` responses are now checked for a non-2xx status and for missing card credentials, so an API failure reaches the merchant's error handler with the API's detail and status, and the Apple Pay sheet is completed as failed rather than left spinning until Apple times it out. Previously the error body was returned as if it were a successful exchange and the handler died on `card.displayName`, so no error event fired at all.

--- a/packages/browser/lib/ui/ApplePay/index.ts
+++ b/packages/browser/lib/ui/ApplePay/index.ts
@@ -31,6 +31,17 @@ import { Transaction } from "../../resources/transaction";
 const APPLE_PAY_SCRIPT_URL =
   "https://applepay.cdn-apple.com/jsapi/1.latest/apple-pay-sdk.js";
 
+type ApiErrorBody = { detail?: string; title?: string };
+
+async function credentialsFailureMessage(res: Response): Promise<string> {
+  const [body] = await tryCatch<ApiErrorBody>(res.json());
+  const detail = body?.detail ?? body?.title;
+
+  return detail
+    ? `Apple Pay credentials exchange failed (${res.status}): ${detail}`
+    : `Apple Pay credentials exchange failed (${res.status})`;
+}
+
 export type ApplePayButtonOptions = {
   type?: ApplePayButtonType;
   style?: ApplePayButtonStyle;
@@ -269,6 +280,7 @@ export default class ApplePayButton {
 
       if (encryptedError) {
         this.#events.dispatch("error", encryptedError.message);
+        await response.complete("fail");
         return;
       }
 
@@ -385,7 +397,19 @@ export default class ApplePayButton {
       body: JSON.stringify(requestBody),
     });
 
-    return res.json();
+    if (!res.ok) {
+      throw new Error(await credentialsFailureMessage(res));
+    }
+
+    const [encrypted] = await tryCatch<EncryptedApplePayData>(res.json());
+
+    if (!encrypted?.card) {
+      throw new Error(
+        "Apple Pay credentials exchange returned no card credentials"
+      );
+    }
+
+    return encrypted;
   }
 
   on(

--- a/packages/browser/test/applePay.test.ts
+++ b/packages/browser/test/applePay.test.ts
@@ -1744,6 +1744,148 @@ describe("ApplePayButton process() payload", () => {
   });
 });
 
+describe("ApplePayButton credentials exchange", () => {
+  function createSessionWithResponse() {
+    const response = {
+      details: {
+        token: {
+          paymentData: {},
+          paymentMethod: { displayName: "Visa 1234", type: "credit" },
+        },
+      },
+      complete: vi.fn().mockResolvedValue(undefined),
+    };
+
+    return {
+      response,
+      session: { show: vi.fn().mockResolvedValue(response), abort: vi.fn() },
+    };
+  }
+
+  function mountButton() {
+    const { response, session } = createSessionWithResponse();
+    buildSessionMock.mockResolvedValue(session);
+
+    const error = vi.fn();
+    const process = vi.fn().mockResolvedValue(undefined);
+    const apple = new ApplePayButton(createMockClient(), createTransaction(), {
+      process,
+    });
+    apple.on("error", error);
+
+    return { apple, error, process, response };
+  }
+
+  beforeEach(() => {
+    buildSessionMock.mockReset();
+    vi.spyOn(applePayUtilities, "buildSession").mockImplementation(
+      buildSessionMock
+    );
+
+    vi.stubGlobal("PaymentRequest", class PaymentRequest {});
+
+    vi.stubGlobal("ApplePaySession", {
+      applePayCapabilities: vi.fn().mockResolvedValue({
+        paymentCredentialStatus: "paymentCredentialsAvailable",
+      }),
+    });
+
+    const script = document.createElement("script");
+    script.src =
+      "https://applepay.cdn-apple.com/jsapi/1.latest/apple-pay-sdk.js";
+    document.body.appendChild(script);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("dispatches error and fails the sheet when the exchange returns a non-2xx", async () => {
+    server.use(
+      http.post(`${apiUrl}/frontend/apple-pay/credentials`, () =>
+        HttpResponse.json(
+          {
+            code: "internal-error",
+            title: "Internal Error",
+            detail: "Unable to decrypt the payment token",
+          },
+          { status: 500 }
+        )
+      )
+    );
+
+    const { apple, error, process, response } = mountButton();
+
+    await clickApplePayButton(apple);
+
+    await vi.waitFor(() => expect(error).toHaveBeenCalledOnce());
+    expect(error).toHaveBeenCalledWith(
+      "Apple Pay credentials exchange failed (500): Unable to decrypt the payment token"
+    );
+    expect(process).not.toHaveBeenCalled();
+    expect(response.complete).toHaveBeenCalledOnce();
+    expect(response.complete).toHaveBeenCalledWith("fail");
+  });
+
+  it("falls back to the status when the error body carries no detail", async () => {
+    server.use(
+      http.post(
+        `${apiUrl}/frontend/apple-pay/credentials`,
+        () => new HttpResponse(null, { status: 502 })
+      )
+    );
+
+    const { apple, error, process } = mountButton();
+
+    await clickApplePayButton(apple);
+
+    await vi.waitFor(() => expect(error).toHaveBeenCalledOnce());
+    expect(error).toHaveBeenCalledWith(
+      "Apple Pay credentials exchange failed (502)"
+    );
+    expect(process).not.toHaveBeenCalled();
+  });
+
+  it("dispatches error when a 200 response carries no card credentials", async () => {
+    server.use(
+      http.post(`${apiUrl}/frontend/apple-pay/credentials`, () =>
+        HttpResponse.json({})
+      )
+    );
+
+    const { apple, error, process, response } = mountButton();
+
+    await clickApplePayButton(apple);
+
+    await vi.waitFor(() => expect(error).toHaveBeenCalledOnce());
+    expect(error).toHaveBeenCalledWith(
+      "Apple Pay credentials exchange returned no card credentials"
+    );
+    expect(process).not.toHaveBeenCalled();
+    expect(response.complete).toHaveBeenCalledOnce();
+    expect(response.complete).toHaveBeenCalledWith("fail");
+  });
+
+  it("completes the sheet successfully when the exchange succeeds", async () => {
+    server.use(
+      http.post(`${apiUrl}/frontend/apple-pay/credentials`, () =>
+        HttpResponse.json({ card: {} })
+      )
+    );
+
+    const { apple, error, process, response } = mountButton();
+
+    await clickApplePayButton(apple);
+
+    await vi.waitFor(() => expect(process).toHaveBeenCalledOnce());
+    expect(error).not.toHaveBeenCalled();
+    expect(response.complete).toHaveBeenCalledOnce();
+    expect(response.complete).toHaveBeenCalledWith("success");
+  });
+});
+
 describe("ApplePayButton.availability", () => {
   function stubApplePaySession(
     capabilities:


### PR DESCRIPTION
Closes CARD-1247. A failed Apple Pay credentials exchange currently dies as an uncaught `TypeError` with no error event and no sheet dismissal, which is why the Upgrow outage ran silent for five days — this puts the failure on the SDK's error channel where a merchant can actually see it.

#1012 stacks on this. Replaces #1010, which GitHub auto-marked merged when a restack briefly made its head an ancestor of its base.
