### PR TITLE
Add existingPaymentMethodRequired field to GooglePay

### DIFF
--- a/packages/browser/lib/ui/googlePay.ts
+++ b/packages/browser/lib/ui/googlePay.ts
@@ -167,7 +167,8 @@ export default class GooglePay {
         allowCreditCards: this.#options.allowCreditCards,
         softwareInfo: this.#options.softwareInfo,
         assuranceDetailsRequired: this.#options.assuranceDetailsRequired,
-        existingPaymentMethodRequired: this.#options.existingPaymentMethodRequired,
+        existingPaymentMethodRequired:
+          this.#options.existingPaymentMethodRequired,
       },
     };
   }

--- a/packages/browser/lib/ui/googlePay.ts
+++ b/packages/browser/lib/ui/googlePay.ts
@@ -167,6 +167,7 @@ export default class GooglePay {
         allowCreditCards: this.#options.allowCreditCards,
         softwareInfo: this.#options.softwareInfo,
         assuranceDetailsRequired: this.#options.assuranceDetailsRequired,
+        existingPaymentMethodRequired: this.#options.existingPaymentMethodRequired,
       },
     };
   }

--- a/packages/types/uiComponents.ts
+++ b/packages/types/uiComponents.ts
@@ -655,6 +655,13 @@ export interface GooglePayOptions {
    * checks and return the result as `assuranceDetails` on the payment method.
    */
   assuranceDetailsRequired?: boolean;
+  /**
+   * When true, requires the user to have an existing payment method
+   * associated with their Google account for the button to be shown as
+   * ready. Checked by `isReadyToPay`, not `loadPaymentData`.
+   * @default false
+   */
+  existingPaymentMethodRequired?: boolean;
 }
 
 export type ApplePayButtonType =

--- a/packages/ui-components/src/GooglePay/index.tsx
+++ b/packages/ui-components/src/GooglePay/index.tsx
@@ -287,7 +287,22 @@ export function GooglePay({ config }: GooglePayProps) {
         }
 
         const paymentRequest = buildPaymentRequest(config, merchant);
