### PR TITLE
Fix apple pay request billing address payload

### DIFF
--- a/.changeset/apple-pay-billing-contact-type-fix.md
+++ b/.changeset/apple-pay-billing-contact-type-fix.md
@@ -1,0 +1,8 @@
+---
+"@evervault/browser": minor
+"@evervault/js": minor
+---
+
+Fix `EncryptedApplePayData.billingContact`/`shippingContact` types to match the actual shape returned by Apple Pay on the web: address fields (`addressLines`, `administrativeArea`, `country`, `countryCode`, `locality`, `postalCode`, `subAdministrativeArea`, `subLocality`) are flat on the contact object, not nested under an `address` key. These fields were already sent by the browser but were not previously exposed on the `EncryptedApplePayData` type.
+
+Also removes an unused `buildAddressObject` helper (and its supporting `DisbursementContactDetails`/`DisbursementContactAddress` types) left over from a disbursement billing-contact flow that was replaced by the `requiredRecipientDetails` recipient-contact model.

--- a/packages/browser/lib/ui/ApplePay/types.ts
+++ b/packages/browser/lib/ui/ApplePay/types.ts
@@ -242,24 +242,6 @@ export interface ValidateMerchantResponse {
   };
 }
 
-export interface DisbursementContactDetails extends DisbursementContactAddress {
-  emailAddress?: string;
-  familyName?: string;
-  givenName?: string;
-  phoneNumber?: string;
-}
-
-export interface DisbursementContactAddress {
-  addressLines?: string[];
-  administrativeArea?: string;
-  country?: string;
-  countryCode?: string;
-  locality?: string;
-  postalCode?: string;
-  subAdministrativeArea?: string;
-  subLocality?: string;
-}
-
 export interface ApplePayToken {
   version: string;
   data: string;

--- a/packages/browser/lib/ui/ApplePay/utilities.ts
+++ b/packages/browser/lib/ui/ApplePay/utilities.ts
@@ -11,8 +11,6 @@ import {
   TransactionLineItem,
 } from "types";
 import {
-  DisbursementContactAddress,
-  DisbursementContactDetails,
   ValidateMerchantResponse,
   ApplePayCardNetwork,
   ApplePayPaymentRequest,
@@ -927,21 +925,6 @@ function buildDisbursementSession(
   );
 
   return request;
-}
-
-export function buildAddressObject(
-  billingContact: DisbursementContactDetails
-): DisbursementContactAddress {
-  return {
-    addressLines: billingContact.addressLines,
-    administrativeArea: billingContact.administrativeArea,
-    country: billingContact.country,
-    countryCode: billingContact.countryCode,
-    locality: billingContact.locality,
-    postalCode: billingContact.postalCode,
-    subAdministrativeArea: billingContact.subAdministrativeArea,
-    subLocality: billingContact.subLocality,
-  };
 }
 
 async function validateMerchant(

--- a/packages/types/uiComponents.ts
+++ b/packages/types/uiComponents.ts
@@ -333,33 +333,36 @@ export interface ApplePayCardEnrichment {
   issuer?: string;
 }
 
+/** Shape of Apple Pay's native billing/shipping contact, as passed through unmodified. */
+export interface ApplePayContact {
+  givenName?: string;
+  familyName?: string;
+  phoneticGivenName?: string;
+  phoneticFamilyName?: string;
+  emailAddress?: string;
+  phoneNumber?: string;
+  addressLines?: string[];
+  subLocality?: string;
+  locality?: string;
+  postalCode?: string;
+  subAdministrativeArea?: string;
+  administrativeArea?: string;
+  country?: string;
+  countryCode?: string;
+}
+
 export type EncryptedApplePayData = Omit<
   EncryptedDPAN<"apple">,
   "token" | "card"
 > & {
   networkToken: PaymentToken<"apple"> & { rawExpiry: string };
   card: EncryptedDPAN<"apple">["card"] & ApplePayCardEnrichment;
-  billingContact?: {
-    givenName?: string;
-    familyName?: string;
-    phoneticGivenName?: string;
-    phoneticFamilyName?: string;
-    emailAddress?: string;
-    phoneNumber?: string;
-    address?: unknown;
-  };
+  billingContact?: ApplePayContact;
   paymentDataType: string;
   transactionType: ApplePayTransactionType;
   transactionId: string;
   deviceManufacturerIdentifier: string;
-  shippingContact?: {
-    givenName?: string;
-    familyName?: string;
-    phoneticGivenName?: string;
-    phoneticFamilyName?: string;
-    emailAddress?: string;
-    phoneNumber?: string;
-  };
+  shippingContact?: ApplePayContact;
   /**
    * Set when `requestPayerDetails` is used. Apple Pay collects these on the
    * shipping contact, so they also appear on `shippingContact`.


### PR DESCRIPTION
# Why
A merchant reported that the billingContact payload doesn't match what our docs/types show. 
The type was just wrong: the SDK has always sent the flat shape (a direct passthrough of what Apple returns), so this only affects TypeScript users — no runtime/data change for anyone.

While in there, found a dead helper function left behind from an old disbursement flow that no longer exists, so cleaned that up too.


