### PR TITLE
Match paymantDataCallbacks with demo callback intents

### DIFF
--- a/.changeset/google-pay-shipping-callback-fix.md
+++ b/.changeset/google-pay-shipping-callback-fix.md
@@ -1,0 +1,5 @@
+---
+"@evervault/ui-components": patch
+---
+
+Fix the Google Pay button failing on click with a `DEVELOPER_ERROR` when neither `shippingAddress` nor `shippingOptions` is configured. `onPaymentDataChanged` was registered on the payments client unconditionally, but Google requires a matching `SHIPPING_ADDRESS`/`SHIPPING_OPTION` callback intent whenever it's registered - now it's only registered when shipping is actually requested.

--- a/packages/ui-components/src/GooglePay/index.tsx
+++ b/packages/ui-components/src/GooglePay/index.tsx
@@ -4,6 +4,7 @@ import {
   buildPaymentRequest,
   buildTransactionInfo,
   exchangePaymentData,
+  isShippingRequired,
   shippingOptionParameters,
 } from "./utilities";
 import { setSize } from "../utilities/resize";
@@ -103,6 +104,86 @@ export function GooglePay({ config }: GooglePayProps) {
         config.shippingOptions
       );
 
+      // Google raises this while the sheet is open, and can raise it more than
+      // once per session, so each request is matched to its reply by id rather
+      // than by message type alone. Google also requires this to be registered
+      // whenever the request declares a SHIPPING_ADDRESS/SHIPPING_OPTION
+      // callback intent (and rejects it being registered when it doesn't), so
+      // it's only added to paymentDataCallbacks below when shipping applies.
+      const handlePaymentDataChanged: google.payments.api.PaymentDataChangedHandler =
+        async (data) => {
+          const id = `gpay-data-change-${++dataChangeSequence}`;
+
+          if (data.shippingAddress !== undefined) {
+            currentShippingAddress = data.shippingAddress;
+          }
+          if (data.shippingOptionData?.id) {
+            currentShippingOptionId = data.shippingOptionData.id;
+          }
+
+          const currentShippingOption =
+            currentShippingOptions?.options.find(
+              (option) => option.id === currentShippingOptionId
+            ) ?? null;
+
+          const update = await new Promise<GooglePayDataChangeResponse>(
+            (resolve) => {
+              const off = on("EV_GOOGLE_PAY_DATA_CHANGE_RESULT", (response) => {
+                if (response.id !== id) return;
+                off();
+                resolve(response);
+              });
+
+              send("EV_GOOGLE_PAY_DATA_CHANGE", {
+                id,
+                trigger: data.callbackTrigger,
+                shippingAddress: currentShippingAddress,
+                selectedShippingOption: currentShippingOption,
+                amount: currentAmount,
+                lineItems: currentLineItems,
+                shippingOptions: currentShippingOptions,
+              });
+            }
+          );
+
+          if (update.error) {
+            const defaultError = defaultShippingError(data);
+            return {
+              error: {
+                reason: update.error.reason ?? defaultError.reason,
+                intent: update.error.intent ?? defaultError.intent,
+                message: update.error.message,
+              },
+            };
+          }
+
+          const result: google.payments.api.PaymentDataRequestUpdate = {};
+
+          if (update.amount !== undefined || update.lineItems !== undefined) {
+            currentAmount = update.amount ?? currentAmount;
+            currentLineItems = update.lineItems ?? currentLineItems;
+
+            const merchant = await merchantPromise;
+            result.newTransactionInfo = buildTransactionInfo(
+              config,
+              merchant?.name ?? "",
+              { amount: currentAmount, lineItems: currentLineItems }
+            );
+          }
+
+          if (update.shippingOptions) {
+            currentShippingOptions = update.shippingOptions;
+            currentShippingOptionId = initialShippingOptionId(
+              currentShippingOptions
+            );
+            result.newShippingOptionParameters = shippingOptionParameters(
+              currentShippingOptions
+            );
+          }
+
+          return result;
+        };
+
       const paymentsClient = new google.payments.api.PaymentsClient({
         // Always use 'test' in staging, but use the resolved environment in production
         environment:
@@ -112,84 +193,9 @@ export function GooglePay({ config }: GooglePayProps) {
             ? "TEST"
             : "PRODUCTION",
         paymentDataCallbacks: {
-          // Google raises this while the sheet is open, and can raise it more
-          // than once per session, so each request is matched to its reply by
-          // id rather than by message type alone.
-          onPaymentDataChanged: async (data) => {
-            const id = `gpay-data-change-${++dataChangeSequence}`;
-
-            if (data.shippingAddress !== undefined) {
-              currentShippingAddress = data.shippingAddress;
-            }
-            if (data.shippingOptionData?.id) {
-              currentShippingOptionId = data.shippingOptionData.id;
-            }
-
-            const currentShippingOption =
-              currentShippingOptions?.options.find(
-                (option) => option.id === currentShippingOptionId
-              ) ?? null;
-
-            const update = await new Promise<GooglePayDataChangeResponse>(
-              (resolve) => {
-                const off = on(
-                  "EV_GOOGLE_PAY_DATA_CHANGE_RESULT",
-                  (response) => {
-                    if (response.id !== id) return;
-                    off();
-                    resolve(response);
-                  }
-                );
-
-                send("EV_GOOGLE_PAY_DATA_CHANGE", {
-                  id,
-                  trigger: data.callbackTrigger,
-                  shippingAddress: currentShippingAddress,
-                  selectedShippingOption: currentShippingOption,
-                  amount: currentAmount,
-                  lineItems: currentLineItems,
-                  shippingOptions: currentShippingOptions,
-                });
-              }
-            );
-
-            if (update.error) {
-              const defaultError = defaultShippingError(data);
-              return {
-                error: {
-                  reason: update.error.reason ?? defaultError.reason,
-                  intent: update.error.intent ?? defaultError.intent,
-                  message: update.error.message,
-                },
-              };
-            }
-
-            const result: google.payments.api.PaymentDataRequestUpdate = {};
-
-            if (update.amount !== undefined || update.lineItems !== undefined) {
-              currentAmount = update.amount ?? currentAmount;
-              currentLineItems = update.lineItems ?? currentLineItems;
-
-              const merchant = await merchantPromise;
-              result.newTransactionInfo = buildTransactionInfo(
-                config,
-                merchant?.name ?? "",
-                { amount: currentAmount, lineItems: currentLineItems }
-              );
-            }
-
-            if (update.shippingOptions) {
-              currentShippingOptions = update.shippingOptions;
-              currentShippingOptionId = initialShippingOptionId(
-                currentShippingOptions
-              );
-              result.newShippingOptionParameters = shippingOptionParameters(
-                currentShippingOptions
-              );
-            }
-
-            return result;
-          },
+          ...(isShippingRequired(config)
+            ? { onPaymentDataChanged: handlePaymentDataChanged }
+            : {}),
           onPaymentAuthorized: async (data) => {
             const payload = await exchangePaymentData(
               app,

--- a/packages/ui-components/src/GooglePay/utilities.ts
+++ b/packages/ui-components/src/GooglePay/utilities.ts
@@ -183,7 +183,7 @@ function phoneNumberRequired(config: GooglePayConfig): boolean {
   return billingConfig?.phoneNumber || false;
 }
 
-function isShippingRequired(config: GooglePayConfig): boolean {
+export function isShippingRequired(config: GooglePayConfig): boolean {
   return !!config.shippingAddress || !!config.shippingOptions;
 }
 

--- a/packages/ui-components/test/GooglePay.test.tsx
+++ b/packages/ui-components/test/GooglePay.test.tsx
@@ -201,6 +201,22 @@ describe("GooglePay shipping data changes", () => {
       });
   }
 
+  it("registers onPaymentDataChanged when shipping is configured", async () => {
+    await mountWithShipping();
+
+    expect(callbacks.onPaymentDataChanged).toBeDefined();
+  });
+
+  it("does not register onPaymentDataChanged when shipping is not configured", async () => {
+    // Google rejects loadPaymentData with a DEVELOPER_ERROR if this callback is
+    // registered without a matching SHIPPING_ADDRESS/SHIPPING_OPTION callback intent.
+    render(<GooglePay config={config} />);
+    getInjectedScript()!.dispatchEvent(new Event("load"));
+    await waitFor(() => expect(createButtonMock).toHaveBeenCalled());
+
+    expect(callbacks.onPaymentDataChanged).toBeUndefined();
+  });
+
   it("sends the buyer's address to the host and applies the new total", async () => {
     await mountWithShipping();
     const postMessage = replyToDataChange({ amount: 1500 });


### PR DESCRIPTION
Master's shipping-address feature registers `onPaymentDataChanged` unconditionally — every button gets it, whether or not the merchant configured shipping. But `callbackIntents()` correctly only adds `SHIPPING_ADDRESS`/`SHIPPING_OPTION` when shipping is configured. 

So for our demo (no shipping set up), the client says "I want shipping-change events" while the request says "actually, no I don't" — Google catches the contradiction and refuses. 