### PR TITLE
Add GooglePayCardEnrichment to response

### DIFF
--- a/.changeset/google-pay-card-enrichment.md
+++ b/.changeset/google-pay-card-enrichment.md
@@ -1,0 +1,6 @@
+---
+"@evervault/browser": minor
+"@evervault/js": minor
+---
+
+Surface Google Pay card enrichment (`funding`, `segment`, `country`, `currency`, `issuer`) on the `card` object in the `process()` payload. These fields were already sent by the backend but were not previously exposed on the `EncryptedGooglePayData` type.

--- a/packages/types/uiComponents.ts
+++ b/packages/types/uiComponents.ts
@@ -473,9 +473,25 @@ export interface EncryptedFPAN {
   messageExpiration?: string;
 }
 
+export interface GooglePayCardEnrichment {
+  funding?: string;
+  segment?: string;
+  country?: string;
+  currency?: string;
+  issuer?: string;
+}
+
+export type EncryptedGooglePayDPAN = Omit<EncryptedDPAN<"google">, "card"> & {
+  card: EncryptedDPAN<"google">["card"] & GooglePayCardEnrichment;
+};
+
+export type EncryptedGooglePayFPAN = Omit<EncryptedFPAN, "card"> & {
+  card: EncryptedFPAN["card"] & GooglePayCardEnrichment;
+};
+
 export type EncryptedGooglePayData = (
-  | EncryptedDPAN<"google">
-  | EncryptedFPAN
+  | EncryptedGooglePayDPAN
+  | EncryptedGooglePayFPAN
 ) & {
   email?: string | null;
   billingAddress?: google.payments.api.Address | null;

--- a/packages/ui-components/test/GooglePay.test.tsx
+++ b/packages/ui-components/test/GooglePay.test.tsx
@@ -472,6 +472,48 @@ describe("GooglePay shipping data changes", () => {
     );
   });
 
+  it("passes the backend's card enrichment fields through to the authorized payload untouched", async () => {
+    await mountWithShipping();
+    const postMessage = vi
+      .spyOn(window.parent, "postMessage")
+      .mockImplementation(() => {});
+    exchangePaymentDataMock.mockResolvedValue({
+      card: {
+        brand: "visa",
+        funding: "credit",
+        segment: "consumer",
+        country: "IE",
+        currency: "EUR",
+        issuer: "Some Bank",
+      },
+    });
+
+    void callbacks.onPaymentAuthorized!({
+      paymentMethodData: {
+        tokenizationData: { token: JSON.stringify({}) },
+      },
+    } as unknown as google.payments.api.PaymentData);
+
+    await waitFor(() =>
+      expect(postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "EV_GOOGLE_PAY_AUTH",
+          payload: expect.objectContaining({
+            card: expect.objectContaining({
+              brand: "visa",
+              funding: "credit",
+              segment: "consumer",
+              country: "IE",
+              currency: "EUR",
+              issuer: "Some Bank",
+            }),
+          }),
+        }),
+        "*"
+      )
+    );
+  });
+
   it("ignores a reply meant for a different data change", async () => {
     await mountWithShipping();
     vi.spyOn(window.parent, "postMessage").mockImplementation(() => {


### PR DESCRIPTION
# Why
https://linear.app/evervault/issue/CARD-1175/add-missing-enrichment-fields-to-encrypteddpanencryptedfpan-google-pay

External docs already include this