-        await paymentsClient.isReadyToPay(buildIsReadyToPayRequest(config));
+        const isReadyToPayResponse = await paymentsClient.isReadyToPay(
+          buildIsReadyToPayRequest(config)
+        );
+
+        // `result` alone doesn't reflect existingPaymentMethodRequired - Google
+        // only ever populates `paymentMethodPresent` for that, so it has to be
+        // checked separately.
+        const canPay =
+          isReadyToPayResponse.result &&
+          (!config.existingPaymentMethodRequired ||
+            isReadyToPayResponse.paymentMethodPresent);
+
+        if (!canPay) {
+          return;
+        }
+
         const btn = paymentsClient.createButton({
           buttonLocale: config.locale || "en",
           buttonType: config.type || "plain",

--- a/packages/ui-components/src/GooglePay/index.tsx
+++ b/packages/ui-components/src/GooglePay/index.tsx
@@ -291,9 +291,6 @@ export function GooglePay({ config }: GooglePayProps) {
           buildIsReadyToPayRequest(config)
         );
 
-        // `result` alone doesn't reflect existingPaymentMethodRequired - Google
-        // only ever populates `paymentMethodPresent` for that, so it has to be
-        // checked separately.
         const canPay =
           isReadyToPayResponse.result &&
           (!config.existingPaymentMethodRequired ||

--- a/packages/ui-components/src/GooglePay/index.tsx
+++ b/packages/ui-components/src/GooglePay/index.tsx
@@ -1,6 +1,7 @@
 import css from "./styles.module.css";
 import { CSSProperties, useLayoutEffect, useRef } from "react";
 import {
+  buildIsReadyToPayRequest,
   buildPaymentRequest,
   buildTransactionInfo,
   exchangePaymentData,
@@ -286,7 +287,7 @@ export function GooglePay({ config }: GooglePayProps) {
         }
 
         const paymentRequest = buildPaymentRequest(config, merchant);
-        await paymentsClient.isReadyToPay(paymentRequest);
+        await paymentsClient.isReadyToPay(buildIsReadyToPayRequest(config));
         const btn = paymentsClient.createButton({
           buttonLocale: config.locale || "en",
           buttonType: config.type || "plain",

--- a/packages/ui-components/src/GooglePay/types.ts
+++ b/packages/ui-components/src/GooglePay/types.ts
@@ -29,4 +29,5 @@ export interface GooglePayConfig {
   allowCreditCards?: boolean;
   softwareInfo?: google.payments.api.SoftwareInfo;
   assuranceDetailsRequired?: boolean;
+  existingPaymentMethodRequired?: boolean;
 }

--- a/packages/ui-components/src/GooglePay/utilities.ts
+++ b/packages/ui-components/src/GooglePay/utilities.ts
@@ -7,49 +7,64 @@ import {
 import { GooglePayConfig } from "./types";
 import { apiConfig } from "../utilities/config";
 
+// Shared for the two builders so they can't drift apart. Named to match the Android SDK's
+// equivalent (PaymentRequest.kt's baseRequest()).
+function baseRequest() {
+  return { apiVersion: 2, apiVersionMinor: 0 } as const;
+}
+
+// The card payment method spec is the same for both the full payment request
+// and the isReadyToPay request.
+function baseCardPaymentMethod(
+  config: GooglePayConfig
+): google.payments.api.IsReadyToPayPaymentMethodSpecification {
+  return {
+    type: "CARD",
+    parameters: {
+      allowedAuthMethods:
+        (config.allowedAuthMethods as google.payments.api.CardAuthMethod[]) || [
+          "PAN_ONLY",
+          "CRYPTOGRAM_3DS",
+        ],
+      allowedCardNetworks:
+        (config.allowedCardNetworks as google.payments.api.CardNetwork[]) || [
+          "AMEX",
+          "DISCOVER",
+          "INTERAC",
+          "JCB",
+          "MASTERCARD",
+          "VISA",
+        ],
+      allowPrepaidCards: config.allowPrepaidCards,
+      allowCreditCards: config.allowCreditCards,
+      assuranceDetailsRequired: config.assuranceDetailsRequired,
+      billingAddressRequired: isBillingRequired(config),
+      // Google ignores these when billingAddressRequired is false. Omit
+      // them so the request says only what it means, and so it matches the
+      // Android SDK.
+      ...(isBillingRequired(config)
+        ? {
+            billingAddressParameters: {
+              format: billingAddressFormat(config),
+              phoneNumberRequired: phoneNumberRequired(config),
+            },
+          }
+        : {}),
+    },
+  };
+}
+
 export function buildPaymentRequest(
   config: GooglePayConfig,
   merchant: MerchantDetail
 ): google.payments.api.PaymentDataRequest {
   const tx = config.transaction;
   return {
-    apiVersion: 2,
-    apiVersionMinor: 0,
+    ...baseRequest(),
     emailRequired: config.emailRequired ?? false,
     allowedPaymentMethods: [
       {
-        type: "CARD",
-        parameters: {
-          allowedAuthMethods:
-            (config.allowedAuthMethods as google.payments.api.CardAuthMethod[]) || [
-              "PAN_ONLY",
-              "CRYPTOGRAM_3DS",
-            ],
-          allowedCardNetworks:
-            (config.allowedCardNetworks as google.payments.api.CardNetwork[]) || [
-              "AMEX",
-              "DISCOVER",
-              "INTERAC",
-              "JCB",
-              "MASTERCARD",
-              "VISA",
-            ],
-          allowPrepaidCards: config.allowPrepaidCards,
-          allowCreditCards: config.allowCreditCards,
-          assuranceDetailsRequired: config.assuranceDetailsRequired,
-          billingAddressRequired: isBillingRequired(config),
-          // Google ignores these when billingAddressRequired is false. Omit
-          // them so the request says only what it means, and so it matches the
-          // Android SDK.
-          ...(isBillingRequired(config)
-            ? {
-                billingAddressParameters: {
-                  format: billingAddressFormat(config),
-                  phoneNumberRequired: phoneNumberRequired(config),
-                },
-              }
-            : {}),
-        },
+        ...baseCardPaymentMethod(config),
         tokenizationSpecification: {
           type: "PAYMENT_GATEWAY",
           parameters: {
@@ -120,6 +135,16 @@ export function buildTransactionInfo(
       type: displayItemType(item.category),
       price: formatAmount(item.amount),
     })),
+  };
+}
+
+export function buildIsReadyToPayRequest(
+  config: GooglePayConfig
+): google.payments.api.IsReadyToPayRequest {
+  return {
+    ...baseRequest(),
+    allowedPaymentMethods: [baseCardPaymentMethod(config)],
+    existingPaymentMethodRequired: config.existingPaymentMethodRequired,
   };
 }
 

--- a/packages/ui-components/test/GooglePay.test.tsx
+++ b/packages/ui-components/test/GooglePay.test.tsx
@@ -619,3 +619,61 @@ describe("GooglePay isReadyToPay request", () => {
     expect(request.existingPaymentMethodRequired).toBe(true);
   });
 });
+
+describe("GooglePay button visibility from isReadyToPay response", () => {
+  beforeEach(() => {
+    createButtonMock.mockReset();
+    getMerchantMock.mockReset();
+    getAppSDKConfigMock.mockReset();
+    isReadyToPayMock.mockReset();
+    getMerchantMock.mockResolvedValue({ id: "merchant_abc", name: "Acme Co" });
+    getAppSDKConfigMock.mockResolvedValue({ is_sandbox: false });
+    (globalThis as unknown as { google: unknown }).google = {
+      payments: { api: { PaymentsClient: MockPaymentsClient } },
+    };
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    delete (globalThis as { google?: unknown }).google;
+  });
+
+  async function renderAndSettle(config: GooglePayConfig) {
+    render(<GooglePay config={config} />);
+    getInjectedScript()!.dispatchEvent(new Event("load"));
+    await waitFor(() => expect(isReadyToPayMock).toHaveBeenCalled());
+    // Give the button-creation branch a tick to run (or not run) after the
+    // isReadyToPay response resolves.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+
+  it("does not create the button when result is false", async () => {
+    isReadyToPayMock.mockResolvedValue({ result: false });
+
+    await renderAndSettle(config);
+
+    expect(createButtonMock).not.toHaveBeenCalled();
+  });
+
+  it("does not create the button when existingPaymentMethodRequired is set but paymentMethodPresent is false", async () => {
+    isReadyToPayMock.mockResolvedValue({
+      result: true,
+      paymentMethodPresent: false,
+    });
+
+    await renderAndSettle({ ...config, existingPaymentMethodRequired: true });
+
+    expect(createButtonMock).not.toHaveBeenCalled();
+  });
+
+  it("creates the button when existingPaymentMethodRequired is set and paymentMethodPresent is true", async () => {
+    isReadyToPayMock.mockResolvedValue({
+      result: true,
+      paymentMethodPresent: true,
+    });
+
+    await renderAndSettle({ ...config, existingPaymentMethodRequired: true });
+
+    expect(createButtonMock).toHaveBeenCalled();
+  });
+});

--- a/packages/ui-components/test/GooglePay.test.tsx
+++ b/packages/ui-components/test/GooglePay.test.tsx
@@ -41,6 +41,7 @@ let latestOnPaymentAuthorized:
       data: google.payments.api.PaymentData
     ) => Promise<google.payments.api.PaymentAuthorizationResult>)
   | undefined;
+const isReadyToPayMock = vi.fn().mockResolvedValue({ result: true });
 
 class MockPaymentsClient {
   constructor(clientConfig: {
@@ -53,7 +54,7 @@ class MockPaymentsClient {
     latestOnPaymentAuthorized =
       clientConfig.paymentDataCallbacks.onPaymentAuthorized;
   }
-  isReadyToPay = vi.fn().mockResolvedValue({ result: true });
+  isReadyToPay = isReadyToPayMock;
   createButton = (...args: unknown[]) => {
     createButtonMock(...args);
     return document.createElement("div");
@@ -575,5 +576,46 @@ describe("GooglePay assuranceDetails response surfacing", () => {
     const payload = await authorize(undefined);
 
     expect(payload).not.toHaveProperty("assuranceDetails");
+  });
+});
+
+describe("GooglePay isReadyToPay request", () => {
+  beforeEach(() => {
+    createButtonMock.mockReset();
+    getMerchantMock.mockReset();
+    getAppSDKConfigMock.mockReset();
+    isReadyToPayMock.mockClear();
+    getMerchantMock.mockResolvedValue({ id: "merchant_abc", name: "Acme Co" });
+    getAppSDKConfigMock.mockResolvedValue({ is_sandbox: false });
+    (globalThis as unknown as { google: unknown }).google = {
+      payments: { api: { PaymentsClient: MockPaymentsClient } },
+    };
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    delete (globalThis as { google?: unknown }).google;
+  });
+
+  async function renderAndGetIsReadyToPayRequest(
+    existingPaymentMethodRequired?: boolean
+  ) {
+    render(<GooglePay config={{ ...config, existingPaymentMethodRequired }} />);
+    getInjectedScript()!.dispatchEvent(new Event("load"));
+    await waitFor(() => expect(isReadyToPayMock).toHaveBeenCalled());
+    return isReadyToPayMock.mock
+      .calls[0][0] as google.payments.api.IsReadyToPayRequest;
+  }
+
+  it("omits existingPaymentMethodRequired by default", async () => {
+    const request = await renderAndGetIsReadyToPayRequest(undefined);
+
+    expect(request.existingPaymentMethodRequired).toBeUndefined();
+  });
+
+  it("passes existingPaymentMethodRequired through when configured", async () => {
+    const request = await renderAndGetIsReadyToPayRequest(true);
+
+    expect(request.existingPaymentMethodRequired).toBe(true);
   });
 });

--- a/packages/ui-components/test/GooglePayRequest.test.ts
+++ b/packages/ui-components/test/GooglePayRequest.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildIsReadyToPayRequest,
   buildPaymentRequest,
   callbackIntents,
 } from "../src/GooglePay/utilities";
@@ -7,8 +8,8 @@ import type { GooglePayConfig } from "../src/GooglePay/types";
 import type { MerchantDetail } from "types";
 
 /**
- * Unit tests for `buildPaymentRequest`/`callbackIntents` behaviour that isn't
- * about matching a fixed request shape (that's `googlePayGoldenRequest.test.ts`).
+ * Unit tests for `GooglePay/utilities` behaviour that isn't about matching a
+ * fixed request shape (that's `googlePayGoldenRequest.test.ts`).
  */
 
 const MERCHANT = { id: "merchant_abc", name: "Acme Co" } as MerchantDetail;
@@ -113,5 +114,39 @@ describe("Google Pay display item category mapping", () => {
       { label: "Promo", type: "DISCOUNT", price: "1.00" },
       { label: "Delivery", type: "SHIPPING_OPTION", price: "0.00" },
     ]);
+  });
+});
+
+describe("buildIsReadyToPayRequest", () => {
+  it("mirrors the payment request's apiVersion, apiVersionMinor and card parameters, without tokenization or transaction details", () => {
+    const paymentRequest = buildPaymentRequest(BASE_CONFIG, MERCHANT);
+    const isReadyToPayRequest = buildIsReadyToPayRequest(BASE_CONFIG);
+
+    expect(isReadyToPayRequest).toEqual({
+      apiVersion: paymentRequest.apiVersion,
+      apiVersionMinor: paymentRequest.apiVersionMinor,
+      allowedPaymentMethods: [
+        {
+          type: paymentRequest.allowedPaymentMethods[0].type,
+          parameters: paymentRequest.allowedPaymentMethods[0].parameters,
+        },
+      ],
+      existingPaymentMethodRequired: undefined,
+    });
+  });
+
+  it("does not require existingPaymentMethodRequired by default", () => {
+    const request = buildIsReadyToPayRequest(BASE_CONFIG);
+
+    expect(request.existingPaymentMethodRequired).toBeUndefined();
+  });
+
+  it("passes existingPaymentMethodRequired through when set", () => {
+    const request = buildIsReadyToPayRequest({
+      ...BASE_CONFIG,
+      existingPaymentMethodRequired: true,
+    });
+
+    expect(request.existingPaymentMethodRequired).toBe(true);
   });
 });


### PR DESCRIPTION
# Why
https://linear.app/evervault/issue/CARD-1059/d-google-pay-web-request-config-passthrough-batch

External docs: https://github.com/evervault/docs/pull/878